### PR TITLE
feat: use backend-provided position labels instead of hardcoded seat mapping

### DIFF
--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -916,6 +916,9 @@ const Table = React.memo(() => {
                 playerLegalActions={playerLegalActions}
                 tableActivePlayers={tableActivePlayers}
                 isSitAndGoWaitingForPlayers={isSitAndGoWaitingForPlayers}
+                smallBlindPosition={tableDataValues.tableDataSmallBlindPosition}
+                bigBlindPosition={tableDataValues.tableDataBigBlindPosition}
+                dealerPosition={tableDataValues.tableDataDealer}
             />
 
             {/* Layout Debug Panel */}

--- a/src/components/playPage/Table/components/TableStatusMessages.tsx
+++ b/src/components/playPage/Table/components/TableStatusMessages.tsx
@@ -24,6 +24,9 @@ export interface TableStatusMessagesProps {
     playerLegalActions: LegalActionDTO[] | null;
     tableActivePlayers: PlayerDTO[];
     isSitAndGoWaitingForPlayers: boolean;
+    smallBlindPosition?: number;
+    bigBlindPosition?: number;
+    dealerPosition?: number;
 }
 
 export const TableStatusMessages: React.FC<TableStatusMessagesProps> = ({
@@ -35,7 +38,10 @@ export const TableStatusMessages: React.FC<TableStatusMessagesProps> = ({
     isCurrentUserTurn,
     playerLegalActions,
     tableActivePlayers,
-    isSitAndGoWaitingForPlayers
+    isSitAndGoWaitingForPlayers,
+    smallBlindPosition,
+    bigBlindPosition,
+    dealerPosition
 }) => {
     const messages = useMemo(() => getTableStatusMessages({
         currentUserSeat,
@@ -45,6 +51,9 @@ export const TableStatusMessages: React.FC<TableStatusMessagesProps> = ({
         hasLegalActions: (playerLegalActions?.length ?? 0) > 0,
         totalActivePlayers: tableActivePlayers.length,
         isSitAndGoWaitingForPlayers,
+        smallBlindPosition,
+        bigBlindPosition,
+        dealerPosition,
     }), [
         currentUserSeat,
         nextToActSeat,
@@ -53,6 +62,9 @@ export const TableStatusMessages: React.FC<TableStatusMessagesProps> = ({
         playerLegalActions,
         tableActivePlayers,
         isSitAndGoWaitingForPlayers,
+        smallBlindPosition,
+        bigBlindPosition,
+        dealerPosition,
     ]);
 
     const getMessageStyle = (msg: TableStatusMessage): string => {

--- a/src/utils/tableStatusDisplayUtils.ts
+++ b/src/utils/tableStatusDisplayUtils.ts
@@ -23,6 +23,9 @@ export interface TableStatusDisplayInput {
     hasLegalActions: boolean;
     totalActivePlayers: number;
     isSitAndGoWaitingForPlayers: boolean;
+    smallBlindPosition?: number;
+    bigBlindPosition?: number;
+    dealerPosition?: number;
 }
 
 /**
@@ -38,6 +41,9 @@ export function getTableStatusMessages(input: TableStatusDisplayInput): TableSta
         hasLegalActions,
         totalActivePlayers,
         isSitAndGoWaitingForPlayers,
+        smallBlindPosition,
+        bigBlindPosition,
+        dealerPosition,
     } = input;
 
     const messages: TableStatusMessage[] = [];
@@ -57,7 +63,7 @@ export function getTableStatusMessages(input: TableStatusDisplayInput): TableSta
         if (isCurrentUserTurn && hasLegalActions) {
             messages.push({ kind: "your-turn", text: "Your turn to act!" });
         } else {
-            const label = getWaitingForPlayerLabel(nextToActSeat);
+            const label = getWaitingForPlayerLabel(nextToActSeat, { smallBlindPosition, bigBlindPosition, dealerPosition });
             messages.push({
                 kind: "waiting-for-player",
                 seatNumber: nextToActSeat,
@@ -82,10 +88,15 @@ export function getTableStatusMessages(input: TableStatusDisplayInput): TableSta
 
 /**
  * Returns a human-readable label for the player at a given seat.
+ * Uses backend-provided position data when available; falls back to generic labels.
  */
-export function getWaitingForPlayerLabel(seatNumber: number): string {
-    if (seatNumber === 1) return "Small Blind";
-    if (seatNumber === 2) return "Big Blind";
+export function getWaitingForPlayerLabel(
+    seatNumber: number,
+    positions?: { smallBlindPosition?: number; bigBlindPosition?: number; dealerPosition?: number }
+): string {
+    if (positions?.dealerPosition === seatNumber) return "Dealer";
+    if (positions?.smallBlindPosition === seatNumber) return "Small Blind";
+    if (positions?.bigBlindPosition === seatNumber) return "Big Blind";
     return `player at seat ${seatNumber}`;
 }
 


### PR DESCRIPTION
## Summary
- `getWaitingForPlayerLabel()` now uses `smallBlindPosition`, `bigBlindPosition`, and `dealerPosition` from the game state instead of hardcoding seat 1 = SB / seat 2 = BB
- Position labels rotate correctly each hand; falls back to generic labels when positions are not provided
- Threads position data from `useTableData()` through `TableStatusMessages` component

## Test plan
- [x] All 48 `tableStatusDisplayUtils` tests pass (including new position-based and backward-compat tests)
- [x] Lint passes (0 errors)
- [ ] Manual: verify position labels display correctly during live gameplay with rotating blinds

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)