### PR TITLE
feat(ui): standardize Web3 wallet references and add wallet panel (#203)

### DIFF
--- a/src/components/CosmosWalletPage.tsx
+++ b/src/components/CosmosWalletPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { generateWallet as generateWalletSDK, createWalletFromMnemonic as createWalletSDK, getAddressFromMnemonic } from "@block52/poker-vm-sdk";
 import { setCosmosMnemonic, setCosmosAddress, getCosmosMnemonic, getCosmosAddress, clearCosmosData, isValidSeedPhrase } from "../utils/cosmos";
 import { AnimatedBackground } from "./common/AnimatedBackground";
+import useUserWalletConnect from "../hooks/wallet/useUserWalletConnect";
 import styles from "./CosmosWalletPage.module.css";
 
 // Seed phrase word grid component
@@ -25,6 +26,7 @@ const SeedPhraseGrid = ({ mnemonic, hidden = false }: { mnemonic: string; hidden
 
 const CosmosWalletPage = () => {
     const navigate = useNavigate();
+    const { open: openWeb3Wallet, disconnect: disconnectWeb3, isConnected: isWeb3Connected, address: web3Address } = useUserWalletConnect();
     const [mnemonic, setMnemonic] = useState<string>("");
     const [address, setAddress] = useState<string>("");
     const [isGenerating, setIsGenerating] = useState(false);
@@ -341,6 +343,52 @@ const CosmosWalletPage = () => {
                         </div>
                     </div>
                 )}
+
+                {/* Web3 Wallet Panel */}
+                <div
+                    className={`backdrop-blur-sm rounded-xl p-5 mt-4 border shadow-lg ${styles.mainCard}`}
+                >
+                    <h2 className="text-xl font-bold text-white mb-4">Web3 Wallet</h2>
+                    {isWeb3Connected && web3Address ? (
+                        <div className="space-y-4">
+                            <div>
+                                <label className={`text-sm ${styles.textSecondary}`}>Connected Address</label>
+                                <div className="flex gap-2 items-center mt-1">
+                                    <input
+                                        type="text"
+                                        value={web3Address}
+                                        readOnly
+                                        className={`flex-1 text-white px-4 py-2 rounded-lg border font-mono text-sm ${styles.inputField}`}
+                                    />
+                                    <button
+                                        onClick={() => copyToClipboard(web3Address, "Web3 Address")}
+                                        className={`text-white px-4 py-2 rounded-lg transition-all hover:opacity-80 ${styles.primaryButton}`}
+                                    >
+                                        Copy
+                                    </button>
+                                </div>
+                            </div>
+                            <button
+                                onClick={() => disconnectWeb3()}
+                                className={`w-full text-white px-6 py-3 rounded-xl font-semibold transition-all hover:opacity-80 ${styles.dangerButton}`}
+                            >
+                                Disconnect Web3 Wallet
+                            </button>
+                        </div>
+                    ) : (
+                        <div>
+                            <p className={`mb-4 text-sm ${styles.textSecondary}`}>
+                                Connect your Web3 wallet for deposits and withdrawals.
+                            </p>
+                            <button
+                                onClick={() => openWeb3Wallet()}
+                                className={`w-full text-white px-6 py-3 rounded-xl font-semibold transition-all hover:opacity-80 ${styles.primaryButton}`}
+                            >
+                                Connect Your Web3 Wallet
+                            </button>
+                        </div>
+                    )}
+                </div>
 
                 {/* Error Display */}
                 {error && (

--- a/src/components/depositComponents/Web3DepositSection.tsx
+++ b/src/components/depositComponents/Web3DepositSection.tsx
@@ -60,7 +60,7 @@ export const Web3DepositSection: React.FC<Web3DepositSectionProps> = ({
                                 USDC via Web3 Wallet
                             </h2>
                             <p className={`text-xs ${styles.secondaryTextStrong}`}>
-                                Metamask, Coinbase Wallet, etc.
+                                Web3 compatible wallets
                             </p>
                         </div>
                     </div>

--- a/src/components/modals/WithdrawalModal.tsx
+++ b/src/components/modals/WithdrawalModal.tsx
@@ -17,7 +17,7 @@ import styles from "./WithdrawalModal.module.css";
  * Handles the complete 2-step withdrawal flow:
  *   Step 1 (Cosmos): Initiate withdrawal signed by cosmos key with eth address in message.
  *          The validator then signs the withdrawal payload for the deposit contract.
- *   Step 2 (Ethereum): User calls the deposit contract withdraw() via MetaMask.
+ *   Step 2 (Ethereum): User calls the deposit contract withdraw() via Web3 wallet.
  *
  * The modal auto-polls for the validator signature after initiation so the user
  * never has to leave or manually refresh.
@@ -45,7 +45,7 @@ const SLOW_POLL_THRESHOLD = 20; // ~60 seconds
 
 const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSuccess }) => {
     const { balance: cosmosBalance, address: cosmosAddress, refreshBalance: refetchAccount } = useCosmosWallet();
-    const { address: web3Address, isConnected: isWeb3Connected } = useUserWalletConnect();
+    const { address: web3Address, isConnected: isWeb3Connected, open: openWalletConnect } = useUserWalletConnect();
     const { currentNetwork } = useNetwork();
     const { withdraw, hash: withdrawHash, isWithdrawConfirmed, withdrawError } = useWithdraw();
 
@@ -166,12 +166,12 @@ const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSu
     // ─── Step 1: Initiate withdrawal on Cosmos ───────────────────────────
     const handleWithdraw = async () => {
         if (!isWeb3Connected || !web3Address) {
-            setError("Please connect your MetaMask wallet first");
+            setError("Please connect your Web3 wallet first");
             return;
         }
 
         if (!ethers.isAddress(web3Address)) {
-            setError("Invalid MetaMask wallet address");
+            setError("Invalid Web3 wallet address");
             return;
         }
 
@@ -227,7 +227,7 @@ const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSu
         }
 
         if (!isWeb3Connected || !web3Address) {
-            setError("Please connect your MetaMask wallet");
+            setError("Please connect your Web3 wallet");
             return;
         }
 
@@ -331,23 +331,28 @@ const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSu
                         </div>
 
                         {!isWeb3Connected || !web3Address ? (
-                            <div className={`mb-4 p-3 rounded-lg ${styles.warningAlert}`}>
-                                <p className={`font-semibold mb-2 ${styles.textWarning}`}>MetaMask Not Connected</p>
-                                <p className={`text-sm ${styles.textSecondary}`}>
-                                    Please connect your MetaMask wallet to withdraw funds. The withdrawal will be sent
-                                    to your connected MetaMask address.
+                            <div className="mb-4">
+                                <p className={`text-sm mb-3 ${styles.textSecondary}`}>
+                                    Connect your Web3 wallet to withdraw funds. The withdrawal will be sent
+                                    to your connected wallet address.
                                 </p>
+                                <button
+                                    onClick={() => openWalletConnect()}
+                                    className={`w-full py-3 px-4 rounded-lg font-semibold text-white transition hover:opacity-90 ${styles.primaryActionButton}`}
+                                >
+                                    Connect Your Web3 Wallet
+                                </button>
                             </div>
                         ) : (
                             <div className="mb-4">
                                 <label className={`block text-sm mb-2 ${styles.textSecondary}`}>
-                                    Withdrawal Address (MetaMask)
+                                    Withdrawal Address
                                 </label>
                                 <div className={`p-3 rounded-lg ${styles.surfacePrimarySoft}`}>
                                     <p className={`font-mono text-sm ${styles.textPrimary}`}>{web3Address}</p>
                                 </div>
                                 <p className="text-xs mt-1 text-gray-500">
-                                    Funds will be sent to your connected MetaMask wallet
+                                    Funds will be sent to your connected Web3 wallet
                                 </p>
                             </div>
                         )}
@@ -487,7 +492,7 @@ const WithdrawalModal: React.FC<WithdrawalModalProps> = ({ isOpen, onClose, onSu
                     <div className="text-center py-8">
                         <div className="animate-spin w-12 h-12 border-4 border-green-500 border-t-transparent rounded-full mx-auto mb-4" />
                         <p className="text-white font-semibold mb-2">Completing on Ethereum</p>
-                        <p className="text-gray-400 text-sm">Confirm the transaction in MetaMask...</p>
+                        <p className="text-gray-400 text-sm">Confirm the transaction in your wallet...</p>
                     </div>
                 )}
 

--- a/src/hooks/wallet/useWithdraw.ts
+++ b/src/hooks/wallet/useWithdraw.ts
@@ -29,7 +29,7 @@ const useWithdraw = () => {
   ): Promise<void> => {
     if (!userAddress) {
       console.error("[useWithdraw] User wallet is not connected");
-      throw new Error("MetaMask wallet is not connected");
+      throw new Error("Web3 wallet is not connected");
     }
 
     if (!nonce || !receiver || amount <= 0n || !signature) {


### PR DESCRIPTION
Replace all MetaMask-specific references with generic "Web3 wallet" terminology across WithdrawalModal, Web3DepositSection, and useWithdraw hook. Add connect button to withdraw modal when wallet is disconnected. Add Web3 Wallet panel to /wallet page with connect/disconnect and address display.