### PR TITLE
Fix toastify import for copy to clipboard issue

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import "./polyfills";
 
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import "react-toastify/dist/ReactToastify.css";
 import App from "./App";
 import { Profiler } from "react";
 import { NetworkProvider } from "./context/NetworkContext";


### PR DESCRIPTION
Fixed, copy to clipboard now working as expected again

<img width="1483" height="651" alt="Screenshot 2026-02-24 at 9 05 03 pm" src="https://github.com/user-attachments/assets/42b7d0ac-3392-42b7-9f6d-7a5edd507f90" />
