### PR TITLE
Updated player UI status handling so seated and sitting-out both stay…

### DIFF
--- a/src/components/playPage/Players/OppositePlayer.tsx
+++ b/src/components/playPage/Players/OppositePlayer.tsx
@@ -37,7 +37,7 @@ type OppositePlayerProps = {
 };
 
 const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, index, color, uiPosition, cardBackStyle }) => {
-    const { playerData, stackValue, isFolded, isAllIn, isSittingOut, isBusted, holeCards, round } = usePlayerData(index);
+    const { playerData, stackValue, isFolded, isAllIn, isSeated, isSittingOut, isBusted, holeCards, round } = usePlayerData(index);
     const { winnerInfo } = useWinnerInfo();
     const { equities, shouldShow: shouldShowEquity } = useAllInEquity();
 
@@ -68,7 +68,7 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
     }, [winnerInfo, index]);
 
     // 2) dim non-winners when someone has won, also dim busted players like sitting out
-    const opacityClass = hasWinner ? (isWinner ? "opacity-100" : "opacity-40") : (isSittingOut || isBusted) ? "opacity-50" : isFolded ? "opacity-60" : "opacity-100";
+    const opacityClass = hasWinner ? (isWinner ? "opacity-100" : "opacity-40") : (isSeated || isSittingOut || isBusted) ? "opacity-50" : isFolded ? "opacity-60" : "opacity-100";
 
     // Get winner amount if this player is a winner
     const winnerAmount = React.useMemo(() => {
@@ -142,7 +142,7 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
                     >
                         {/* Progress bar is not shown in showdown */}
                         {!isWinner && round !== "showdown" && <ProgressBar index={index} />}
-                        {!isWinner && isSittingOut && (
+                        {!isWinner && (isSeated || isSittingOut) && (
                             <span className={`font-bold animate-progress delay-2000 flex items-center w-full h-2 mb-2 mt-auto gap-2 justify-center ${styles.whiteText}`}>SITTING OUT</span>
                         )}
                         {!isWinner && isFolded && (

--- a/src/components/playPage/Players/Player.tsx
+++ b/src/components/playPage/Players/Player.tsx
@@ -19,7 +19,7 @@ import styles from "./PlayersCommon.module.css";
 const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
     ({ left, top, index, currentIndex: _currentIndex, color, status: _status, uiPosition }) => {
         const { id } = useParams<{ id: string }>();
-        const { playerData, stackValue, isFolded, isAllIn, isSittingOut, isBusted, holeCards, round } = usePlayerData(index);
+        const { playerData, stackValue, isFolded, isAllIn, isSeated, isSittingOut, isBusted, holeCards, round } = usePlayerData(index);
         const { winnerInfo } = useWinnerInfo();
         const { extendTime, canExtend, isCurrentUserTurn } = usePlayerTimer(id, index);
 
@@ -78,7 +78,7 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
         const isWinner = useMemo(() => !!winnerInfo?.some((w: any) => w.seat === index), [winnerInfo, index]);
 
         // 3) dim non-winners when someone has won, also dim busted players like sitting out
-        const opacityClass = hasWinner ? (isWinner ? "opacity-100" : "opacity-40") : (isSittingOut || isBusted) ? "opacity-50" : isFolded ? "opacity-60" : "opacity-100";
+        const opacityClass = hasWinner ? (isWinner ? "opacity-100" : "opacity-40") : (isSeated || isSittingOut || isBusted) ? "opacity-50" : isFolded ? "opacity-60" : "opacity-100";
 
         // 4) memoize winner amount
         const winnerAmount = useMemo(() => {
@@ -122,7 +122,7 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
                     </span>
                 );
             }
-            if (isSittingOut) {
+            if (isSeated || isSittingOut) {
                 return (
                     <span className={`font-bold animate-progress delay-2000 flex items-center w-full h-2 mb-2 mt-auto gap-2 justify-center ${styles.whiteText}`}>
                         SITTING OUT
@@ -149,7 +149,7 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
                 );
             }
             return null;
-        }, [isWinner, winnerAmount, isSittingOut, isFolded, isAllIn, playerEquity]);
+        }, [isWinner, winnerAmount, isSeated, isSittingOut, isFolded, isAllIn, playerEquity]);
 
         // 7) container style for positioning
         const containerStyle = useMemo(

--- a/src/hooks/player/usePlayerData.ts
+++ b/src/hooks/player/usePlayerData.ts
@@ -67,9 +67,17 @@ export const usePlayerData = (seatIndex?: number): PlayerDataReturn => {
   const isAllIn = React.useMemo((): boolean => {
     return playerData?.status === PlayerStatus.ALL_IN;
   }, [playerData]);
+
+  const isSeated = React.useMemo((): boolean => {
+    return playerData?.status === PlayerStatus.SEATED;
+  }, [playerData]);
   
   const isSittingOut = React.useMemo((): boolean => {
     return playerData?.status === PlayerStatus.SITTING_OUT;
+  }, [playerData]);
+
+  const isSittingIn = React.useMemo((): boolean => {
+    return playerData?.status === PlayerStatus.SITTING_IN;
   }, [playerData]);
   
   const isBusted = React.useMemo((): boolean => {
@@ -89,7 +97,9 @@ export const usePlayerData = (seatIndex?: number): PlayerDataReturn => {
     stackValue,
     isFolded,
     isAllIn,
+    isSeated,
     isSittingOut,
+    isSittingIn,
     isBusted,
     holeCards,
     round,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -342,7 +342,9 @@ export interface PlayerDataReturn extends BaseHookReturn {
     stackValue: number;
     isFolded: boolean;
     isAllIn: boolean;
+    isSeated: boolean;
     isSittingOut: boolean;
+    isSittingIn: boolean;
     isBusted: boolean;
     holeCards: string[];
     round: TexasHoldemRound | null;


### PR DESCRIPTION
… greyed with a “SITTING OUT” label, and both visuals clear immediately on sitting-in (for both local and opposite players).