### PR TITLE
fix(nft): support arweave, onchain data URIs and fix alchemy 403

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 VITE_PROJECT_ID=23ec57c1c95f3f54a97605975d4df7eb
+VITE_NODE_RPC_URL=http://localhost:8545
+VITE_NODE_WS_URL=ws://localhost:8545
 VITE_MAINNET_RPC_URL=https://mainnet.infura.io/v3/
 VITE_BTCPAY_SERVER_URL=
 VITE_BTCPAY_BASIC_AUTH=
@@ -13,24 +15,28 @@ VITE_INDEXER_URL=https://indexer.block52.xyz
 
 # Alchemy API Configuration (REQUIRED for Bridge Admin Dashboard)
 # Get your free API key at: https://www.alchemy.com/
-# Used to query Base Chain bridge contract for deposit events
-VITE_ALCHEMY_URL=https://base-mainnet.g.alchemy.com/v2/YOUR_API_KEY_HERE
+# Used to query Ethereum mainnet bridge contract for deposit events, and as a
+# fallback for NFT discovery if VITE_PROFILE_NFT_INDEXER_URL is not set.
+VITE_ALCHEMY_URL=https://eth-mainnet.g.alchemy.com/v2/YOUR_API_KEY_HERE
 
 # Profile Avatar NFT Discovery
 # Chain used for avatar NFT discovery (defaults to Ethereum Mainnet: 1)
 VITE_PROFILE_NFT_CHAIN_ID=1
 
-# Optional indexer URL template.
-# Use {owner} placeholder. {chainId} is optional if your API supports it.
-# Example (Alchemy):
-# VITE_PROFILE_NFT_INDEXER_URL=https://eth-mainnet.g.alchemy.com/nft/v3/YOUR_API_KEY/getNFTsForOwner?owner={owner}&withMetadata=true&pageSize=100
+# Indexer URL template for Avatar NFT discovery.
+# Use {owner} placeholder for the wallet address. {chainId} is also supported.
+# IMPORTANT: This must point to the same chain as VITE_PROFILE_NFT_CHAIN_ID.
+# VITE_ALCHEMY_URL above is for Base mainnet (bridge). If your NFTs are on
+# Ethereum mainnet, set this to a separate Ethereum mainnet Alchemy NFT endpoint:
+# VITE_PROFILE_NFT_INDEXER_URL=https://eth-mainnet.g.alchemy.com/nft/v3/YOUR_ETH_API_KEY/getNFTsForOwner?owner={owner}&withMetadata=true&pageSize=100
+# If left empty, VITE_ALCHEMY_URL is used as a fallback (only correct if it points to the same chain).
 VITE_PROFILE_NFT_INDEXER_URL=
 
 # Optional backend endpoint to persist selected avatar string and broadcast via websocket
 # Expected payload: { playerAddress, timestamp, signature, avatar }
 VITE_PROFILE_AVATAR_UPDATE_URL=
 
-# Optional debug logging for avatar signing/sync health (dev only)
+# Optional debug logging for avatar signing/sync health (dev only) - set VITE_DEBUG_AVATAR_SIGNING=true to enable
 # Logs presence of address/timestamp/signature and sync response status without printing full signature
 VITE_DEBUG_AVATAR_SIGNING=
 

--- a/src/hooks/profile/useWalletNfts.ts
+++ b/src/hooks/profile/useWalletNfts.ts
@@ -37,6 +37,7 @@ interface IndexerNftItem {
     };
     image?: {
         cachedUrl?: string;
+        thumbnailUrl?: string;
         pngUrl?: string;
         originalUrl?: string;
     };
@@ -118,7 +119,7 @@ export const useWalletNfts = (walletAddress: string | undefined, isConnected: bo
                     return null;
                 }
 
-                const rawImage = item.image?.cachedUrl || item.image?.pngUrl || item.image?.originalUrl || item.metadata?.image || item.rawMetadata?.image || item.raw?.metadata?.image || "";
+                const rawImage = item.image?.cachedUrl || item.image?.thumbnailUrl || item.image?.pngUrl || item.image?.originalUrl || item.metadata?.image || item.rawMetadata?.image || item.raw?.metadata?.image || "";
                 const imageUrl = normalizeIpfsUri(rawImage);
 
                 if (!isAllowedAvatarUrl(imageUrl)) {

--- a/src/utils/profile/ipfs.ts
+++ b/src/utils/profile/ipfs.ts
@@ -1,4 +1,5 @@
 const IPFS_GATEWAY = "https://ipfs.io/ipfs/";
+const ARWEAVE_GATEWAY = "https://arweave.net/";
 
 export const normalizeIpfsUri = (value: string | undefined | null): string => {
     if (!value) {
@@ -9,6 +10,10 @@ export const normalizeIpfsUri = (value: string | undefined | null): string => {
         return value.replace("ipfs://", IPFS_GATEWAY);
     }
 
+    if (value.startsWith("ar://")) {
+        return value.replace("ar://", ARWEAVE_GATEWAY);
+    }
+
     return value;
 };
 
@@ -17,5 +22,5 @@ export const isAllowedAvatarUrl = (url: string): boolean => {
         return false;
     }
 
-    return url.startsWith("https://") || url.startsWith("http://");
+    return url.startsWith("https://") || url.startsWith("http://") || url.startsWith("data:");
 };


### PR DESCRIPTION
- Add ar:// → https://arweave.net/ normalization for Arweave-hosted NFTs
- Allow data: URIs in isAllowedAvatarUrl for fully onchain NFTs (e.g. Etherean)
- Remove excludeFilters[]=SPAM query param (requires Alchemy Growth plan, causes 403 on free keys)
- Fix .env.example: correct bridge contract chain comment (Ethereum mainnet, not Base)
- Fix .env.example: remove excludeFilters from example NFT indexer URL