### PR TITLE
fix: disable pot-sized bet buttons below minimum bet (#18)

### DIFF
--- a/src/components/Footer/PotSizedBetButtons.tsx
+++ b/src/components/Footer/PotSizedBetButtons.tsx
@@ -37,21 +37,24 @@ export const PotSizedBetButtons: React.FC<PotSizedBetButtonsProps> = ({
 
     return (
         <div className="flex justify-between gap-1 lg:gap-2 mb-1">
-            {potBetOptions.map(({ label, variation }) => (
-                <button
-                    key={label}
-                    className="btn-pot px-1 lg:px-2 py-1 lg:py-1.5 rounded-lg w-full border shadow-md text-[10px] lg:text-xs transition-all duration-200 transform hover:scale-105"
-                    onClick={() => onAmountSelect(calculatePotBet(variation))}
-                    disabled={disabled}
-                >
-                    {label}
-                </button>
-            ))}
+            {potBetOptions.map(({ label, variation }) => {
+                const amount = calculatePotBet(variation);
+                return (
+                    <button
+                        key={label}
+                        className="btn-pot px-1 lg:px-2 py-1 lg:py-1.5 rounded-lg w-full border shadow-md text-[10px] lg:text-xs transition-all duration-200 transform hover:scale-105"
+                        onClick={() => onAmountSelect(amount)}
+                        disabled={disabled || amount < minAmount}
+                    >
+                        {label}
+                    </button>
+                );
+            })}
 
             <button
                 className="btn-pot px-1 lg:px-2 py-1 lg:py-1.5 rounded-lg w-full border shadow-md text-[10px] lg:text-xs transition-all duration-200 transform hover:scale-105"
                 onClick={() => onAmountSelect(calculatePotBet("1"))}
-                disabled={disabled}
+                disabled={disabled || calculatePotBet("1") < minAmount}
             >
                 Pot
             </button>


### PR DESCRIPTION
## Summary

- Disable 1/4 Pot, 1/2 Pot, 3/4 Pot, and Pot buttons when their calculated amount is below the minimum bet size
- Previously these buttons were clickable even when the pot fraction was too small to be a legal bet

## Closes

- #18

## Test plan

- [ ] With a small pot, verify fractional pot buttons (e.g. 1/4 Pot) are disabled when their value is below the min bet
- [ ] With a large pot, verify all buttons remain enabled
- [ ] ALL-IN button is unaffected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)