### PR TITLE
fix(ui): trigger re-render when other players' NFT avatars load

### DIFF
--- a/src/context/profile/ProfileAvatarContext.tsx
+++ b/src/context/profile/ProfileAvatarContext.tsx
@@ -49,9 +49,6 @@ interface ProfileAvatarContextType extends ProfileAvatarState {
 
 const ProfileAvatarContext = createContext<ProfileAvatarContextType | null>(null);
 
-// Session cache for chain-queried avatars: cosmosAddress → imageUrl
-const chainAvatarCache = new Map<string, string | null>();
-
 const AVATAR_CACHE_KEY = "b52_nft_avatar";
 
 function loadCachedAvatar(cosmosAddr: string): AvatarSelection | null {
@@ -94,6 +91,9 @@ export const ProfileAvatarProvider: React.FC<{ children: React.ReactNode }> = ({
     );
     const [isRegistering, setIsRegistering] = useState(false);
     const [registrationError, setRegistrationError] = useState<string | null>(null);
+
+    // Session cache for chain-queried avatars: cosmosAddress → imageUrl
+    const [chainAvatarCache, setChainAvatarCache] = useState<Map<string, string | null>>(new Map());
 
     // Persist avatar selection to localStorage
     useEffect(() => {
@@ -146,7 +146,11 @@ export const ProfileAvatarProvider: React.FC<{ children: React.ReactNode }> = ({
                     });
 
                     if (matchingNft?.imageUrl) {
-                        chainAvatarCache.set(cosmosAddress.toLowerCase(), matchingNft.imageUrl);
+                        setChainAvatarCache(prev => {
+                            const next = new Map(prev);
+                            next.set(cosmosAddress.toLowerCase(), matchingNft.imageUrl);
+                            return next;
+                        });
                     }
                 }
             } catch (err) {
@@ -220,7 +224,11 @@ export const ProfileAvatarProvider: React.FC<{ children: React.ReactNode }> = ({
                 };
 
                 setSelectedAvatar(nextSelection);
-                chainAvatarCache.set(cosmosAddress.toLowerCase(), asset.imageUrl);
+                setChainAvatarCache(prev => {
+                    const next = new Map(prev);
+                    next.set(cosmosAddress.toLowerCase(), asset.imageUrl);
+                    return next;
+                });
             };
 
             doRegistration()
@@ -239,7 +247,11 @@ export const ProfileAvatarProvider: React.FC<{ children: React.ReactNode }> = ({
     const clearAvatar = useCallback(() => {
         setSelectedAvatar(null);
         if (cosmosAddress) {
-            chainAvatarCache.delete(cosmosAddress.toLowerCase());
+            setChainAvatarCache(prev => {
+                const next = new Map(prev);
+                next.delete(cosmosAddress.toLowerCase());
+                return next;
+            });
         }
         // TODO: Send a cosmos tx to clear the on-chain avatar when SDK supports it
     }, [cosmosAddress]);
@@ -272,7 +284,11 @@ export const ProfileAvatarProvider: React.FC<{ children: React.ReactNode }> = ({
                     imageUrl,
                     selectedAt: Date.now()
                 });
-                chainAvatarCache.set(cosmosAddress.toLowerCase(), imageUrl);
+                setChainAvatarCache(prev => {
+                    const next = new Map(prev);
+                    next.set(cosmosAddress.toLowerCase(), imageUrl);
+                    return next;
+                });
             }
         });
     }, [cosmosAddress, currentNetwork, selectedAvatar]);
@@ -307,18 +323,20 @@ export const ProfileAvatarProvider: React.FC<{ children: React.ReactNode }> = ({
 
                 const { restEndpoint } = getCosmosUrls(currentNetwork);
                 queryNftAvatar(restEndpoint, targetAddress).then(async result => {
-                    if (result) {
-                        const imageUrl = await resolveNftImageUrl(result.contractAddress, result.tokenId);
-                        chainAvatarCache.set(normalized, imageUrl);
-                    } else {
-                        chainAvatarCache.set(normalized, null);
-                    }
+                    const imageUrl = result
+                        ? await resolveNftImageUrl(result.contractAddress, result.tokenId)
+                        : null;
+                    setChainAvatarCache(prev => {
+                        const next = new Map(prev);
+                        next.set(normalized, imageUrl);
+                        return next;
+                    });
                 });
             }
 
             return null;
         },
-        [cosmosAddress, selectedAvatar, currentNetwork]
+        [cosmosAddress, selectedAvatar, currentNetwork, chainAvatarCache]
     );
 
     const contextValue = useMemo(


### PR DESCRIPTION
## Summary

- Fix NFT avatars not loading for other players at the table
- Convert `chainAvatarCache` from module-level Map to React state so async queries trigger re-renders

## Problem

When a user joined a table, other players' NFT avatars weren't displaying. The `getAvatarForAddress()` function was triggering async queries correctly, but storing results in a module-level `Map` that didn't trigger React re-renders.

## Solution

Changed `chainAvatarCache` to React state (`useState`). Now when async avatar queries complete, `setChainAvatarCache()` is called, which triggers a re-render and displays the avatar.

## Test plan

- [ ] User A registers an NFT avatar
- [ ] User B joins a table where User A is seated
- [ ] User B should see User A's NFT avatar within a few seconds
- [ ] Verify no duplicate REST queries (pendingQueriesRef still prevents duplicates)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)