### PR TITLE
fix(ui): replace Cosmos with Block52 in user-facing copy

### DIFF
--- a/src/components/modals/DepositCore.tsx
+++ b/src/components/modals/DepositCore.tsx
@@ -443,11 +443,11 @@ const DepositCore: React.FC<DepositCoreProps> = ({
                             <div className="mb-4 p-3 rounded-lg bg-gray-900 border border-gray-700">
                                 <div className="text-sm text-gray-400">
                                     {cosmosWallet.address
-                                        ? "b52USDC will be minted to your Cosmos address:"
-                                        : "⚠️ No Cosmos wallet found"}
+                                        ? "b52USDC will be minted to your Block52 address:"
+                                        : "⚠️ No Block52 wallet found"}
                                 </div>
                                 <div className="text-xs font-mono text-gray-300 truncate">
-                                    {cosmosWallet.address || "Visit /wallet to generate a Cosmos wallet first"}
+                                    {cosmosWallet.address || "Visit /wallet to generate a Block52 wallet first"}
                                 </div>
                             </div>
 

--- a/src/components/modals/SitAndGoAutoJoinModal.tsx
+++ b/src/components/modals/SitAndGoAutoJoinModal.tsx
@@ -101,7 +101,7 @@ const SitAndGoAutoJoinModal: React.FC<SitAndGoAutoJoinModalProps> = ({ tableId, 
                 setIsBalanceLoading(true);
 
                 if (!publicKey) {
-                    setBuyInError("No Cosmos wallet address available");
+                    setBuyInError("No Block52 wallet address available");
                     setIsBalanceLoading(false);
                     return;
                 }

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -100,7 +100,7 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
             const playerAddress = localStorage.getItem("user_cosmos_address");
 
             if (!playerAddress) {
-                setError(new Error("No Cosmos wallet address found. Please connect your wallet."));
+                setError(new Error("No Block52 wallet address found. Please connect your wallet."));
                 setIsLoading(false);
                 return;
             }
@@ -294,7 +294,7 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
             const playerAddress = localStorage.getItem("user_cosmos_address");
 
             if (!playerAddress) {
-                throw new Error("No Cosmos wallet address found. Please connect your wallet.");
+                throw new Error("No Block52 wallet address found. Please connect your wallet.");
             }
 
             const actionMessage = {

--- a/src/hooks/game/useFindGames.ts
+++ b/src/hooks/game/useFindGames.ts
@@ -30,7 +30,7 @@ export const useFindGames = (): FindGamesReturn => {
         try {
             const cosmosClient = getCosmosClient(currentNetwork);
             if (!cosmosClient) {
-                throw new Error("Cosmos client not initialized. Please create or import a Cosmos wallet first.");
+                throw new Error("Block52 client not initialized. Please create or import a Block52 wallet first.");
             }
 
             // Fetch all games from Cosmos REST API

--- a/src/hooks/wallet/useCosmosWallet.ts
+++ b/src/hooks/wallet/useCosmosWallet.ts
@@ -66,7 +66,7 @@ export const useCosmosWallet = (): UseCosmosWalletReturn => {
         try {
             const client = getCosmosClient(currentNetwork);
             if (!client) {
-                throw new Error("Cosmos client not initialized");
+                throw new Error("Block52 client not initialized");
             }
 
             const balances = await client.getAllBalances(address);

--- a/src/pages/BridgeAdminDashboard.tsx
+++ b/src/pages/BridgeAdminDashboard.tsx
@@ -303,12 +303,12 @@ export default function BridgeAdminDashboard() {
         e.preventDefault();
 
         if (!manualCosmosAddress || !manualAmount) {
-            toast.error("Please enter both Cosmos address and amount");
+            toast.error("Please enter both Block52 address and amount");
             return;
         }
 
         if (!manualCosmosAddress.startsWith("b52")) {
-            toast.error("Cosmos address must start with 'b52'");
+            toast.error("Block52 address must start with 'b52'");
             return;
         }
 

--- a/src/pages/GenesisState.tsx
+++ b/src/pages/GenesisState.tsx
@@ -513,7 +513,7 @@ export default function GenesisState() {
                         <h3 className="text-lg font-semibold text-white mb-2">⚠️ Why Export Bridge State?</h3>
                         <ul className="list-disc list-inside text-sm text-gray-300 space-y-1">
                             <li>Withdrawals are <strong>real USDC</strong> transactions on Ethereum</li>
-                            <li>If you reset the Cosmos chain, withdrawal records will be lost</li>
+                            <li>If you reset the Block52 chain, withdrawal records will be lost</li>
                             <li>But Ethereum still knows about those nonces - must preserve them!</li>
                             <li>Export before reset, then import into new genesis to maintain integrity</li>
                         </ul>

--- a/src/pages/ManualBridgeTrigger.tsx
+++ b/src/pages/ManualBridgeTrigger.tsx
@@ -219,7 +219,7 @@ export default function ManualBridgeTrigger() {
                                 <p className="text-blue-200 text-sm font-medium mb-3">📦 Deposit Information</p>
                                 <div className="space-y-2">
                                     <div>
-                                        <p className="text-blue-300 text-xs">Recipient (Cosmos Address):</p>
+                                        <p className="text-blue-300 text-xs">Recipient (Block52 Address):</p>
                                         <p className="text-blue-100 text-sm font-mono break-all">{queryResult.recipient}</p>
                                     </div>
                                     <div>

--- a/src/pages/explorer/AddressPage.tsx
+++ b/src/pages/explorer/AddressPage.tsx
@@ -45,7 +45,7 @@ export default function AddressPage() {
                 });
 
                 if (!cosmosClient) {
-                    throw new Error("Cosmos client not initialized.");
+                    throw new Error("Block52 client not initialized.");
                 }
 
                 // Fetch balances

--- a/src/pages/explorer/AllAccountsPage.tsx
+++ b/src/pages/explorer/AllAccountsPage.tsx
@@ -66,7 +66,7 @@ export default function AllAccountsPage() {
             });
 
             if (!cosmosClient) {
-                throw new Error("Cosmos client not initialized");
+                throw new Error("Block52 client not initialized");
             }
 
             // Fetch validators first to identify validator accounts

--- a/src/pages/explorer/BlockDetailPage.tsx
+++ b/src/pages/explorer/BlockDetailPage.tsx
@@ -88,7 +88,7 @@ export default function BlockDetailPage() {
                 const cosmosClient = getCosmosClient(currentNetwork);
 
                 if (!cosmosClient) {
-                    throw new Error("Cosmos client not initialized. Please check your wallet connection.");
+                    throw new Error("Block52 client not initialized. Please check your wallet connection.");
                 }
 
                 const blockData = await cosmosClient.getBlock(parseInt(height));

--- a/src/pages/explorer/BlocksPage.tsx
+++ b/src/pages/explorer/BlocksPage.tsx
@@ -49,7 +49,7 @@ export default function BlocksPage() {
             });
 
             if (!cosmosClient) {
-                throw new Error("Cosmos client not initialized.");
+                throw new Error("Block52 client not initialized.");
             }
 
             const recentBlocks = await cosmosClient.getLatestBlocks(50);
@@ -151,7 +151,7 @@ export default function BlocksPage() {
                                 </svg>
                             </div>
                             <h2 className="text-2xl font-bold text-white mb-4">Error: {error}</h2>
-                            <p className="text-gray-300 mb-4">Make sure your Cosmos blockchain is running</p>
+                            <p className="text-gray-300 mb-4">Make sure your Block52 blockchain is running</p>
                             <p className="text-sm text-gray-400 mb-6">Try selecting a different network from the dropdown above</p>
 
                             {/* Retry Button */}

--- a/src/pages/explorer/DistributionPage.tsx
+++ b/src/pages/explorer/DistributionPage.tsx
@@ -29,7 +29,7 @@ export default function DistributionPage() {
             });
 
             if (!cosmosClient) {
-                throw new Error("Cosmos client not initialized.");
+                throw new Error("Block52 client not initialized.");
             }
 
             // Fetch all games

--- a/src/pages/explorer/TransactionPage.tsx
+++ b/src/pages/explorer/TransactionPage.tsx
@@ -36,7 +36,7 @@ export default function TransactionPage() {
                 const cosmosClient = getCosmosClient(currentNetwork);
 
                 if (!cosmosClient) {
-                    throw new Error("Cosmos client not initialized. Please check your wallet connection.");
+                    throw new Error("Block52 client not initialized. Please check your wallet connection.");
                 }
 
                 const tx = await cosmosClient.getTx(hashToSearch.trim());
@@ -512,7 +512,7 @@ export default function TransactionPage() {
                                                 >
                                                     {/* Cosmos Events Primer */}
                                                     <div className={`mb-6 pb-4 ${styles.eventExplanationPrimer}`}>
-                                                        <h4 className="text-lg font-bold text-white mb-3">📚 About Cosmos Blockchain Events</h4>
+                                                        <h4 className="text-lg font-bold text-white mb-3">📚 About Block52 Blockchain Events</h4>
                                                         <div className="text-gray-300 text-sm space-y-2">
                                                             <p>
                                                                 <strong className={styles.eventExplanationStrong}>Events</strong> are records emitted during
@@ -521,7 +521,7 @@ export default function TransactionPage() {
                                                             </p>
                                                             <p>
                                                                 <strong className={styles.eventExplanationStrong}>Standard SDK events</strong> (coin_spent,
-                                                                coin_received, transfer, message, tx) are automatically emitted by the Cosmos SDK for all
+                                                                coin_received, transfer, message, tx) are automatically emitted by the Block52 SDK for all
                                                                 transactions.
                                                             </p>
                                                             <p>

--- a/src/utils/cosmos/client.ts
+++ b/src/utils/cosmos/client.ts
@@ -131,7 +131,7 @@ export async function getSigningClient(network: NetworkEndpoints) {
     const mnemonic = getCosmosMnemonic();
 
     if (!userAddress || !mnemonic) {
-        throw new Error("Cosmos wallet not initialized. Please create or import a Cosmos wallet first.");
+        throw new Error("Block52 wallet not initialized. Please create or import a Block52 wallet first.");
     }
 
     const { rpcEndpoint, restEndpoint } = getCosmosUrls(network);

--- a/src/utils/cosmosAccountUtils.ts
+++ b/src/utils/cosmosAccountUtils.ts
@@ -70,13 +70,13 @@ export const getCosmosBalance = async (network: NetworkEndpoints, denom: string 
     const client = getCosmosClient(network);
 
     if (!client) {
-        throw new Error("No Cosmos wallet connected. Please create or import a wallet first.");
+        throw new Error("No Block52 wallet connected. Please create or import a wallet first.");
     }
 
     // Get address from localStorage instead of client.getWalletAddress() (which doesn't work in REST-only mode)
     const address = getCosmosAddressSync();
     if (!address) {
-        throw new Error("No Cosmos address found. Please create or import a wallet first.");
+        throw new Error("No Block52 address found. Please create or import a wallet first.");
     }
 
     try {
@@ -88,7 +88,7 @@ export const getCosmosBalance = async (network: NetworkEndpoints, denom: string 
         return balance.toString();
     } catch (error) {
         console.error("❌ Error fetching Cosmos balance:", error);
-        throw new Error(`Failed to fetch Cosmos balance: ${error instanceof Error ? error.message : "Unknown error"}`);
+        throw new Error(`Failed to fetch Block52 balance: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
 };
 
@@ -102,13 +102,13 @@ export const getAllCosmosBalances = async (network: NetworkEndpoints): Promise<A
     const client = getCosmosClient(network);
 
     if (!client) {
-        throw new Error("No Cosmos wallet connected. Please create or import a wallet first.");
+        throw new Error("No Block52 wallet connected. Please create or import a wallet first.");
     }
 
     // Get address from localStorage instead of client.getWalletAddress() (which doesn't work in REST-only mode)
     const address = getCosmosAddressSync();
     if (!address) {
-        throw new Error("No Cosmos address found. Please create or import a wallet first.");
+        throw new Error("No Block52 address found. Please create or import a wallet first.");
     }
 
     try {


### PR DESCRIPTION
## Summary
- Replaced all user-visible "Cosmos" references with "Block52" across error messages, labels, headings, and tooltips (16 files, 27 string changes)
- Variable names, file names, imports, code comments, and console.log/console.error messages are intentionally unchanged
- Kept "Cosmos SDK" label in NodeStatusPage (accurate technical reference) and "SigningCosmosClient" button in TestSigningPage (dev page referencing SDK class)

## Files changed
- `GameStateContext.tsx` - wallet not found errors
- `DepositCore.tsx` - mint address label, wallet not found
- `SitAndGoAutoJoinModal.tsx` - wallet address error
- `BridgeAdminDashboard.tsx` - address validation messages
- `ManualBridgeTrigger.tsx` - recipient label
- `GenesisState.tsx` - chain reset warning
- `TransactionPage.tsx` - blockchain events heading and SDK reference
- `BlocksPage.tsx` - blockchain running message, client init error
- `BlockDetailPage.tsx` - client init error
- `AddressPage.tsx` - client init error
- `AllAccountsPage.tsx` - client init error
- `DistributionPage.tsx` - client init error
- `cosmosAccountUtils.ts` - wallet/address/balance errors
- `cosmos/client.ts` - wallet init error
- `useFindGames.ts` - client init error
- `useCosmosWallet.ts` - client init error

## Test plan
- [x] `yarn build` passes (0 errors)
- [x] `yarn lint` passes (0 errors, only pre-existing warnings)
- [x] Grep confirmed no remaining user-facing "Cosmos" strings (only console.error, imports, variable names, and intentional exclusions remain)
- [ ] Manual: verify error messages display "Block52" when wallet is disconnected
- [ ] Manual: verify deposit modal shows "Block52 address" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)