### PR TITLE
fix(ui): improve withdrawal modal and dashboard UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ function AppContent() {
                 <Route path="/table/admin" element={<TableAdminPage />} /> {/* Legacy - keep for backwards compat */}
                 <Route path="/wallet" element={<CosmosWalletPage />} />
                 {/* User-facing routes */}
+                <Route path="/withdrawals" element={<WithdrawalDashboard />} />
                 <Route path="/bridge/withdrawals" element={<WithdrawalDashboard />} />
                 {/* Admin routes - consolidated under /admin */}
                 <Route path="/admin" element={<AdminDashboard />} />

--- a/src/components/modals/WithdrawalModal.tsx
+++ b/src/components/modals/WithdrawalModal.tsx
@@ -463,11 +463,14 @@ const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSu
                             >
                                 Complete on Ethereum
                             </button>
+                            <p className="text-center text-sm text-gray-400">
+                                You can complete this withdrawal later from the Withdrawal Dashboard
+                            </p>
                             <button
                                 onClick={onClose}
-                                className="w-full py-2 px-4 rounded-lg font-semibold text-gray-400 hover:text-white transition"
+                                className={`w-full py-2 px-4 rounded-lg font-semibold text-white transition hover:opacity-80 ${styles.cancelActionButton}`}
                             >
-                                Complete Later
+                                Close
                             </button>
                         </div>
                     </div>

--- a/src/pages/WithdrawalDashboard.tsx
+++ b/src/pages/WithdrawalDashboard.tsx
@@ -393,12 +393,14 @@ export default function WithdrawalDashboard() {
                                     filteredWithdrawals.map(withdrawal => (
                                         <tr key={withdrawal.nonce} className="hover:bg-gray-700/50 transition-colors">
                                             <td className="px-6 py-4 whitespace-nowrap">
-                                                <span className="text-white font-mono text-sm">#{withdrawal.nonce}</span>
+                                                <span className="text-white font-mono text-sm" title={withdrawal.nonce}>
+                                                    #{withdrawal.nonce.slice(0, 10)}...{withdrawal.nonce.slice(-4)}
+                                                </span>
                                             </td>
                                             <td className="px-6 py-4">
                                                 <div className="flex items-center gap-2">
-                                                    <span className="text-white font-mono text-xs" title={withdrawal.baseAddress}>
-                                                        {withdrawal.baseAddress.slice(0, 10)}...{withdrawal.baseAddress.slice(-8)}
+                                                    <span className="text-white font-mono text-sm">
+                                                        {withdrawal.baseAddress}
                                                     </span>
                                                     <button
                                                         onClick={() => {
@@ -423,26 +425,17 @@ export default function WithdrawalDashboard() {
                                             </td>
                                             <td className="px-6 py-4 whitespace-nowrap text-center">
                                                 {withdrawal.status === "pending" && (
-                                                    <span className="px-3 py-1 text-xs font-semibold rounded-full bg-yellow-900/50 text-yellow-300 border border-yellow-700">
-                                                        ⏳ Awaiting Signature
-                                                    </span>
+                                                    <span className="text-sm text-yellow-400">Pending</span>
                                                 )}
                                                 {withdrawal.status === "signed" && (
-                                                    <span className="px-3 py-1 text-xs font-semibold rounded-full bg-blue-900/50 text-blue-300 border border-blue-700">
-                                                        ✍️ Signed (Ready)
-                                                    </span>
+                                                    <span className="text-sm text-blue-400">Signed</span>
                                                 )}
                                                 {withdrawal.status === "completed" && (
-                                                    <span className="px-3 py-1 text-xs font-semibold rounded-full bg-green-900/50 text-green-300 border border-green-700">
-                                                        ✅ Completed
-                                                    </span>
+                                                    <span className="text-sm text-green-400">Completed</span>
                                                 )}
                                                 {withdrawal.status === "error" && (
-                                                    <span
-                                                        className="px-3 py-1 text-xs font-semibold rounded-full bg-red-900/50 text-red-300 border border-red-700 cursor-help"
-                                                        title={withdrawal.errorMessage}
-                                                    >
-                                                        ❌ Error
+                                                    <span className="text-sm text-red-400 cursor-help" title={withdrawal.errorMessage}>
+                                                        Error
                                                     </span>
                                                 )}
                                             </td>


### PR DESCRIPTION
## Summary

- Add `/withdrawals` route alias for easier access
- Update WithdrawalModal close button styling for consistency
- Add helpful text about completing withdrawal later
- Truncate nonce column in dashboard (show first 10 + last 4 chars)
- Show full Ethereum address in dashboard
- Simplify status column to plain colored text (remove badges/emojis)
- Use consistent font-mono styling across nonce and address columns

## Test plan

- [ ] Navigate to `/withdrawals` - should show Withdrawal Dashboard
- [ ] Check withdrawal modal close button matches other modal buttons
- [ ] Verify nonce is truncated but full value shows on hover
- [ ] Verify full ETH address is displayed with consistent font

🤖 Generated with [Claude Code](https://claude.com/claude-code)