### PR TITLE
feat: hand replay page with shareable URLs (#140)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import TransactionPage from "./pages/explorer/TransactionPage";
 import AddressPage from "./pages/explorer/AddressPage";
 import AllAccountsPage from "./pages/explorer/AllAccountsPage";
 import DistributionPage from "./pages/explorer/DistributionPage";
+import HandReplayPage from "./pages/explorer/HandReplayPage";
 import TestSigningPage from "./pages/TestSigningPage";
 import ManualBridgeTrigger from "./pages/ManualBridgeTrigger";
 import BridgeAdminDashboard from "./pages/BridgeAdminDashboard";
@@ -96,6 +97,7 @@ function AppContent() {
                 <Route path="/explorer/address/:address" element={<AddressPage />} />
                 <Route path="/explorer/accounts" element={<AllAccountsPage />} />
                 <Route path="/explorer/distribution" element={<DistributionPage />} />
+                <Route path="/explorer/hand/:gameId/:handNumber" element={<HandReplayPage />} />
                 <Route path="/nodes" element={<NodesPage />} />
                 <Route path="/node/:name" element={<NodeStatusPage />} />
                 <Route path="/" element={<Dashboard />} />

--- a/src/components/ActionsLog.tsx
+++ b/src/components/ActionsLog.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 import { useGameProgress } from "../hooks/game/useGameProgress";
 import { formatPlayerId, formatAmount } from "../utils/accountUtils";
 import { ActionDTO } from "@block52/poker-vm-sdk";
-import { FaCopy, FaCheck, FaFileDownload } from "react-icons/fa";
+import { FaCopy, FaCheck, FaFileDownload, FaShare } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { useGameStateContext } from "../context/GameStateContext";
 import styles from "./ActionsLog.module.css";
@@ -79,6 +79,7 @@ const ActionsLog: React.FC = () => {
     const { gameState } = useGameStateContext();
     const [copied, setCopied] = useState(false);
     const [copiedJSON, setCopiedJSON] = useState(false);
+    const [copiedShare, setCopiedShare] = useState(false);
 
     // Reusable utility function for copying text to clipboard
     const copyTextToClipboard = (text: string, onSuccess: () => void, errorMessage: string) => {
@@ -174,8 +175,25 @@ const ActionsLog: React.FC = () => {
         }
     };
 
+    const handleShareHand = () => {
+        if (!id || !gameState?.handNumber) {
+            toast.info("No hand data available to share");
+            return;
+        }
+        const shareUrl = `${window.location.origin}/explorer/hand/${id}/${gameState.handNumber}`;
+        copyTextToClipboard(
+            shareUrl,
+            () => {
+                setCopiedShare(true);
+                toast.success("Hand replay URL copied to clipboard!");
+                setTimeout(() => setCopiedShare(false), 2000);
+            },
+            "Failed to copy share URL"
+        );
+    };
+
     return (
-        <div 
+        <div
             className={`rounded w-full h-full overflow-y-auto scrollbar-hide backdrop-blur-sm ${styles.container}`}
         >
             <div 
@@ -196,6 +214,13 @@ const ActionsLog: React.FC = () => {
                         className={`p-1.5 rounded hover:bg-white/10 transition-colors duration-200 ${copiedJSON ? styles.copyButtonCopied : styles.copyButtonDefault}`}
                     >
                         {copiedJSON ? <FaCheck size={12} /> : <FaFileDownload size={12} />}
+                    </button>
+                    <button
+                        onClick={handleShareHand}
+                        title="Share hand replay URL"
+                        className={`p-1.5 rounded hover:bg-white/10 transition-colors duration-200 ${copiedShare ? styles.copyButtonCopied : styles.copyButtonDefault}`}
+                    >
+                        {copiedShare ? <FaCheck size={12} /> : <FaShare size={12} />}
                     </button>
                 </div>
             </div>

--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -574,6 +574,25 @@ const Table = React.memo(() => {
         }
     }, [id]);
 
+    // Handler for sharing current hand replay URL
+    const handleShareHand = useCallback(async () => {
+        if (!id || !handNumber) {
+            toast.info("No hand data available to share");
+            return;
+        }
+        try {
+            const shareUrl = `${window.location.origin}/explorer/hand/${id}/${handNumber}`;
+            await navigator.clipboard.writeText(shareUrl);
+            toast.success("Hand replay URL copied to clipboard!", {
+                position: "top-right",
+                autoClose: 2000,
+            });
+        } catch (error) {
+            console.error("Failed to copy share URL:", error);
+            toast.error("Failed to copy share URL.");
+        }
+    }, [id, handNumber]);
+
     // Memoize event handlers to prevent re-renders
     const handleLobbyClick = useCallback(() => {
         window.location.href = "/";
@@ -667,6 +686,7 @@ const Table = React.memo(() => {
                 copyToClipboard={copyToClipboard}
                 onCloseSideBar={onCloseSideBar}
                 handleLeaveTableClick={handleLeaveTableClick}
+                handleShareHand={handleShareHand}
             />
 
             {/* Mobile Landscape Floating Controls */}

--- a/src/components/playPage/Table/components/TableHeader.tsx
+++ b/src/components/playPage/Table/components/TableHeader.tsx
@@ -219,6 +219,12 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
                             <span className={`text-[10px] sm:text-[15px] font-semibold ${styles.secondaryText}`}>
                                 Hand #{handNumber}
                             </span>
+                            <span className={`hidden sm:inline-block text-[15px] font-semibold ${styles.secondaryText}`}>
+                                <span className="ml-2">Actions # {actionCount}</span>
+                            </span>
+                            <span className={`text-[10px] sm:text-[15px] font-semibold ${styles.secondaryText}`}>
+                                <span className="sm:ml-2">Next to act: Seat {nextToAct}</span>
+                            </span>
                             <button
                                 onClick={handleShareHand}
                                 className={`flex items-center gap-1 text-[10px] sm:text-[15px] font-semibold transition-colors duration-200 hover:opacity-80 ${styles.secondaryText}`}
@@ -227,12 +233,6 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
                                 <FaShare size={10} />
                                 <span className="hidden sm:inline">Share</span>
                             </button>
-                            <span className={`hidden sm:inline-block text-[15px] font-semibold ${styles.secondaryText}`}>
-                                <span className="ml-2">Actions # {actionCount}</span>
-                            </span>
-                            <span className={`text-[10px] sm:text-[15px] font-semibold ${styles.secondaryText}`}>
-                                <span className="sm:ml-2">Next to act: Seat {nextToAct}</span>
-                            </span>
                         </div>
                     </div>
                 </div>

--- a/src/components/playPage/Table/components/TableHeader.tsx
+++ b/src/components/playPage/Table/components/TableHeader.tsx
@@ -221,7 +221,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
                             </span>
                             <button
                                 onClick={handleShareHand}
-                                className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] sm:text-xs transition-colors duration-200 hover:opacity-80 ${styles.secondaryText}`}
+                                className={`flex items-center gap-1 text-[10px] sm:text-[15px] font-semibold transition-colors duration-200 hover:opacity-80 ${styles.secondaryText}`}
                                 title="Share this hand"
                             >
                                 <FaShare size={10} />

--- a/src/components/playPage/Table/components/TableHeader.tsx
+++ b/src/components/playPage/Table/components/TableHeader.tsx
@@ -9,7 +9,7 @@
  */
 
 import React from "react";
-import { FaCopy } from "react-icons/fa";
+import { FaCopy, FaShare } from "react-icons/fa";
 import { LuPanelLeftOpen, LuPanelLeftClose } from "react-icons/lu";
 import { RxExit } from "react-icons/rx";
 import { NetworkSelector } from "../../../NetworkSelector";
@@ -58,6 +58,7 @@ export interface TableHeaderProps {
     copyToClipboard: (text: string) => void;
     onCloseSideBar: () => void;
     handleLeaveTableClick: () => void;
+    handleShareHand: () => void;
 }
 
 export const TableHeader: React.FC<TableHeaderProps> = ({
@@ -83,6 +84,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
     copyToClipboard,
     onCloseSideBar,
     handleLeaveTableClick,
+    handleShareHand,
 }) => {
     // Hidden in mobile landscape
     if (isMobileLandscape) {
@@ -217,6 +219,14 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
                             <span className={`text-[10px] sm:text-[15px] font-semibold ${styles.secondaryText}`}>
                                 Hand #{handNumber}
                             </span>
+                            <button
+                                onClick={handleShareHand}
+                                className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] sm:text-xs transition-colors duration-200 hover:opacity-80 ${styles.secondaryText}`}
+                                title="Share this hand"
+                            >
+                                <FaShare size={10} />
+                                <span className="hidden sm:inline">Share</span>
+                            </button>
                             <span className={`hidden sm:inline-block text-[15px] font-semibold ${styles.secondaryText}`}>
                                 <span className="ml-2">Actions # {actionCount}</span>
                             </span>

--- a/src/pages/explorer/HandReplayPage.tsx
+++ b/src/pages/explorer/HandReplayPage.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { useParams, Link } from "react-router-dom";
+import { AnimatedBackground } from "../../components/common/AnimatedBackground";
+import { ExplorerHeader } from "../../components/explorer/ExplorerHeader";
+import { getCardImageUrl } from "../../utils/cardImages";
+import { FaCopy, FaCheck } from "react-icons/fa";
+import { toast } from "react-toastify";
+import type { HandDetail, HandListItem, HandListResponse } from "./types";
+
+const INDEXER_URL = import.meta.env.VITE_INDEXER_URL || "https://indexer.block52.xyz";
+
+export default function HandReplayPage() {
+    const { gameId, handNumber } = useParams<{ gameId: string; handNumber: string }>();
+
+    const [hand, setHand] = useState<HandDetail | null>(null);
+    const [hands, setHands] = useState<HandListItem[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [copiedUrl, setCopiedUrl] = useState(false);
+
+    const fetchHand = useCallback(async () => {
+        if (!gameId || !handNumber) return;
+        try {
+            setLoading(true);
+            setError(null);
+
+            const res = await fetch(`${INDEXER_URL}/api/v1/hands/${gameId}/${handNumber}`);
+            if (!res.ok) throw new Error(`Hand not found (${res.status})`);
+            const data: HandDetail = await res.json();
+            setHand(data);
+
+            // Also fetch all hands for this game for navigation
+            try {
+                const listRes = await fetch(`${INDEXER_URL}/api/v1/hands?game_id=${gameId}&limit=100`);
+                if (listRes.ok) {
+                    const listData: HandListResponse = await listRes.json();
+                    setHands(listData.data);
+                }
+            } catch {
+                // Non-critical
+            }
+
+            setLoading(false);
+        } catch (err) {
+            console.error("Error fetching hand:", err);
+            setError("Unable to load hand data. Please check the URL and try again.");
+            setLoading(false);
+        }
+    }, [gameId, handNumber]);
+
+    useEffect(() => {
+        fetchHand();
+    }, [fetchHand]);
+
+    const shareUrl = `${window.location.origin}/explorer/hand/${gameId}/${handNumber}`;
+
+    const handleCopyUrl = () => {
+        navigator.clipboard.writeText(shareUrl).then(() => {
+            setCopiedUrl(true);
+            toast.success("Hand URL copied to clipboard!");
+            setTimeout(() => setCopiedUrl(false), 2000);
+        }).catch(() => {
+            toast.error("Failed to copy URL");
+        });
+    };
+
+    // Parse community and hole cards from revealed_cards
+    const communityCards = useMemo(() => {
+        if (!hand?.revealed_cards) return [];
+        return hand.revealed_cards
+            .filter(c => c.card_type === "community")
+            .sort((a, b) => a.position - b.position)
+            .map(c => c.card.toUpperCase());
+    }, [hand?.revealed_cards]);
+
+    const holeCards = useMemo(() => {
+        if (!hand?.revealed_cards) return [];
+        return hand.revealed_cards
+            .filter(c => c.card_type === "hole")
+            .sort((a, b) => a.position - b.position)
+            .map(c => c.card.toUpperCase());
+    }, [hand?.revealed_cards]);
+
+    // Parse the full deck string: "[AC]-JC-6D-7D-..."
+    const deckCards = useMemo(() => {
+        if (!hand?.deck) return [];
+        return hand.deck.replace(/[\[\]]/g, "").split("-");
+    }, [hand?.deck]);
+
+    // Sorted hand list for navigation
+    const sortedHands = useMemo(() => {
+        return [...hands].sort((a, b) => a.hand_number - b.hand_number);
+    }, [hands]);
+
+    const currentHandNum = Number(handNumber);
+
+    const truncateId = (id: string) => {
+        if (id.length <= 14) return id;
+        return `${id.slice(0, 8)}...${id.slice(-4)}`;
+    };
+
+    return (
+        <div className="min-h-screen p-8 relative">
+            <AnimatedBackground />
+            <div className="max-w-7xl mx-auto relative z-10">
+                <ExplorerHeader title="Hand Replay" />
+
+                {loading ? (
+                    <div className="text-center py-12">
+                        <p className="text-lg text-white">Loading hand data...</p>
+                    </div>
+                ) : error ? (
+                    <div className="text-center py-12">
+                        <div className="bg-red-900/30 rounded-lg p-6 border border-red-700 inline-block">
+                            <p className="text-lg text-red-300">{error}</p>
+                            <button
+                                onClick={fetchHand}
+                                className="mt-4 px-4 py-2 bg-red-700 hover:bg-red-600 text-white rounded transition-colors"
+                            >
+                                Retry
+                            </button>
+                        </div>
+                    </div>
+                ) : hand ? (
+                    <>
+                        {/* Header with share button */}
+                        <div className="flex items-center justify-between mb-6">
+                            <h2 className="text-2xl font-bold text-white">
+                                Hand #{hand.hand_number}
+                            </h2>
+                            <button
+                                onClick={handleCopyUrl}
+                                className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors text-sm"
+                            >
+                                {copiedUrl ? <FaCheck /> : <FaCopy />}
+                                {copiedUrl ? "Copied!" : "Share Hand"}
+                            </button>
+                        </div>
+
+                        {/* Hand Info Card */}
+                        <div className="bg-gray-800 rounded-lg p-6 border border-gray-700 mb-6">
+                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                <div>
+                                    <p className="text-sm text-gray-400">Game ID</p>
+                                    <p className="text-white font-mono text-sm">{truncateId(hand.game_id)}</p>
+                                </div>
+                                <div>
+                                    <p className="text-sm text-gray-400">Block Height</p>
+                                    <Link
+                                        to={`/explorer/block/${hand.block_height}`}
+                                        className="text-blue-400 hover:text-blue-300"
+                                    >
+                                        #{hand.block_height.toLocaleString()}
+                                    </Link>
+                                </div>
+                                <div>
+                                    <p className="text-sm text-gray-400">Played</p>
+                                    <p className="text-white">{new Date(hand.created_at).toLocaleString()}</p>
+                                </div>
+                            </div>
+                            {hand.deck_seed && (
+                                <div className="mt-4">
+                                    <p className="text-sm text-gray-400">Deck Seed (Verifiable)</p>
+                                    <p className="text-white font-mono text-xs break-all">{hand.deck_seed}</p>
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Community Cards */}
+                        <div className="bg-gray-800 rounded-lg p-6 border border-gray-700 mb-6">
+                            <h3 className="text-lg font-semibold text-white mb-4">Community Cards</h3>
+                            {communityCards.length > 0 ? (
+                                <div className="flex gap-3">
+                                    {communityCards.map((card, idx) => (
+                                        <img
+                                            key={idx}
+                                            src={getCardImageUrl(card)}
+                                            alt={card}
+                                            className="w-[70px] h-[105px] rounded shadow-lg"
+                                        />
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-gray-400">No community cards revealed</p>
+                            )}
+                        </div>
+
+                        {/* Revealed Hole Cards */}
+                        {holeCards.length > 0 && (
+                            <div className="bg-gray-800 rounded-lg p-6 border border-gray-700 mb-6">
+                                <h3 className="text-lg font-semibold text-white mb-4">Revealed Hole Cards</h3>
+                                <div className="flex gap-3">
+                                    {holeCards.map((card, idx) => (
+                                        <img
+                                            key={idx}
+                                            src={getCardImageUrl(card)}
+                                            alt={card}
+                                            className="w-[70px] h-[105px] rounded shadow-lg"
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Hand Result */}
+                        {hand.result && (
+                            <div className="bg-gray-800 rounded-lg p-6 border border-gray-700 mb-6">
+                                <h3 className="text-lg font-semibold text-white mb-4">Result</h3>
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div>
+                                        <p className="text-sm text-gray-400">Winner(s)</p>
+                                        <p className="text-green-400 font-semibold">
+                                            {hand.result.winner_count} winner{hand.result.winner_count !== 1 ? "s" : ""}
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p className="text-sm text-gray-400">Result Recorded</p>
+                                        <p className="text-white">{new Date(hand.result.created_at).toLocaleString()}</p>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Full Deck (Provably Fair) */}
+                        {deckCards.length > 0 && (
+                            <div className="bg-gray-800 rounded-lg p-6 border border-gray-700 mb-6">
+                                <h3 className="text-lg font-semibold text-white mb-4">
+                                    Full Deck (Provably Fair)
+                                </h3>
+                                <p className="text-sm text-gray-400 mb-4">
+                                    The complete shuffled deck derived from the on-chain seed. Verify this against the block hash.
+                                </p>
+                                <div className="flex flex-wrap gap-1.5">
+                                    {deckCards.map((card, idx) => (
+                                        <img
+                                            key={idx}
+                                            src={getCardImageUrl(card)}
+                                            alt={card}
+                                            className="w-[45px] h-[67px] rounded shadow"
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Hand Navigation */}
+                        {sortedHands.length > 1 && (
+                            <div className="bg-gray-800 rounded-lg p-6 border border-gray-700">
+                                <h3 className="text-lg font-semibold text-white mb-4">
+                                    All Hands in This Game ({sortedHands.length})
+                                </h3>
+                                <div className="flex flex-wrap gap-2">
+                                    {sortedHands.map(h => (
+                                        <Link
+                                            key={h.hand_number}
+                                            to={`/explorer/hand/${h.game_id}/${h.hand_number}`}
+                                            className={`px-3 py-1.5 rounded text-sm transition-colors ${
+                                                h.hand_number === currentHandNum
+                                                    ? "bg-blue-600 text-white"
+                                                    : "bg-gray-700 text-gray-300 hover:bg-gray-600"
+                                            }`}
+                                        >
+                                            Hand #{h.hand_number}
+                                        </Link>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                    </>
+                ) : null}
+            </div>
+        </div>
+    );
+}

--- a/src/pages/explorer/HandReplayPage.tsx
+++ b/src/pages/explorer/HandReplayPage.tsx
@@ -84,7 +84,7 @@ export default function HandReplayPage() {
     // Parse the full deck string: "[AC]-JC-6D-7D-..."
     const deckCards = useMemo(() => {
         if (!hand?.deck) return [];
-        return hand.deck.replace(/[\[\]]/g, "").split("-");
+        return hand.deck.replace(/[[\]]/g, "").split("-");
     }, [hand?.deck]);
 
     // Sorted hand list for navigation

--- a/src/pages/explorer/types.ts
+++ b/src/pages/explorer/types.ts
@@ -103,3 +103,50 @@ export interface IndexerStatus {
     total_hands: number;
     total_games: number;
 }
+
+// GET /api/v1/hands
+export interface HandListItem {
+    game_id: string;
+    hand_number: number;
+    block_height: number;
+    deck_seed: string;
+    deck: string;
+    tx_hash: string;
+    created_at: string;
+}
+
+export interface HandListResponse {
+    data: HandListItem[];
+    pagination: {
+        limit: number;
+        offset: number;
+        total: number;
+    };
+}
+
+// GET /api/v1/hands/:gameId/:handNumber
+export interface RevealedCard {
+    id: number;
+    game_id: string;
+    hand_number: number;
+    block_height: number;
+    card: string;
+    card_type: "community" | "hole";
+    position: number;
+    created_at: string;
+}
+
+export interface HandResult {
+    game_id: string;
+    hand_number: number;
+    block_height: number;
+    community_cards: string[];
+    winner_count: number;
+    tx_hash: string;
+    created_at: string;
+}
+
+export interface HandDetail extends HandListItem {
+    result: HandResult | null;
+    revealed_cards: RevealedCard[];
+}


### PR DESCRIPTION
## Summary

Implements Option 1 (Block-Based Indexer) from #140 — hand replay via the indexer API.

- **New route**: `/explorer/hand/:gameId/:handNumber` — displays a read-only hand replay
- **HandReplayPage** fetches from `indexer.block52.xyz/api/v1/hands/:gameId/:handNumber` and shows:
  - Hand metadata (game ID, block height, timestamp)
  - Community cards and revealed hole cards rendered with card images
  - Full provably-fair deck from on-chain seed (all 52 cards)
  - Hand result (winner count)
  - Navigation between all hands in the same game
  - Share button to copy replay URL to clipboard
- **Share Hand button** added to the ActionsLog header — copies a replay URL for the current hand

## Example URL

```
https://app.block52.xyz/explorer/hand/0x8144ab58.../7
```

## Sub-issues created

- #161 — Option 2: Hand replay via transaction hash direct query
- #162 — Option 3: Local storage hand history cache

## Refs

- #140

## Test plan

- [ ] Navigate to `/explorer/hand/{gameId}/{handNumber}` with a known hand — verify cards, metadata, and deck render
- [ ] Click Share Hand button — verify URL is copied to clipboard
- [ ] Click hand navigation buttons to switch between hands in the same game
- [ ] Test error state with invalid gameId/handNumber
- [ ] On the table page, click the share icon in the ActionsLog header — verify replay URL is copied

🤖 Generated with [Claude Code](https://claude.com/claude-code)