### PR TITLE
fix: hide duplicate Main Pot at showdown (#1806)

### DIFF
--- a/src/components/playPage/Table/components/TableBoard.tsx
+++ b/src/components/playPage/Table/components/TableBoard.tsx
@@ -70,12 +70,14 @@ export const TableBoard: React.FC<TableBoardProps> = ({
                                 {potDisplayValues.isTournamentStyle ? ` ${potDisplayValues.totalPot}` : ` $${potDisplayValues.totalPot}`}
                             </span>
                         </div>
-                        <div className="pot-display-secondary">
-                            Main Pot:
-                            <span className="pot-value-bold">
-                                {potDisplayValues.isTournamentStyle ? ` ${potDisplayValues.mainPot}` : ` $${potDisplayValues.mainPot}`}
-                            </span>
-                        </div>
+                        {potDisplayValues.mainPot !== potDisplayValues.totalPot && (
+                            <div className="pot-display-secondary">
+                                Main Pot:
+                                <span className="pot-value-bold">
+                                    {potDisplayValues.isTournamentStyle ? ` ${potDisplayValues.mainPot}` : ` $${potDisplayValues.mainPot}`}
+                                </span>
+                            </div>
+                        )}
                     </>
                 )}
 


### PR DESCRIPTION
## Summary

- Hide Main Pot display when it equals Total Pot (e.g. at showdown)
- At showdown all bets are consolidated, so both values are identical — showing both is confusing
- Matches Ignition/PokerStars behaviour: only show pot breakdown when values differ

## What changed

`TableBoard.tsx` — Main Pot line is now conditionally rendered only when `mainPot !== totalPot`.

## Closes

- block52/poker-vm#1806

## Test plan

- [ ] During active betting rounds, verify Main Pot and Total Pot show different values
- [ ] At showdown, verify only Total Pot is displayed (Main Pot hidden)
- [ ] Test with cash games and tournament/SNG formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)