### PR TITLE
fix: update sit-in button labels (#38)

### DIFF
--- a/src/components/playPage/Table/components/PlayerActionButtons.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.tsx
@@ -107,7 +107,7 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
                                 flex items-center justify-center gap-2 transform hover:scale-105
                                 ${isCompact ? "py-2 px-3 text-xs" : "py-2.5 px-4 text-sm"}`}
                         >
-                            Wait For Next Blind
+                            Sit In On Next Big Blind
                         </button>
                         <button
                             onClick={() => handleSitIn(tableId, currentNetwork, SIT_IN_METHOD_POST_NOW)}
@@ -117,7 +117,7 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
                                 flex items-center justify-center gap-2 transform hover:scale-105
                                 ${isCompact ? "py-2 px-3 text-xs" : "py-2.5 px-4 text-sm"}`}
                         >
-                            Post And Play
+                            Post Required Blinds Now
                         </button>
                     </div>
                 </div>

--- a/src/utils/playerActionDisplayUtils.test.ts
+++ b/src/utils/playerActionDisplayUtils.test.ts
@@ -291,7 +291,7 @@ describe("getPlayerActionDisplay", () => {
             playerStatus: PlayerStatus.SITTING_IN,
             sitInMethod: SIT_IN_METHOD_NEXT_BB,
         });
-        expect(result).toEqual({ kind: "pending", waitingMessage: "Waiting For Next Blind..." });
+        expect(result).toEqual({ kind: "pending", waitingMessage: "Waiting For Next Big Blind..." });
     });
 
     it("returns pending with post-now message when method is post-now", () => {
@@ -300,7 +300,7 @@ describe("getPlayerActionDisplay", () => {
             playerStatus: PlayerStatus.SITTING_IN,
             sitInMethod: SIT_IN_METHOD_POST_NOW,
         });
-        expect(result).toEqual({ kind: "pending", waitingMessage: "Waiting to Post And Play..." });
+        expect(result).toEqual({ kind: "pending", waitingMessage: "Waiting to Post Required Blinds..." });
     });
 
     it("returns pending with next-bb message when method is null", () => {
@@ -309,7 +309,7 @@ describe("getPlayerActionDisplay", () => {
             playerStatus: PlayerStatus.SITTING_IN,
             sitInMethod: null,
         });
-        expect(result).toEqual({ kind: "pending", waitingMessage: "Waiting For Next Blind..." });
+        expect(result).toEqual({ kind: "pending", waitingMessage: "Waiting For Next Big Blind..." });
     });
 
     it("returns pending even if legalActions contains SIT_IN", () => {
@@ -330,7 +330,7 @@ describe("getPlayerActionDisplay", () => {
             sitInMethod: SIT_IN_METHOD_NEXT_BB,
             totalSeatedPlayers: 1,
         });
-        expect(result).toEqual({ kind: "pending", waitingMessage: "Waiting For Next Blind..." });
+        expect(result).toEqual({ kind: "pending", waitingMessage: "Waiting For Next Big Blind..." });
     });
 
     // --- No actions ---

--- a/src/utils/playerActionDisplayUtils.ts
+++ b/src/utils/playerActionDisplayUtils.ts
@@ -49,8 +49,8 @@ export function getPlayerActionDisplay(input: PlayerActionDisplayInput): PlayerA
     // 1. Pending: player already confirmed sit-in, waiting for action
     if (playerStatus === PlayerStatus.SITTING_IN) {
         const waitingMessage = sitInMethod === SIT_IN_METHOD_POST_NOW
-            ? "Waiting to Post And Play..."
-            : "Waiting For Next Blind...";
+            ? "Waiting to Post Required Blinds..."
+            : "Waiting For Next Big Blind...";
         return { kind: "pending", waitingMessage };
     }
 


### PR DESCRIPTION
## Summary
- Updated "Wait For Next Blind" → "Sit In On Next Big Blind"
- Updated "Post And Play" → "Post Required Blinds Now"
- Updated pending messages to match: "Waiting For Next Big Blind..." and "Waiting to Post Required Blinds..."
- Updated test assertions to match new label strings

Closes #38

## Test plan
- [x] `yarn test` — all 32 tests pass
- [x] `tsc --noEmit` — no type errors
- [ ] Manual: verify button labels render correctly on the sit-in method selection panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)