### PR TITLE
feat: auto-start new hand when current hand ends (#48)

### DIFF
--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -9,6 +9,7 @@ import { useGameStateContext } from "../../context/GameStateContext";
 import { dealCardsWithEntropy } from "../../hooks/playerActions/dealCards";
 import { useAutoDeal } from "../../hooks/playerActions/useAutoDeal";
 import { useAutoPostBlinds } from "../../hooks/playerActions/useAutoPostBlinds";
+import { useAutoNewHand } from "../../hooks/playerActions/useAutoNewHand";
 
 // Import action handlers
 import {
@@ -100,6 +101,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({
     const hasMuckAction = hasAction(legalActions, PlayerActionType.MUCK);
     const hasShowAction = hasAction(legalActions, PlayerActionType.SHOW);
     const hasDealAction = hasAction(legalActions, NonPlayerActionType.DEAL);
+    const hasNewHandAction = hasAction(legalActions, NonPlayerActionType.NEW_HAND);
 
     // Blind amounts - single source of truth from gameState.gameOptions (per Commandment 7)
     // Defined early so they can be used in useAutoPostBlinds hook
@@ -148,6 +150,23 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({
             }
         }, // onBlindComplete
         () => setLoadingAction(null) // onBlindError
+    );
+
+    // Auto-new-hand hook - automatically starts new hand when current hand ends
+    // Can be disabled via URL query param: ?autonewhand=false
+    useAutoNewHand(
+        tableId,
+        network,
+        hasNewHandAction,
+        isUsersTurn,
+        () => setLoadingAction("new-hand"), // onNewHandStarted
+        (txHash) => {
+            setLoadingAction(null);
+            if (onTransactionSubmitted) {
+                onTransactionSubmitted(txHash);
+            }
+        }, // onNewHandComplete
+        () => setLoadingAction(null) // onNewHandError
     );
 
     // Check if auto-deal is enabled (cached on mount) - used for DealButtonGroup

--- a/src/hooks/playerActions/index.ts
+++ b/src/hooks/playerActions/index.ts
@@ -18,6 +18,7 @@ import { useOptimisticAction, OptimisticAction } from "./useOptimisticAction";
 import type { OptimisticActionType } from "./useOptimisticAction";
 import { useAutoDeal } from "./useAutoDeal";
 import { useAutoPostBlinds } from "./useAutoPostBlinds";
+import { useAutoNewHand } from "./useAutoNewHand";
 
 export {
     betHand,
@@ -40,7 +41,8 @@ export {
     useOptimisticAction,
     OptimisticAction,
     useAutoDeal,
-    useAutoPostBlinds
+    useAutoPostBlinds,
+    useAutoNewHand
 };
 
 export type { OptimisticActionType, SitInMethod };

--- a/src/hooks/playerActions/useAutoNewHand.ts
+++ b/src/hooks/playerActions/useAutoNewHand.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useCallback } from "react";
+import type { NetworkEndpoints } from "../../context/NetworkContext";
+import { startNewHand } from "./startNewHand";
+import { getAutoNewHandEnabled } from "../../utils/urlParams";
+
+/**
+ * Hook to automatically trigger new hand action when the current hand ends.
+ *
+ * Auto-new-hand is enabled by default and can be disabled via URL query param:
+ * - ?autonewhand=false -> disables auto-new-hand
+ * - ?autonewhand=true or no param -> enables auto-new-hand (default)
+ *
+ * When enabled, this hook will automatically trigger the new hand action when:
+ * 1. The user has the NEW_HAND action in their legal actions
+ * 2. It is the user's turn
+ * 3. Auto-new-hand has not already been triggered for this opportunity
+ *
+ * @param tableId - The table/game ID
+ * @param network - The network configuration
+ * @param hasNewHandAction - Whether the NEW_HAND action is available in legal actions
+ * @param isUsersTurn - Whether it is currently the user's turn
+ * @param onNewHandStarted - Optional callback when auto-new-hand starts
+ * @param onNewHandComplete - Optional callback when auto-new-hand completes
+ * @param onNewHandError - Optional callback when auto-new-hand fails
+ */
+export function useAutoNewHand(
+    tableId: string,
+    network: NetworkEndpoints,
+    hasNewHandAction: boolean,
+    isUsersTurn: boolean,
+    onNewHandStarted?: () => void,
+    onNewHandComplete?: (txHash: string) => void,
+    onNewHandError?: (error: Error) => void
+): void {
+    // Track if we've already triggered new hand for this opportunity
+    const hasTriggeredRef = useRef<boolean>(false);
+    // Track if new hand is currently in progress to prevent duplicate calls
+    const isProcessingRef = useRef<boolean>(false);
+    // Check if auto-new-hand is enabled (cached on first render)
+    const autoNewHandEnabledRef = useRef<boolean>(getAutoNewHandEnabled());
+
+    const triggerAutoNewHand = useCallback(async () => {
+        if (!tableId || isProcessingRef.current) {
+            return;
+        }
+
+        isProcessingRef.current = true;
+        onNewHandStarted?.();
+
+        try {
+            const result = await startNewHand(tableId, network);
+            onNewHandComplete?.(result.hash);
+        } catch (error) {
+            console.error("Auto-new-hand failed:", error);
+            onNewHandError?.(error instanceof Error ? error : new Error(String(error)));
+        } finally {
+            isProcessingRef.current = false;
+        }
+    }, [tableId, network, onNewHandStarted, onNewHandComplete, onNewHandError]);
+
+    useEffect(() => {
+        // Check all conditions for auto-new-hand
+        const shouldAutoNewHand =
+            autoNewHandEnabledRef.current &&
+            hasNewHandAction &&
+            isUsersTurn &&
+            !hasTriggeredRef.current &&
+            !isProcessingRef.current;
+
+        if (shouldAutoNewHand) {
+            hasTriggeredRef.current = true;
+            triggerAutoNewHand();
+        }
+
+        // Reset the trigger flag when new hand action is no longer available
+        // This allows auto-new-hand to trigger again on the next opportunity
+        if (!hasNewHandAction) {
+            hasTriggeredRef.current = false;
+        }
+    }, [hasNewHandAction, isUsersTurn, triggerAutoNewHand]);
+}

--- a/src/utils/urlParams.ts
+++ b/src/utils/urlParams.ts
@@ -43,3 +43,23 @@ export const getAutoPostBlindsEnabled = (): boolean => {
     // Default to true if param is missing or any value other than "false"
     return autoblinds !== "false";
 };
+
+/**
+ * Check if auto-new-hand is enabled via query string parameter.
+ *
+ * Auto-new-hand is ENABLED by default. It can only be disabled by explicitly
+ * setting ?autonewhand=false in the URL.
+ *
+ * @returns true if auto-new-hand is enabled, false if explicitly disabled
+ *
+ * @example
+ * // URL: /table/123 -> returns true (default)
+ * // URL: /table/123?autonewhand=true -> returns true
+ * // URL: /table/123?autonewhand=false -> returns false
+ */
+export const getAutoNewHandEnabled = (): boolean => {
+    const params = new URLSearchParams(window.location.search);
+    const autonewhand = params.get("autonewhand");
+    // Default to true if param is missing or any value other than "false"
+    return autonewhand !== "false";
+};


### PR DESCRIPTION
## Summary
- Added `useAutoNewHand` hook that automatically triggers `startNewHand()` when `NEW_HAND` appears in `legalActions` and it's the user's turn
- Added `getAutoNewHandEnabled()` URL param utility — enabled by default, disable with `?autonewhand=false`
- Follows the exact same pattern as `useAutoDeal` (ref guards, processing lock, reset on action unavailable)

Closes #48

## Test plan
- [x] `tsc --noEmit` — no type errors
- [x] `yarn lint` — 0 errors
- [ ] Manual: verify new hand auto-starts after showdown/fold-out
- [ ] Manual: verify `?autonewhand=false` disables auto-start and shows the START NEW HAND button

🤖 Generated with [Claude Code](https://claude.com/claude-code)