### PR TITLE
fix(ui): SEATED player no longer displays as SITTING OUT

### DIFF
--- a/src/components/playPage/Players/OppositePlayer.tsx
+++ b/src/components/playPage/Players/OppositePlayer.tsx
@@ -142,7 +142,10 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
                     >
                         {/* Progress bar is not shown in showdown */}
                         {!isWinner && round !== "showdown" && <ProgressBar index={index} />}
-                        {!isWinner && (isSeated || isSittingOut) && (
+                        {!isWinner && isSeated && (
+                            <span className={`font-bold animate-progress delay-2000 flex items-center w-full h-2 mb-2 mt-auto gap-2 justify-center ${styles.whiteText}`}>SEATED</span>
+                        )}
+                        {!isWinner && isSittingOut && (
                             <span className={`font-bold animate-progress delay-2000 flex items-center w-full h-2 mb-2 mt-auto gap-2 justify-center ${styles.whiteText}`}>SITTING OUT</span>
                         )}
                         {!isWinner && isFolded && (

--- a/src/components/playPage/Players/Player.tsx
+++ b/src/components/playPage/Players/Player.tsx
@@ -122,7 +122,14 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
                     </span>
                 );
             }
-            if (isSeated || isSittingOut) {
+            if (isSeated) {
+                return (
+                    <span className={`font-bold animate-progress delay-2000 flex items-center w-full h-2 mb-2 mt-auto gap-2 justify-center ${styles.whiteText}`}>
+                        SEATED
+                    </span>
+                );
+            }
+            if (isSittingOut) {
                 return (
                     <span className={`font-bold animate-progress delay-2000 flex items-center w-full h-2 mb-2 mt-auto gap-2 justify-center ${styles.whiteText}`}>
                         SITTING OUT

--- a/src/hooks/game/useGameProgress.ts
+++ b/src/hooks/game/useGameProgress.ts
@@ -43,8 +43,8 @@ export const useGameProgress = (_tableId?: string): GameProgressReturn => {
             return defaultState;
         }
 
-        // Filter for active players (not folded and not sitting out)
-        const activePlayers = gameState.players.filter((player: PlayerDTO) => player.status !== PlayerStatus.FOLDED && player.status !== PlayerStatus.SITTING_OUT);
+        // Filter for active players (not folded, not sitting out, and not seated)
+        const activePlayers = gameState.players.filter((player: PlayerDTO) => player.status !== PlayerStatus.FOLDED && player.status !== PlayerStatus.SITTING_OUT && player.status !== PlayerStatus.SEATED);
 
         // Game is in progress if there are at least 2 active players
         const isGameInProgress = activePlayers.length > 1;


### PR DESCRIPTION
## Summary
- Split `isSeated || isSittingOut` condition into separate checks in `Player.tsx` and `OppositePlayer.tsx`
- `SEATED` players now show "SEATED" text (dimmed, not in the hand)
- `SITTING_OUT` players continue to show "SITTING OUT" text
- Exclude `SEATED` players from active player count in `useGameProgress.ts`

## Root Cause
PR #123 introduced `isSeated` to `usePlayerData` and added it to the "SITTING OUT" display condition with `(isSeated || isSittingOut)`, causing any player with `status: "seated"` (e.g. mid-hand joiner) to display as "SITTING OUT".

## Test plan
- [x] All 439 tests pass
- [x] Type check passes (pre-existing errors in `convertUtils.ts` only)
- [ ] Manual: join a table as 3rd player mid-hand — should show "SEATED" not "SITTING OUT"

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)