### PR TITLE
fix(ui): prevent infinite toast loop on payment completion

### DIFF
--- a/src/components/modals/DepositCore.tsx
+++ b/src/components/modals/DepositCore.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import * as React from "react";
 import axios from "axios";
 import useUserWalletConnect from "../../hooks/wallet/useUserWalletConnect";
@@ -224,7 +224,7 @@ const DepositCore: React.FC<DepositCoreProps> = ({
         }
     };
 
-    const handlePaymentComplete = () => {
+    const handlePaymentComplete = useCallback(() => {
         toast.success("Payment complete! USDC deposited to your game wallet.", { autoClose: 5000 });
         cosmosWallet.refreshBalance();
         setTimeout(() => {
@@ -232,7 +232,7 @@ const DepositCore: React.FC<DepositCoreProps> = ({
             setAmount("0");
             if (onSuccess) onSuccess();
         }, 3000);
-    };
+    }, [cosmosWallet, onSuccess]);
 
     const handleNewPayment = () => {
         setPaymentData(null);


### PR DESCRIPTION
## Summary
- Fix infinite "Payment complete!" toast loop (~15 toasts firing repeatedly)
- Root cause: `handlePaymentComplete` was not memoized, causing PaymentStatusMonitor's fetchStatus to re-trigger on every parent render, which called onPaymentComplete again in an infinite cycle
- Use refs for callback props in PaymentStatusMonitor to break dependency cascade
- Guard onPaymentComplete with `completionFiredRef` — fires exactly once
- Use `statusRef` for interval closure to avoid stale state
- Wrap `handlePaymentComplete` in `useCallback` in DepositCore

## Test plan
- [ ] Complete a crypto payment — "Payment complete!" toast shows exactly once
- [ ] Payment status monitor stops polling after terminal status (finished/failed/expired)
- [ ] No console errors or infinite re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)