### PR TITLE
fix(ui): correct withdrawal flow to 2-step architecture

### DIFF
--- a/src/components/modals/WithdrawalModal.tsx
+++ b/src/components/modals/WithdrawalModal.tsx
@@ -1,135 +1,208 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { ethers } from "ethers";
-import { useNavigate } from "react-router-dom";
 import useCosmosWallet from "../../hooks/wallet/useCosmosWallet";
-import { microToUsdc, usdcToMicroBigInt } from "../../constants/currency";
+import { microToUsdc, usdcToMicroBigInt, formatMicroAsUsdc } from "../../constants/currency";
 import useUserWalletConnect from "../../hooks/wallet/useUserWalletConnect";
 import { useNetwork } from "../../context/NetworkContext";
 import { getSigningClient } from "../../utils/cosmos/client";
+import { base64ToHex } from "../../utils/encodingUtils";
+import { BRIDGE_WITHDRAWAL_ABI } from "../../utils/bridge/abis";
+import { COSMOS_BRIDGE_ADDRESS } from "../../config/constants";
 import styles from "./WithdrawalModal.module.css";
 
 /**
  * WithdrawalModal Component
  *
- * PURPOSE:
- * Allows users to initiate a withdrawal from their Block52 (Cosmos) wallet.
- * This handles Step 1 of the 2-step withdrawal flow:
- *   Step 1 (this modal): Initiate withdrawal on Cosmos chain (burns USDC, creates withdrawal request)
- *   Step 2 (WithdrawalDashboard): After validators sign, complete withdrawal on Ethereum
+ * Handles the complete 2-step withdrawal flow:
+ *   Step 1 (Cosmos): Initiate withdrawal signed by cosmos key with eth address in message.
+ *          The validator then signs the withdrawal payload for the deposit contract.
+ *   Step 2 (Ethereum): User calls the deposit contract withdraw() via MetaMask.
  *
- * TECHNICAL FLOW:
- * 1. User must have MetaMask connected (Ethereum address is the withdrawal destination)
- * 2. User enters amount to withdraw
- * 3. Component validates the amount and checks sufficient balance
- * 4. Calls signingClient.initiateWithdrawal() on the Cosmos chain
- * 5. Directs user to WithdrawalDashboard to monitor signing and complete on Ethereum
- *
- * DEPENDENCIES:
- * - ethers.js for address validation
- * - Cosmos signing client for withdrawal initiation
- * - MetaMask (REQUIRED) for providing the Ethereum destination address
+ * The modal auto-polls for the validator signature after initiation so the user
+ * never has to leave or manually refresh.
  */
 
 import type { WithdrawalModalProps } from "./types";
 
+type ModalStep =
+    | "input"
+    | "initiating"
+    | "waiting_signature"
+    | "ready_to_complete"
+    | "completing_eth"
+    | "done";
+
+interface WithdrawalInfo {
+    nonce: string;
+    baseAddress: string;
+    amount: string;
+    signature: string;
+}
+
+const POLL_INTERVAL_MS = 3000;
+const SLOW_POLL_THRESHOLD = 20; // ~60 seconds
+
 const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSuccess }) => {
-    const { balance: cosmosBalance, refreshBalance: refetchAccount } = useCosmosWallet();
+    const { balance: cosmosBalance, address: cosmosAddress, refreshBalance: refetchAccount } = useCosmosWallet();
     const { address: web3Address, isConnected: isWeb3Connected } = useUserWalletConnect();
     const { currentNetwork } = useNetwork();
-    const navigate = useNavigate();
 
-    // Memoized USDC balance in human-readable format (avoids duplication)
     const balanceInUSDC = useMemo(() => {
         const usdcBalanceEntry = cosmosBalance.find(b => b.denom === "usdc");
         return usdcBalanceEntry ? microToUsdc(usdcBalanceEntry.amount) : 0;
     }, [cosmosBalance]);
 
-    // Amount to withdraw in USDC
+    // Form state
     const [amount, setAmount] = useState("");
 
-    // UI state management
-    const [isWithdrawing, setIsWithdrawing] = useState(false);
+    // Flow state
+    const [step, setStep] = useState<ModalStep>("input");
     const [error, setError] = useState("");
-    const [success, setSuccess] = useState(false);
-    const [txHash, setTxHash] = useState<string>("");
+    const [txHash, setTxHash] = useState("");
+    const [ethTxHash, setEthTxHash] = useState("");
+    const [withdrawalInfo, setWithdrawalInfo] = useState<WithdrawalInfo | null>(null);
+    const [pollCount, setPollCount] = useState(0);
+    const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    // Reset form when modal opens/closes
+    // Track the micro amount we initiated so we can match it during polling
+    const initiatedAmountRef = useRef<string>("");
+
+    // Cleanup polling on unmount
+    useEffect(() => {
+        return () => {
+            if (pollIntervalRef.current) {
+                clearInterval(pollIntervalRef.current);
+                pollIntervalRef.current = null;
+            }
+        };
+    }, []);
+
+    // Reset form when modal opens; cleanup polling when it closes.
+    // setState in effect is intentional — standard modal reset pattern
+    // where isOpen is controlled by the parent and there is no onOpen callback.
     useEffect(() => {
         if (isOpen) {
+            // eslint-disable-next-line react-hooks/set-state-in-effect
             setAmount("");
             setError("");
-            setSuccess(false);
+            setStep("input");
             setTxHash("");
+            setEthTxHash("");
+            setWithdrawalInfo(null);
+            setPollCount(0);
+            initiatedAmountRef.current = "";
             refetchAccount();
+        } else {
+            if (pollIntervalRef.current) {
+                clearInterval(pollIntervalRef.current);
+                pollIntervalRef.current = null;
+            }
         }
-    }, [isOpen, refetchAccount, web3Address, isWeb3Connected]);
+    }, [isOpen, refetchAccount]);
 
     const validateAmount = (value: string): boolean => {
-        if (!value || isNaN(Number(value)) || Number(value) <= 0) {
-            return false;
-        }
-        if (Number(value) < 0.01) {
-            return false;
-        }
+        if (!value || isNaN(Number(value)) || Number(value) <= 0) return false;
+        if (Number(value) < 0.01) return false;
         return Number(value) <= balanceInUSDC;
     };
 
+    // Poll for validator signature after initiation
+    const startPolling = useCallback(
+        (targetAmount: string, targetBaseAddress: string) => {
+            if (pollIntervalRef.current) {
+                clearInterval(pollIntervalRef.current);
+            }
+
+            const poll = async () => {
+                try {
+                    const { signingClient } = await getSigningClient(currentNetwork);
+                    const withdrawals = await signingClient.listWithdrawalRequests(cosmosAddress!);
+
+                    // Find matching withdrawal: same base address & amount, prefer signed
+                    const matching = withdrawals
+                        .filter(
+                            (w: any) =>
+                                w.base_address?.toLowerCase() === targetBaseAddress.toLowerCase() &&
+                                w.amount === targetAmount
+                        )
+                        .sort((a: any, b: any) => {
+                            if (a.status === "signed" && b.status !== "signed") return -1;
+                            if (b.status === "signed" && a.status !== "signed") return 1;
+                            return 0;
+                        });
+
+                    const found = matching[0];
+
+                    if (found && found.status === "signed" && found.signature) {
+                        // Validator has signed - stop polling
+                        if (pollIntervalRef.current) {
+                            clearInterval(pollIntervalRef.current);
+                            pollIntervalRef.current = null;
+                        }
+                        setWithdrawalInfo({
+                            nonce: found.nonce,
+                            baseAddress: found.base_address,
+                            amount: found.amount,
+                            signature: found.signature
+                        });
+                        setStep("ready_to_complete");
+                    } else {
+                        setPollCount(prev => prev + 1);
+                    }
+                } catch (err) {
+                    console.error("[WithdrawalModal] Polling error:", err);
+                }
+            };
+
+            // Poll immediately, then on interval
+            poll();
+            pollIntervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
+        },
+        [currentNetwork, cosmosAddress]
+    );
+
+    // ─── Step 1: Initiate withdrawal on Cosmos ───────────────────────────
     const handleWithdraw = async () => {
-        // STEP 1: Check if MetaMask is connected
         if (!isWeb3Connected || !web3Address) {
-            console.error("[WithdrawalModal] MetaMask not connected");
             setError("Please connect your MetaMask wallet first");
             return;
         }
 
-        // STEP 2: Validate the connected wallet address
         if (!ethers.isAddress(web3Address)) {
-            console.error("[WithdrawalModal] Invalid MetaMask address:", web3Address);
             setError("Invalid MetaMask wallet address");
             return;
         }
 
-        // STEP 3: Validate the amount
         if (!validateAmount(amount)) {
-            if (Number(amount) < 0.01) {
-                console.error("[WithdrawalModal] Amount too small:", amount);
-                setError("Minimum withdrawal amount is 0.01 USDC");
-            } else {
-                console.error("[WithdrawalModal] Invalid amount or insufficient balance:", amount);
-                setError("Invalid amount or insufficient balance");
-            }
+            setError(
+                Number(amount) < 0.01
+                    ? "Minimum withdrawal amount is 0.01 USDC"
+                    : "Invalid amount or insufficient balance"
+            );
             return;
         }
 
-        setIsWithdrawing(true);
+        setStep("initiating");
         setError("");
 
         try {
             const { signingClient } = await getSigningClient(currentNetwork);
-
-            // Convert USDC to micro (6 decimals)
             const microAmount = usdcToMicroBigInt(parseFloat(amount));
+            initiatedAmountRef.current = microAmount.toString();
 
-            // Initiate the withdrawal on Cosmos chain
+            // Send MsgInitiateWithdrawal signed by cosmos key, eth address in message
             const hash = await signingClient.initiateWithdrawal(web3Address, microAmount);
 
-            setSuccess(true);
             setTxHash(hash);
+            setStep("waiting_signature");
 
-            // Refresh balance after successful initiation
-            setTimeout(() => {
-                refetchAccount();
-                if (onSuccess) {
-                    onSuccess();
-                }
-            }, 2000);
+            // Start auto-polling for the validator signature
+            startPolling(microAmount.toString(), web3Address);
+
+            // Refresh cosmos balance in the background
+            setTimeout(() => refetchAccount(), 2000);
         } catch (err: any) {
             console.error("[WithdrawalModal] Withdrawal error:", err);
-            console.error("[WithdrawalModal] Error details:", {
-                message: err.message,
-                code: err.code,
-                data: err.data
-            });
 
             if (err.message?.includes("insufficient")) {
                 setError("Insufficient balance for withdrawal");
@@ -140,14 +213,60 @@ const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSu
             } else {
                 setError(err.message || "Failed to initiate withdrawal");
             }
-        } finally {
-            setIsWithdrawing(false);
+            setStep("input");
+        }
+    };
+
+    // ─── Step 2: Complete withdrawal on Ethereum ─────────────────────────
+    const handleCompleteOnEthereum = async () => {
+        if (!withdrawalInfo) {
+            setError("No withdrawal signature available");
+            return;
+        }
+
+        if (!isWeb3Connected || !web3Address) {
+            setError("Please connect your MetaMask wallet");
+            return;
+        }
+
+        setStep("completing_eth");
+        setError("");
+
+        try {
+            const provider = new ethers.BrowserProvider((window as any).ethereum);
+            const signer = await provider.getSigner();
+
+            const contract = new ethers.Contract(COSMOS_BRIDGE_ADDRESS, BRIDGE_WITHDRAWAL_ABI, signer);
+
+            const hexSignature = base64ToHex(withdrawalInfo.signature);
+
+            // Call bridge contract: withdraw(amount, receiver, nonce, signature)
+            const tx = await contract.withdraw(
+                withdrawalInfo.amount,
+                withdrawalInfo.baseAddress,
+                withdrawalInfo.nonce,
+                hexSignature
+            );
+
+            const receipt = await tx.wait();
+
+            if (receipt.status === 1) {
+                setEthTxHash(receipt.hash);
+                setStep("done");
+                if (onSuccess) onSuccess();
+            } else {
+                setError("Ethereum transaction failed");
+                setStep("ready_to_complete");
+            }
+        } catch (err: any) {
+            console.error("[WithdrawalModal] Ethereum tx error:", err);
+            setError(err.message || "Failed to complete withdrawal on Ethereum");
+            setStep("ready_to_complete");
         }
     };
 
     if (!isOpen) return null;
 
-    // Format balance for display (2 decimal places)
     const balanceDisplay = balanceInUSDC.toFixed(2);
 
     return (
@@ -155,41 +274,40 @@ const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSu
             <div className={`rounded-xl p-6 w-full max-w-md mx-4 ${styles.modalContainer}`}>
                 <h2 className="text-2xl font-bold mb-4 text-white">Withdraw Funds</h2>
 
-                {/* Current Balance */}
-                <div className={`mb-4 p-3 rounded-lg ${styles.surfaceMuted}`}>
-                    <p className={`text-sm ${styles.textSecondary}`}>
-                        Available Balance
-                    </p>
-                    <p className={`text-xl font-bold ${styles.textPrimary}`}>
-                        ${balanceDisplay} USDC
-                    </p>
-                </div>
-
-                {/* Success Message */}
-                {success && (
-                    <div className={`mb-4 p-3 rounded-lg ${styles.successAlert}`}>
-                        <p className={`font-semibold ${styles.textSuccess}`}>
-                            Withdrawal Initiated!
-                        </p>
-                        {txHash && (
-                            <p className={`text-sm mt-2 font-mono ${styles.textSecondary}`}>
-                                Tx: {txHash.slice(0, 16)}...
-                            </p>
-                        )}
-                        <p className={`text-sm mt-2 ${styles.textSecondary}`}>
-                            Validators will sign your withdrawal within a few blocks. Complete it on the Withdrawal Dashboard.
-                        </p>
-                        <button
-                            onClick={() => {
-                                onClose();
-                                navigate("/bridge/withdrawals");
-                            }}
-                            className={`mt-3 w-full py-2 px-4 rounded-lg font-semibold text-white transition hover:opacity-90 ${styles.primaryActionButton}`}
-                        >
-                            Go to Withdrawal Dashboard
-                        </button>
+                {/* Step indicator */}
+                <div className="mb-4 flex items-center justify-center gap-2">
+                    <div
+                        className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+                            step === "input" || step === "initiating" || step === "waiting_signature"
+                                ? "bg-blue-600 text-white"
+                                : "bg-green-600 text-white"
+                        }`}
+                    >
+                        1
                     </div>
-                )}
+                    <div
+                        className={`w-12 h-0.5 ${
+                            step === "ready_to_complete" || step === "completing_eth" || step === "done"
+                                ? "bg-green-600"
+                                : "bg-gray-600"
+                        }`}
+                    />
+                    <div
+                        className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold ${
+                            step === "ready_to_complete" || step === "completing_eth"
+                                ? "bg-blue-600 text-white"
+                                : step === "done"
+                                  ? "bg-green-600 text-white"
+                                  : "bg-gray-600 text-gray-400"
+                        }`}
+                    >
+                        2
+                    </div>
+                </div>
+                <div className="mb-4 flex justify-between text-xs text-gray-400 px-2">
+                    <span>Block52 Chain</span>
+                    <span>Ethereum</span>
+                </div>
 
                 {/* Error Message */}
                 {error && (
@@ -198,41 +316,39 @@ const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSu
                     </div>
                 )}
 
-                {!success && (
+                {/* ─── STEP: Input ─────────────────────────────────────── */}
+                {step === "input" && (
                     <>
-                        {/* MetaMask Connection Status */}
+                        <div className={`mb-4 p-3 rounded-lg ${styles.surfaceMuted}`}>
+                            <p className={`text-sm ${styles.textSecondary}`}>Available Balance</p>
+                            <p className={`text-xl font-bold ${styles.textPrimary}`}>${balanceDisplay} USDC</p>
+                        </div>
+
                         {!isWeb3Connected || !web3Address ? (
                             <div className={`mb-4 p-3 rounded-lg ${styles.warningAlert}`}>
-                                <p className={`font-semibold mb-2 ${styles.textWarning}`}>
-                                    MetaMask Not Connected
-                                </p>
+                                <p className={`font-semibold mb-2 ${styles.textWarning}`}>MetaMask Not Connected</p>
                                 <p className={`text-sm ${styles.textSecondary}`}>
-                                    Please connect your MetaMask wallet to withdraw funds. The withdrawal will be sent to your connected MetaMask address.
+                                    Please connect your MetaMask wallet to withdraw funds. The withdrawal will be sent
+                                    to your connected MetaMask address.
                                 </p>
                             </div>
                         ) : (
-                            /* Receiver Address Display (Read-only) */
                             <div className="mb-4">
                                 <label className={`block text-sm mb-2 ${styles.textSecondary}`}>
                                     Withdrawal Address (MetaMask)
                                 </label>
-                                <div
-                                    className={`p-3 rounded-lg ${styles.surfacePrimarySoft}`}
-                                >
-                                    <p className={`font-mono text-sm ${styles.textPrimary}`}>
-                                        {web3Address}
-                                    </p>
+                                <div className={`p-3 rounded-lg ${styles.surfacePrimarySoft}`}>
+                                    <p className={`font-mono text-sm ${styles.textPrimary}`}>{web3Address}</p>
                                 </div>
-                                <p className="text-xs mt-1 text-gray-500">Funds will be sent to your connected MetaMask wallet</p>
+                                <p className="text-xs mt-1 text-gray-500">
+                                    Funds will be sent to your connected MetaMask wallet
+                                </p>
                             </div>
                         )}
 
-                        {/* Amount Input - Only show if MetaMask is connected */}
                         {isWeb3Connected && web3Address && (
                             <div className="mb-6">
-                                <label className={`block text-sm mb-2 ${styles.textSecondary}`}>
-                                    Amount (USDC)
-                                </label>
+                                <label className={`block text-sm mb-2 ${styles.textSecondary}`}>Amount (USDC)</label>
                                 <input
                                     type="number"
                                     value={amount}
@@ -242,33 +358,152 @@ const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSu
                                     min="0"
                                     max={balanceInUSDC}
                                     className={`w-full px-3 py-2 rounded-lg focus:outline-none focus:ring-2 ${styles.amountInput}`}
-                                    disabled={isWithdrawing}
                                 />
                                 <p className="text-xs text-gray-500 mt-1">Minimum: 0.01 USDC</p>
                             </div>
                         )}
+
+                        <div className="flex flex-col space-y-3">
+                            <button
+                                onClick={handleWithdraw}
+                                className={`w-full py-2 px-4 rounded-lg font-semibold text-white transition hover:opacity-90 disabled:opacity-50 ${styles.primaryActionButton}`}
+                                disabled={!isWeb3Connected || !web3Address || !amount}
+                            >
+                                Withdraw
+                            </button>
+                            <button
+                                onClick={onClose}
+                                className={`w-full py-2 px-4 rounded-lg font-semibold text-white transition hover:opacity-80 ${styles.cancelActionButton}`}
+                            >
+                                Cancel
+                            </button>
+                        </div>
                     </>
                 )}
 
-                {/* Action Buttons */}
-                <div className="flex flex-col space-y-3">
-                    {!success && (
+                {/* ─── STEP: Initiating cosmos tx ──────────────────────── */}
+                {step === "initiating" && (
+                    <div className="text-center py-8">
+                        <div className="animate-spin w-12 h-12 border-4 border-blue-500 border-t-transparent rounded-full mx-auto mb-4" />
+                        <p className="text-white font-semibold mb-2">Initiating Withdrawal</p>
+                        <p className="text-gray-400 text-sm">
+                            Signing withdrawal request on Block52 chain...
+                        </p>
+                    </div>
+                )}
+
+                {/* ─── STEP: Waiting for validator signature ───────────── */}
+                {step === "waiting_signature" && (
+                    <div className="text-center py-6">
+                        <div className="animate-spin w-12 h-12 border-4 border-yellow-500 border-t-transparent rounded-full mx-auto mb-4" />
+                        <p className="text-white font-semibold mb-2">Waiting for Validator Signature</p>
+                        <p className="text-gray-400 text-sm mb-4">
+                            Your withdrawal request has been submitted. The validator is signing the withdrawal
+                            payload for the deposit contract...
+                        </p>
+                        {txHash && (
+                            <p className="text-gray-500 text-xs font-mono mb-2">
+                                Cosmos Tx: {txHash.slice(0, 16)}...
+                            </p>
+                        )}
+                        <p className="text-gray-600 text-xs">
+                            Checking... ({pollCount} {pollCount === 1 ? "attempt" : "attempts"})
+                        </p>
+
+                        {pollCount > SLOW_POLL_THRESHOLD && (
+                            <div className={`mt-4 p-3 rounded-lg text-left ${styles.warningAlert}`}>
+                                <p className={`text-sm ${styles.textWarning}`}>
+                                    Signing is taking longer than expected. The validator may need additional time.
+                                    You can wait here or check the Withdrawal Dashboard later.
+                                </p>
+                            </div>
+                        )}
+
                         <button
-                            onClick={handleWithdraw}
-                            className={`w-full py-2 px-4 rounded-lg font-semibold text-white transition hover:opacity-90 disabled:opacity-50 ${styles.primaryActionButton}`}
-                            disabled={isWithdrawing || !isWeb3Connected || !web3Address || !amount}
+                            onClick={onClose}
+                            className="mt-4 text-sm text-gray-500 hover:text-gray-300 transition"
                         >
-                            {isWithdrawing ? "Processing..." : !isWeb3Connected ? "Connect Wallet First" : "Withdraw"}
+                            Close (withdrawal will continue in background)
                         </button>
-                    )}
-                    <button
-                        onClick={onClose}
-                        className={`w-full py-2 px-4 rounded-lg font-semibold text-white transition hover:opacity-80 ${styles.cancelActionButton}`}
-                        disabled={isWithdrawing}
-                    >
-                        Cancel
-                    </button>
-                </div>
+                    </div>
+                )}
+
+                {/* ─── STEP: Ready to complete on Ethereum ─────────────── */}
+                {step === "ready_to_complete" && withdrawalInfo && (
+                    <div className="py-4">
+                        <div className={`mb-4 p-3 rounded-lg ${styles.successAlert}`}>
+                            <p className={`font-semibold ${styles.textSuccess}`}>Validator Signature Received</p>
+                            <p className={`text-sm mt-1 ${styles.textSecondary}`}>
+                                Your withdrawal is signed and ready to complete on Ethereum.
+                            </p>
+                        </div>
+
+                        <div className={`mb-4 p-3 rounded-lg ${styles.surfaceMuted}`}>
+                            <div className="space-y-2 text-sm">
+                                <div className="flex justify-between">
+                                    <span className="text-gray-400">Amount:</span>
+                                    <span className="text-white font-semibold">
+                                        {formatMicroAsUsdc(withdrawalInfo.amount, 6)} USDC
+                                    </span>
+                                </div>
+                                <div className="flex justify-between">
+                                    <span className="text-gray-400">To:</span>
+                                    <span className="text-white font-mono text-xs">
+                                        {withdrawalInfo.baseAddress.slice(0, 10)}...
+                                        {withdrawalInfo.baseAddress.slice(-8)}
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="flex flex-col space-y-3">
+                            <button
+                                onClick={handleCompleteOnEthereum}
+                                className={`w-full py-3 px-4 rounded-lg font-semibold text-white transition hover:opacity-90 ${styles.primaryActionButton}`}
+                            >
+                                Complete on Ethereum
+                            </button>
+                            <button
+                                onClick={onClose}
+                                className="w-full py-2 px-4 rounded-lg font-semibold text-gray-400 hover:text-white transition"
+                            >
+                                Complete Later
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                {/* ─── STEP: Completing on Ethereum ────────────────────── */}
+                {step === "completing_eth" && (
+                    <div className="text-center py-8">
+                        <div className="animate-spin w-12 h-12 border-4 border-green-500 border-t-transparent rounded-full mx-auto mb-4" />
+                        <p className="text-white font-semibold mb-2">Completing on Ethereum</p>
+                        <p className="text-gray-400 text-sm">Confirm the transaction in MetaMask...</p>
+                    </div>
+                )}
+
+                {/* ─── STEP: Done ──────────────────────────────────────── */}
+                {step === "done" && (
+                    <div className="py-4">
+                        <div className={`mb-4 p-4 rounded-lg ${styles.successAlert}`}>
+                            <p className={`text-lg font-bold ${styles.textSuccess}`}>Withdrawal Complete!</p>
+                            <p className={`text-sm mt-2 ${styles.textSecondary}`}>
+                                USDC has been transferred to your Ethereum wallet.
+                            </p>
+                            {ethTxHash && (
+                                <p className="text-xs mt-2 font-mono text-gray-500">
+                                    Eth Tx: {ethTxHash.slice(0, 16)}...
+                                </p>
+                            )}
+                        </div>
+                        <button
+                            onClick={onClose}
+                            className={`w-full py-2 px-4 rounded-lg font-semibold text-white transition hover:opacity-90 ${styles.primaryActionButton}`}
+                        >
+                            Close
+                        </button>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/src/pages/WithdrawalDashboard.tsx
+++ b/src/pages/WithdrawalDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import useCosmosWallet from "../hooks/wallet/useCosmosWallet";
 import { useNetwork } from "../context/NetworkContext";
 import { toast } from "react-toastify";
@@ -14,11 +14,12 @@ import { COSMOS_BRIDGE_ADDRESS } from "../config/constants";
 /**
  * WithdrawalDashboard - Interface for managing USDC withdrawals to Ethereum
  *
- * Features:
- * - Initiate new withdrawals from Block52 to Ethereum
- * - View withdrawal status (pending/signed/completed)
- * - Complete signed withdrawals on Ethereum
- * - 2-step withdrawal flow with automatic validator signing
+ * 2-step withdrawal flow:
+ *   Step 1: User sends withdrawal request to Block52 (signed by cosmos key, eth address in message).
+ *           The validator then signs the withdrawal payload for the deposit contract.
+ *   Step 2: User calls the deposit contract withdraw() on Ethereum via MetaMask.
+ *
+ * This dashboard auto-polls for pending withdrawals so users see status updates in real time.
  */
 
 interface Withdrawal {
@@ -231,6 +232,35 @@ export default function WithdrawalDashboard() {
         loadWithdrawals();
     }, [loadWithdrawals]);
 
+    // Auto-poll for pending withdrawals every 5 seconds
+    const autoPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    useEffect(() => {
+        const hasPending = withdrawals.some(w => w.status === "pending");
+
+        if (hasPending && cosmosWallet.address) {
+            // Start auto-polling
+            if (!autoPollRef.current) {
+                autoPollRef.current = setInterval(() => {
+                    loadWithdrawals();
+                }, 5000);
+            }
+        } else {
+            // No pending withdrawals - stop polling
+            if (autoPollRef.current) {
+                clearInterval(autoPollRef.current);
+                autoPollRef.current = null;
+            }
+        }
+
+        return () => {
+            if (autoPollRef.current) {
+                clearInterval(autoPollRef.current);
+                autoPollRef.current = null;
+            }
+        };
+    }, [withdrawals, cosmosWallet.address, loadWithdrawals]);
+
     // Filter withdrawals based on selected filter
     const filteredWithdrawals = withdrawals.filter(withdrawal => {
         if (filter === "all") return true;
@@ -430,7 +460,10 @@ export default function WithdrawalDashboard() {
                                                             : "Complete on Ethereum"}
                                                     </button>
                                                 ) : withdrawal.status === "pending" ? (
-                                                    <span className="text-gray-500 text-sm">Waiting for validator...</span>
+                                                    <span className="text-yellow-400 text-sm flex items-center justify-center gap-2">
+                                                        <span className="inline-block w-3 h-3 border-2 border-yellow-400 border-t-transparent rounded-full animate-spin" />
+                                                        Awaiting validator signature...
+                                                    </span>
                                                 ) : (
                                                     <span className="text-gray-500 text-sm">—</span>
                                                 )}
@@ -445,19 +478,19 @@ export default function WithdrawalDashboard() {
 
                 {/* Info Box */}
                 <div className="mt-6 bg-blue-900/20 border border-blue-700 rounded-lg p-4">
-                    <h3 className="text-blue-200 font-semibold mb-2">ℹ️ How Withdrawals Work</h3>
+                    <h3 className="text-blue-200 font-semibold mb-2">How Withdrawals Work</h3>
                     <ul className="text-blue-300 text-sm space-y-1 list-disc list-inside">
                         <li>
-                            <strong>Step 1:</strong> Click "New Withdrawal" to burn USDC on Block52 and create a withdrawal request
+                            <strong>Step 1 (Block52):</strong> Send a withdrawal request signed by your cosmos address
+                            with your Ethereum address in the message. The validator then signs the withdrawal payload
+                            for the deposit contract.
                         </li>
                         <li>
-                            <strong>Step 2:</strong> Validators automatically sign your withdrawal (usually within a few blocks)
+                            <strong>Step 2 (Ethereum):</strong> Once the validator has signed, call the deposit
+                            contract withdraw function on Ethereum using MetaMask.
                         </li>
-                        <li>
-                            <strong>Step 3:</strong> Once signed, click "Complete on Ethereum" to receive USDC on Ethereum
-                        </li>
-                        <li>Make sure your Ethereum wallet is connected before completing withdrawals</li>
-                        <li>Each withdrawal requires two transactions: one on Block52, one on Ethereum</li>
+                        <li>Pending withdrawals auto-refresh every 5 seconds until the validator signs.</li>
+                        <li>Make sure your Ethereum wallet is connected before completing withdrawals.</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- **WithdrawalModal** rewritten for end-to-end 2-step flow: Cosmos initiation → auto-poll for validator signature → Ethereum completion via MetaMask — all within the modal
- **WithdrawalDashboard** gains auto-polling (5s) for pending withdrawals and updated messaging
- Fixes the broken "Waiting for validator..." dead state where users had to manually refresh

Closes https://github.com/block52/poker-vm/issues/1926 (FE portion)

## Architecture

```
Step 1 (Block52): MsgInitiateWithdrawal signed by cosmos key, ETH address in message
                  → validator signs withdrawal payload for deposit contract
Step 2 (Ethereum): User calls bridge contract withdraw() via MetaMask
```

Modal auto-polls `listWithdrawalRequests` every 3s until the validator signature arrives, then transitions directly to the Ethereum completion step.

## Test plan

- [ ] Initiate a withdrawal from the modal — verify cosmos tx is submitted
- [ ] Confirm auto-polling detects the validator signature
- [ ] Complete withdrawal on Ethereum via MetaMask
- [ ] Verify dashboard auto-refreshes pending withdrawals
- [ ] Close modal during polling — verify dashboard still shows the pending withdrawal
- [ ] Test slow signing (>60s) — warning should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)