### PR TITLE
Remove hardcoded defaults in convertUtils and TableAdminPage (Commandment 7)

### DIFF
--- a/src/components/TableList.tsx
+++ b/src/components/TableList.tsx
@@ -216,7 +216,7 @@ const TableList: React.FC = () => {
                                     </td>
                                     <td className="px-4 py-4 text-center">
                                         <span className="text-white font-semibold">
-                                            {game.currentPlayers}/{game.maxPlayers}
+                                            {game.currentPlayers ?? "\u2014"}/{game.maxPlayers}
                                         </span>
                                     </td>
                                     <td className="px-4 py-4 text-center">
@@ -229,7 +229,7 @@ const TableList: React.FC = () => {
                                             href={`/table/${game.gameId}`}
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            aria-label={`Join ${formatGameFormatDisplay(game.gameFormat)} table with ${game.currentPlayers} of ${game.maxPlayers} players, blinds $${formatMicroAsUsdc(game.smallBlind, 2)}/$${formatMicroAsUsdc(game.bigBlind, 2)}`}
+                                            aria-label={`Join ${formatGameFormatDisplay(game.gameFormat)} table with ${game.currentPlayers ?? "unknown"} of ${game.maxPlayers} players, blinds $${formatMicroAsUsdc(game.smallBlind, 2)}/$${formatMicroAsUsdc(game.bigBlind, 2)}`}
                                             className={`inline-block px-4 py-2 text-white text-sm font-semibold rounded-lg transition-all hover:opacity-90 ${styles.actionButton}`}
                                         >
                                             Join

--- a/src/pages/TableAdminPage.tsx
+++ b/src/pages/TableAdminPage.tsx
@@ -33,13 +33,13 @@ interface TableData {
     gameFormat: string;
     minPlayers: number;
     maxPlayers: number;
-    currentPlayers: number;
+    currentPlayers?: number;
     minBuyIn: string;
     maxBuyIn: string;
     smallBlind: string;
     bigBlind: string;
     timeout?: number;
-    status: string;
+    status?: string;
     creator?: string;
     createdAt?: string;
 }

--- a/src/utils/convertUtils.test.ts
+++ b/src/utils/convertUtils.test.ts
@@ -31,12 +31,12 @@ describe("convertUtils", () => {
             expect(result.maxBuyIn).toBe("50000000");
             expect(result.minPlayers).toBe(2);
             expect(result.maxPlayers).toBe(9);
-            expect(result.currentPlayers).toBe(0);
+            expect(result.currentPlayers).toBeUndefined();
             expect(result.gameFormat).toBe(GameFormat.CASH);
             expect(result.gameVariant).toBe(GameVariant.TEXAS_HOLDEM);
             expect(result.smallBlind).toBe("50000");
             expect(result.bigBlind).toBe("100000");
-            expect(result.status).toBe("waiting");
+            expect(result.status).toBeUndefined();
             expect(result.creator).toBe("cosmos1abc");
             expect(result.timeout).toBe(30);
             expect(result.createdAt).toBe("2026-02-04T10:00:00Z");

--- a/src/utils/convertUtils.ts
+++ b/src/utils/convertUtils.ts
@@ -11,12 +11,12 @@ export interface GameWithFormat {
     maxBuyIn: string;
     minPlayers: number;
     maxPlayers: number;
-    currentPlayers: number;
+    currentPlayers?: number;
     gameFormat: GameFormat | "unknown";
     gameVariant: GameVariant | "unknown";
     smallBlind: string;
     bigBlind: string;
-    status: string;
+    status?: string;
     creator?: string;
     timeout?: number;
     createdAt?: string;
@@ -43,12 +43,10 @@ export const convertGameListItemToGameWithFormat = (game: GameListItem): GameWit
         maxBuyIn: opts.maxBuyIn,
         minPlayers: opts.minPlayers,
         maxPlayers: opts.maxPlayers,
-        currentPlayers: 0,
         gameFormat: getGameFormat(game.format),
         gameVariant: getGameVariant(game.variant),
         smallBlind: opts.smallBlind,
         bigBlind: opts.bigBlind,
-        status: "waiting",
         creator: game.creator,
         timeout: opts.timeout,
         createdAt: game.createdAt,


### PR DESCRIPTION
## Summary
- Removed fabricated `currentPlayers: 0` and `status: "waiting"` defaults from `convertGameListItemToGameWithFormat()` — these fields don't exist in the SDK `GameListItem` type and violated Commandment 7 (NO Defaults Policy)
- Made `currentPlayers` and `status` optional in `GameWithFormat` and `TableData` interfaces
- Updated `TableList.tsx` to display "—" when `currentPlayers` is unavailable

## Test plan
- [x] `yarn lint` — 0 errors
- [x] `yarn build` — passes
- [x] `yarn test` — all 11 convertUtils tests pass (updated assertions for removed defaults)
- [ ] Verify table list renders correctly with "—" for missing player counts

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)