### PR TITLE
fix: remove misleading blocks remaining from distribution page (#33)

### DIFF
--- a/src/pages/explorer/DistributionPage.tsx
+++ b/src/pages/explorer/DistributionPage.tsx
@@ -196,13 +196,8 @@ export default function DistributionPage() {
                                         }}
                                     />
                                 </div>
-                                <div className="flex items-center justify-between mt-2 text-xs text-gray-400">
+                                <div className="mt-2 text-xs text-gray-400">
                                     <span>{indexerStatus.percent_complete.toFixed(1)}% complete</span>
-                                    <span>
-                                        {indexerStatus.total_blocks - indexerStatus.blocks_indexed > 0
-                                            ? `${(indexerStatus.total_blocks - indexerStatus.blocks_indexed).toLocaleString()} blocks remaining`
-                                            : "Fully synced"}
-                                    </span>
                                 </div>
                                 <div className="flex gap-6 mt-3 text-xs text-gray-500">
                                     <span>Hands: {indexerStatus.total_hands.toLocaleString()}</span>


### PR DESCRIPTION
## Summary

- Remove the "X blocks remaining" text from the indexer sync progress bar on `/explorer/distribution`
- `blocks_indexed` counts blocks containing game data, not total blocks scanned, so the remaining calculation was wrong (showed 273,950 remaining despite being 99.3% synced)

## Closes

- #33 (partial — the main chart issue is an indexer backend bug tracked in block52/indexer#4)

## Test plan

- [ ] Visit `/explorer/distribution` and verify progress bar shows percentage only, no "blocks remaining"

🤖 Generated with [Claude Code](https://claude.com/claude-code)