### PR TITLE
chore(ui): bump SDK to 1.1.15 — NFT avatar registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "=https://paymentservice.texashodl.net",
   "dependencies": {
-    "@block52/poker-vm-sdk": "1.1.14",
+    "@block52/poker-vm-sdk": "1.1.15",
     "@metamask/sdk": "^0.34.0",
     "@reown/appkit": "1.6.7",
     "@reown/appkit-adapter-ethers": "1.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,10 +306,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@block52/poker-vm-sdk@1.1.14":
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.1.14.tgz#6162653be3cd0e64ae90cbe9cfd517516886d640"
-  integrity sha512-halfeIAlFNY6Ex+GMJRRlEjWvnUdJka4C8nBBbs/t+vGgqcFXTKuO/PTzpmceZRf2lGjQyoBNreSy69w5inPRA==
+"@block52/poker-vm-sdk@1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.1.15.tgz#59ba70eea94200d743f92b6c61bfca46efc88367"
+  integrity sha512-W9rja30KDgbk3BJJolApDISKsDKcKKkWZ1gK/LUq4nviSGGrUggbXVFnV6wgZglSwFntl9qTxsmiIMQXei262w==
   dependencies:
     "@bufbuild/protobuf" "^2.10.0"
     "@cosmjs/crypto" "^0.32.4"


### PR DESCRIPTION
## Summary
- Bumps `@block52/poker-vm-sdk` from 1.1.14 → 1.1.15
- Picks up `registerNftAvatar()` on `SigningCosmosClient` — the UI's NFT avatar flow now has the SDK method it needs

## New SDK methods in 1.1.15
- `registerNftAvatar(ethAddress, contractAddress, tokenId, ethSignature)` — broadcasts `MsgRegisterNftAvatar` to chain
- `deleteGame(gameId)` — allows game creator to delete empty tables
- `signWithdrawal(nonce, validatorEthKeyHex)` — validator withdrawal signing

## Test plan
- [ ] Connect wallet, open profile avatar drawer, select NFT, verify MetaMask sign + cosmos broadcast succeeds
- [ ] Verify existing game functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)