### PR TITLE
feat(ui): replace Sit Out button with checkboxes

### DIFF
--- a/src/components/common/actionHandlers.ts
+++ b/src/components/common/actionHandlers.ts
@@ -9,12 +9,13 @@ import {
     sitIn,
     SIT_IN_METHOD_NEXT_BB,
     sitOut,
+    SIT_OUT_METHOD_NEXT_HAND,
     startNewHand,
     postSmallBlind,
     postBigBlind,
     raiseHand
 } from "../../hooks/playerActions";
-import type { SitInMethod } from "../../hooks/playerActions";
+import type { SitInMethod, SitOutMethod } from "../../hooks/playerActions";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 
 /**
@@ -142,9 +143,20 @@ const handleDeal = createSimpleHandler("deal", dealCards, {
 
 const handleStartNewHand = createSimpleHandler("start new hand", startNewHand);
 
-const handleSitOut = createSimpleHandler("sit out", sitOut, {
-    successLog: "Sit out completed successfully"
-});
+const handleSitOut = async (
+    tableId: string | undefined,
+    network: NetworkEndpoints,
+    method: SitOutMethod = SIT_OUT_METHOD_NEXT_HAND
+): Promise<string | null> => {
+    if (!tableId) return null;
+    try {
+        const result = await sitOut(tableId, network, method);
+        return result?.hash || null;
+    } catch (error: unknown) {
+        console.error("Failed to sit out:", error);
+        return null;
+    }
+};
 
 const handleSitIn = async (
     tableId: string | undefined,

--- a/src/components/playPage/Table/components/PlayerActionButtons.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.tsx
@@ -6,8 +6,8 @@
  * Responsive design for mobile, tablet, and desktop viewports.
  */
 
-import React, { useEffect, useRef } from "react";
-import { LegalActionDTO } from "@block52/poker-vm-sdk";
+import React, { useState, useEffect, useRef } from "react";
+import { LegalActionDTO, SIT_OUT_METHOD_NEXT_HAND, SIT_OUT_METHOD_NEXT_BB } from "@block52/poker-vm-sdk";
 import { handleSitOut, handleSitIn } from "../../../common/actionHandlers";
 import { SIT_IN_METHOD_NEXT_BB, SIT_IN_METHOD_POST_NOW } from "../../../../hooks/playerActions";
 import type { NetworkEndpoints } from "../../../../context/NetworkContext";
@@ -26,17 +26,6 @@ export interface PlayerActionButtonsProps {
     hasActivePlayers: boolean;
 }
 
-const SitOutIcon: React.FC<{ size: string }> = ({ size }) => (
-    <svg xmlns="http://www.w3.org/2000/svg" className={size} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-        />
-    </svg>
-);
-
 export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
     isMobile,
     isMobileLandscape,
@@ -51,6 +40,27 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
 }) => {
     const isCompact = isMobile || isMobileLandscape;
     const positionClass = isMobileLandscape ? "bottom-2 left-2" : isMobile ? "bottom-[260px] right-4" : "bottom-20 left-4";
+
+    const [sitOutNextHand, setSitOutNextHand] = useState(false);
+    const [sitOutNextBB, setSitOutNextBB] = useState(false);
+
+    const handleToggleSitOutNextHand = () => {
+        const newValue = !sitOutNextHand;
+        setSitOutNextHand(newValue);
+        if (newValue) {
+            setSitOutNextBB(false);
+            handleSitOut(tableId, currentNetwork, SIT_OUT_METHOD_NEXT_HAND);
+        }
+    };
+
+    const handleToggleSitOutNextBB = () => {
+        const newValue = !sitOutNextBB;
+        setSitOutNextBB(newValue);
+        if (newValue) {
+            setSitOutNextHand(false);
+            handleSitOut(tableId, currentNetwork, SIT_OUT_METHOD_NEXT_BB);
+        }
+    };
 
     const display = getPlayerActionDisplay({
         playerStatus, sitInMethod, legalActions, totalSeatedPlayers, handNumber, hasActivePlayers
@@ -141,27 +151,30 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
         case "sit-out-button":
             return (
                 <div className={`fixed z-30 ${positionClass}`}>
-                    {isCompact ? (
-                        <button
-                            onClick={() => handleSitOut(tableId, currentNetwork)}
-                            className="btn-sit-out text-white font-medium py-1.5 px-3 rounded-lg shadow-md text-xs
-                                backdrop-blur-sm transition-all duration-300 border
-                                flex items-center justify-center gap-2 transform hover:scale-105"
-                        >
-                            <SitOutIcon size="h-3 w-3" />
-                            Sit Out
-                        </button>
-                    ) : (
-                        <button
-                            onClick={() => handleSitOut(tableId, currentNetwork)}
-                            className="btn-sit-out text-white font-medium py-2 px-4 rounded-lg shadow-md text-sm
-                                backdrop-blur-sm transition-all duration-300 border
-                                flex items-center justify-center gap-2 transform hover:scale-105"
-                        >
-                            <SitOutIcon size="h-4 w-4" />
-                            Sit Out
-                        </button>
-                    )}
+                    <div className={`backdrop-blur-sm rounded-lg shadow-lg border border-white/20 bg-black/60 ${isCompact ? "p-2" : "p-3"}`}>
+                        <label className="flex items-center mb-2 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={sitOutNextHand}
+                                onChange={handleToggleSitOutNextHand}
+                                className="form-checkbox h-4 w-4 text-amber-500 border-gray-500 rounded focus:ring-0"
+                            />
+                            <span className={`ml-2 text-white ${isCompact ? "text-xs" : "text-sm"}`}>
+                                Sit Out Next Hand
+                            </span>
+                        </label>
+                        <label className="flex items-center cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={sitOutNextBB}
+                                onChange={handleToggleSitOutNextBB}
+                                className="form-checkbox h-4 w-4 text-amber-500 border-gray-500 rounded focus:ring-0"
+                            />
+                            <span className={`ml-2 text-white ${isCompact ? "text-xs" : "text-sm"}`}>
+                                Sit Out Next Big Blind
+                            </span>
+                        </label>
+                    </div>
                 </div>
             );
 

--- a/src/hooks/playerActions/index.ts
+++ b/src/hooks/playerActions/index.ts
@@ -12,7 +12,8 @@ import { raiseHand } from "./raiseHand";
 import { showCards } from "./showCards";
 import { sitIn, SIT_IN_METHOD_NEXT_BB, SIT_IN_METHOD_POST_NOW } from "./sitIn";
 import type { SitInMethod } from "./sitIn";
-import { sitOut } from "./sitOut";
+import { sitOut, SIT_OUT_METHOD_NEXT_HAND, SIT_OUT_METHOD_NEXT_BB } from "./sitOut";
+import type { SitOutMethod } from "./sitOut";
 import { startNewHand } from "./startNewHand";
 import { useOptimisticAction, OptimisticAction } from "./useOptimisticAction";
 import type { OptimisticActionType } from "./useOptimisticAction";
@@ -36,6 +37,8 @@ export {
     SIT_IN_METHOD_NEXT_BB,
     SIT_IN_METHOD_POST_NOW,
     sitOut,
+    SIT_OUT_METHOD_NEXT_HAND,
+    SIT_OUT_METHOD_NEXT_BB,
     startNewHand,
     useOptimisticAction,
     OptimisticAction,
@@ -43,4 +46,4 @@ export {
     useAutoPostBlinds
 };
 
-export type { OptimisticActionType, SitInMethod };
+export type { OptimisticActionType, SitInMethod, SitOutMethod };

--- a/src/hooks/playerActions/sitOut.ts
+++ b/src/hooks/playerActions/sitOut.ts
@@ -1,25 +1,35 @@
 import { getSigningClient } from "../../utils/cosmos/client";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import type { SitOutMethod } from "@block52/poker-vm-sdk";
+import { SIT_OUT_METHOD_NEXT_HAND } from "@block52/poker-vm-sdk";
+
+export { SIT_OUT_METHOD_NEXT_HAND };
+export { SIT_OUT_METHOD_NEXT_BB } from "@block52/poker-vm-sdk";
+export type { SitOutMethod } from "@block52/poker-vm-sdk";
 
 /**
  * Sit out in a poker game using Cosmos SDK SigningCosmosClient.
  *
  * @param tableId - The ID of the table (game ID on Cosmos) where the action will be performed
  * @param network - The current network configuration from NetworkContext
+ * @param method - The sit-out method: "next-hand" or "next-bb"
  * @returns Promise with PlayerActionResult containing transaction details
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
-export async function sitOut(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient, userAddress } = await getSigningClient(network);
-
+export async function sitOut(
+    tableId: string,
+    network: NetworkEndpoints,
+    method: SitOutMethod = SIT_OUT_METHOD_NEXT_HAND
+): Promise<PlayerActionResult> {
+    const { signingClient } = await getSigningClient(network);
 
     const transactionHash = await signingClient.performAction(
         tableId,
         "sit-out",
-        0n
+        0n,
+        `method=${method}`
     );
-
 
     return {
         hash: transactionHash,


### PR DESCRIPTION
## Summary

- Replace immediate "Sit Out" button with two Ignition-style checkboxes: **Sit Out Next Hand** and **Sit Out Next Big Blind**
- Checkboxes are mutually exclusive (selecting one deselects the other)
- `sitOut` hook now accepts a `SitOutMethod` parameter (`"next-hand"` or `"next-bb"`), mirroring the `sitIn` pattern
- `handleSitOut` in `actionHandlers.ts` updated to pass method through
- PVM queuing logic is a separate PR — for now the PVM processes sit-out immediately

## Test plan

- [x] `yarn build` — builds without errors
- [x] `yarn lint:fix` — 0 errors (only pre-existing warnings)
- [ ] Load a table and verify two checkboxes appear instead of "Sit Out" button
- [ ] Click "Sit Out Next Hand" — sends `sit-out` action with `method=next-hand`
- [ ] Click "Sit Out Next Big Blind" — sends `sit-out` action with `method=next-bb`
- [ ] Verify selecting one checkbox deselects the other

Depends on: block52/poker-vm#1892
Refs: block52/poker-vm#1891, #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)