### PR TITLE
feat: Nouns NFT themed table with iconic glasses logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
         <link rel="apple-touch-icon" href="/b52favicon.svg" />
         <link rel="mask-icon" href="/b52favicon.svg" color="#000000" />
         <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;700&display=swap" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css2?family=Silkscreen:wght@400;700&display=swap" rel="stylesheet" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="theme-color" content="#000000" />
         <meta name="description" content="Play on-chain poker powered by the Poker VM." />

--- a/src/components/playPage/Table.css
+++ b/src/components/playPage/Table.css
@@ -390,6 +390,95 @@
     animation: actionPulse 1s ease-in-out;
 }
 
+/* ===== Nouns NFT Theme ===== */
+/* Reference: https://www.nouns.com | https://github.com/block52/nouns.poker */
+
+.nouns-table-felt {
+    background: linear-gradient(
+        135deg,
+        #2d1f3d 0%,
+        #1a1a2e 40%,
+        #1e2a3a 100%
+    );
+    box-shadow:
+        0 4px 20px rgba(0,0,0,0.5),
+        inset 0 0 60px rgba(0,0,0,0.3),
+        inset 0 0 120px rgba(214, 60, 94, 0.05),
+        inset 0 0 120px rgba(43, 131, 246, 0.05);
+}
+
+/* Pixel grid overlay on Nouns felt */
+.nouns-table-felt::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background-image:
+        linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px);
+    background-size: 8px 8px;
+    pointer-events: none;
+    z-index: 1;
+}
+
+/* Nouns glasses logo positioning */
+.table-logo-nouns {
+    bottom: 25px;
+}
+
+.nouns-glasses-logo {
+    opacity: 0.25;
+    animation: nounsDropIn 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+@keyframes nounsDropIn {
+    0% {
+        opacity: 0;
+        transform: translateY(-20px) scale(0.8);
+    }
+    100% {
+        opacity: 0.25;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* Nouns background — warm dark with pixel grid */
+.nouns-background {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    background:
+        radial-gradient(circle at 20% 30%, rgba(214, 60, 94, 0.08) 0%, transparent 50%),
+        radial-gradient(circle at 80% 70%, rgba(43, 131, 246, 0.08) 0%, transparent 50%),
+        radial-gradient(circle at 50% 50%, rgba(67, 185, 127, 0.04) 0%, transparent 60%),
+        #0d0d1a;
+}
+
+.nouns-background::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image:
+        linear-gradient(rgba(255,255,255,0.015) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.015) 1px, transparent 1px);
+    background-size: 8px 8px;
+    pointer-events: none;
+}
+
+/* Nouns-themed pot displays */
+.nouns-table-felt .pot-display,
+.nouns-table-felt .pot-display-secondary {
+    font-family: "Silkscreen", monospace;
+    border: 2px solid rgba(214, 60, 94, 0.3);
+    background-color: rgba(26, 26, 46, 0.6);
+}
+
+/* Nouns-themed total pot */
+.nouns-table-felt .pot-display {
+    background: linear-gradient(135deg, rgba(214, 60, 94, 0.2), rgba(43, 131, 246, 0.2));
+    border: 2px solid rgba(214, 60, 94, 0.3);
+}
+
 /* Performance mode - disable expensive animations */
 @media (prefers-reduced-motion: reduce) {
     .background-animated-static {
@@ -413,6 +502,11 @@
     .action-box-exit,
     .action-box-pulse {
         animation: none;
+    }
+
+    .nouns-glasses-logo {
+        animation: none;
+        opacity: 0.25;
     }
 }
 

--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -632,7 +632,7 @@ const Table = React.memo(() => {
     const [isMobileLandscape, setIsMobileLandscape] = useState(
         window.innerWidth <= 1024 && window.innerWidth > window.innerHeight && window.innerHeight <= 600
     );
-    const [tableStyle, setTableStyle] = useState<"modern" | "classic">("modern");
+    const [tableStyle, setTableStyle] = useState<"modern" | "classic" | "nouns">("modern");
 
     // Update viewport mode on window resize
     useEffect(() => {
@@ -860,24 +860,24 @@ const Table = React.memo(() => {
             <LayoutDebugOverlay />
             {/* Table style toggle */}
             <button
-                onClick={() => setTableStyle(s => s === "modern" ? "classic" : "modern")}
+                onClick={() => setTableStyle(s => s === "modern" ? "classic" : s === "classic" ? "nouns" : "modern")}
                 style={{
                     position: "fixed",
                     bottom: 12,
                     left: 12,
                     zIndex: 999999,
                     padding: "6px 12px",
-                    borderRadius: 6,
-                    border: "2px solid #555",
-                    backgroundColor: "rgba(0,0,0,0.6)",
-                    color: "#ccc",
+                    borderRadius: tableStyle === "nouns" ? 0 : 6,
+                    border: tableStyle === "nouns" ? "2px solid #d63c5e" : "2px solid #555",
+                    backgroundColor: tableStyle === "nouns" ? "rgba(26,26,46,0.8)" : "rgba(0,0,0,0.6)",
+                    color: tableStyle === "nouns" ? "#e1d7d5" : "#ccc",
                     fontSize: 12,
-                    fontFamily: "monospace",
+                    fontFamily: tableStyle === "nouns" ? "'Silkscreen', monospace" : "monospace",
                     fontWeight: "bold",
                     cursor: "pointer"
                 }}
             >
-                Table: {tableStyle === "modern" ? "Modern" : "Classic"}
+                Table: {tableStyle === "modern" ? "Modern" : tableStyle === "classic" ? "Classic" : "Nouns"}
             </button>
             <GeometryFixedOverlay
                 containerWidth={tableLayout.containerWidth}
@@ -947,10 +947,16 @@ const Table = React.memo(() => {
             {/*//! BODY — single flex-grow container, measured by geometry engine */}
             <div ref={tableContainerRef} className="flex-grow relative overflow-visible">
                 {/* Background layers */}
-                <HexagonPattern patternId="hexagons-table" />
-                <div className="background-shimmer shimmer-animation" />
-                <div className="background-animated-static" />
-                <div className="background-base-static" />
+                {tableStyle !== "nouns" && <HexagonPattern patternId="hexagons-table" />}
+                {tableStyle === "nouns" ? (
+                    <div className="nouns-background" />
+                ) : (
+                    <>
+                        <div className="background-shimmer shimmer-animation" />
+                        <div className="background-animated-static" />
+                        <div className="background-base-static" />
+                    </>
+                )}
 
                 {/*//! TABLE — zoom-wrapper applies calculated transform */}
                 <div
@@ -959,25 +965,38 @@ const Table = React.memo(() => {
                 >
                     {/*//! 1000x500 table coordinate space — positioned at TABLE_ORIGIN (300,285) in the 1600x850 stage */}
                     <div ref={tableDivRef} className="w-[1000px] h-[500px] absolute" style={{ left: "300px", top: "285px" }}>
-                        {/* Outer rail — Ignition-style 3D depth (modern only) */}
-                        {tableStyle === "modern" && <div className="absolute z-10 rounded-[290px]" style={{
+                        {/* Outer rail — Ignition-style 3D depth (modern and nouns) */}
+                        {(tableStyle === "modern" || tableStyle === "nouns") && <div className="absolute z-10 rounded-[290px]" style={{
                             width: "1060px",
                             height: "560px",
                             left: "-30px",
                             top: "-30px",
-                            border: "10px solid rgba(100, 75, 40, 0.6)",
-                            boxShadow: "0 12px 48px rgba(0,0,0,0.8), 0 4px 16px rgba(0,0,0,0.5), inset 0 3px 12px rgba(0,0,0,0.5), inset 0 -2px 6px rgba(255,255,255,0.05)",
-                            background: "linear-gradient(180deg, rgba(80,55,25,0.25) 0%, rgba(40,25,10,0.45) 100%)"
+                            border: tableStyle === "nouns"
+                                ? "10px solid rgba(26, 26, 46, 0.8)"
+                                : "10px solid rgba(100, 75, 40, 0.6)",
+                            boxShadow: tableStyle === "nouns"
+                                ? "0 12px 48px rgba(0,0,0,0.8), 0 4px 16px rgba(0,0,0,0.5), inset 0 3px 12px rgba(0,0,0,0.5), inset 0 -2px 6px rgba(255,255,255,0.05)"
+                                : "0 12px 48px rgba(0,0,0,0.8), 0 4px 16px rgba(0,0,0,0.5), inset 0 3px 12px rgba(0,0,0,0.5), inset 0 -2px 6px rgba(255,255,255,0.05)",
+                            background: tableStyle === "nouns"
+                                ? "linear-gradient(180deg, rgba(26,26,46,0.4) 0%, rgba(26,26,46,0.7) 100%)"
+                                : "linear-gradient(180deg, rgba(80,55,25,0.25) 0%, rgba(40,25,10,0.45) 100%)"
                         }} />}
                         {/* Table felt surface */}
-                        <div className={`table-surface-shadow z-20 relative flex flex-col w-[1000px] h-[500px] text-center border-solid rounded-[250px] items-center justify-center ${tableStyle === "classic" ? "border-[3px]" : "border-[2px]"}`}
-                            style={{ borderColor: tableStyle === "classic" ? "rgba(255, 255, 255, 0.3)" : "rgba(255, 255, 255, 0.08)" }}>
+                        <div className={`table-surface-shadow z-20 relative flex flex-col w-[1000px] h-[500px] text-center border-solid rounded-[250px] items-center justify-center ${tableStyle === "nouns" ? "nouns-table-felt border-[3px]" : tableStyle === "classic" ? "border-[3px]" : "border-[2px]"}`}
+                            style={{
+                                borderColor: tableStyle === "nouns"
+                                    ? "rgba(214, 60, 94, 0.4)"
+                                    : tableStyle === "classic"
+                                        ? "rgba(255, 255, 255, 0.3)"
+                                        : "rgba(255, 255, 255, 0.08)"
+                            }}>
                             <TableBoard
                                 clubLogo={clubLogo}
                                 potDisplayValues={potDisplayValues}
                                 communityCards={tableDataValues.tableDataCommunityCards || []}
                                 isSitAndGoWaitingForPlayers={isSitAndGoWaitingForPlayers}
                                 cardBackStyle={cardBackStyle}
+                                tableTheme={tableStyle}
                             />
 
                             {/* Chips */}

--- a/src/components/playPage/Table/components/NounsGlasses.tsx
+++ b/src/components/playPage/Table/components/NounsGlasses.tsx
@@ -1,0 +1,57 @@
+/**
+ * NounsGlasses Component
+ *
+ * Inline SVG pixel-art rendering of the iconic Nouns DAO glasses.
+ * Red left lens, blue right lens, with poker suit accents.
+ * Reference: https://github.com/block52/nouns.poker
+ * Official Nouns: https://www.nouns.com
+ */
+
+import React from "react";
+
+interface NounsGlassesProps {
+    width?: number;
+    className?: string;
+}
+
+export const NounsGlasses: React.FC<NounsGlassesProps> = ({ width = 300, className = "" }) => {
+    return (
+        <svg
+            viewBox="0 0 240 80"
+            width={width}
+            className={className}
+            shapeRendering="crispEdges"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            {/* Bridge */}
+            <rect x="104" y="24" width="32" height="8" fill="#1a1a2e" />
+
+            {/* Left Frame */}
+            <rect x="8" y="12" width="96" height="56" rx="0" fill="#1a1a2e" />
+            {/* Left Lens - Red */}
+            <rect x="16" y="20" width="80" height="40" fill="#d63c5e" />
+            {/* Left Lens Shine */}
+            <rect x="20" y="24" width="12" height="8" fill="rgba(255,255,255,0.25)" />
+            {/* Left Lens - Spade Accent */}
+            <rect x="48" y="32" width="8" height="8" fill="rgba(255,255,255,0.15)" />
+            <rect x="44" y="40" width="16" height="4" fill="rgba(255,255,255,0.15)" />
+            <rect x="48" y="44" width="8" height="4" fill="rgba(255,255,255,0.15)" />
+
+            {/* Right Frame */}
+            <rect x="136" y="12" width="96" height="56" rx="0" fill="#1a1a2e" />
+            {/* Right Lens - Blue */}
+            <rect x="144" y="20" width="80" height="40" fill="#2b83f6" />
+            {/* Right Lens Shine */}
+            <rect x="148" y="24" width="12" height="8" fill="rgba(255,255,255,0.25)" />
+            {/* Right Lens - Diamond Accent */}
+            <rect x="180" y="32" width="8" height="4" fill="rgba(255,255,255,0.15)" />
+            <rect x="176" y="36" width="16" height="4" fill="rgba(255,255,255,0.15)" />
+            <rect x="180" y="40" width="8" height="4" fill="rgba(255,255,255,0.15)" />
+
+            {/* Left Arm */}
+            <rect x="0" y="24" width="8" height="8" fill="#1a1a2e" />
+            {/* Right Arm */}
+            <rect x="232" y="24" width="8" height="8" fill="#1a1a2e" />
+        </svg>
+    );
+};

--- a/src/components/playPage/Table/components/TableBoard.tsx
+++ b/src/components/playPage/Table/components/TableBoard.tsx
@@ -14,6 +14,9 @@ import { PotDisplayValues } from "../../../../utils/potDisplayUtils";
 import OppositePlayerCards from "../../Card/OppositePlayerCards";
 import { TotalPotDisplay } from "./TotalPotDisplay";
 import { MainPotDisplay } from "./MainPotDisplay";
+import { NounsGlasses } from "./NounsGlasses";
+
+export type TableTheme = "modern" | "classic" | "nouns";
 
 export interface TableBoardProps {
     // Display data
@@ -26,6 +29,7 @@ export interface TableBoardProps {
 
     // Styling
     cardBackStyle: CardBackStyle;
+    tableTheme: TableTheme;
 }
 
 export const TableBoard: React.FC<TableBoardProps> = ({
@@ -33,7 +37,8 @@ export const TableBoard: React.FC<TableBoardProps> = ({
     potDisplayValues,
     communityCards,
     isSitAndGoWaitingForPlayers,
-    cardBackStyle
+    cardBackStyle,
+    tableTheme
 }) => {
     // Memoize community cards rendering
     const communityCardsElements = useMemo(() => {
@@ -54,8 +59,12 @@ export const TableBoard: React.FC<TableBoardProps> = ({
     return (
         <>
             {/* Club Logo */}
-            <div className="table-logo">
-                <img src={clubLogo} alt="Club Logo" />
+            <div className={`table-logo ${tableTheme === "nouns" ? "table-logo-nouns" : ""}`}>
+                {tableTheme === "nouns" ? (
+                    <NounsGlasses width={300} className="nouns-glasses-logo" />
+                ) : (
+                    <img src={clubLogo} alt="Club Logo" />
+                )}
             </div>
 
             {/* Central Display Area */}

--- a/src/components/playPage/Table/components/TableBoard.tsx
+++ b/src/components/playPage/Table/components/TableBoard.tsx
@@ -29,7 +29,7 @@ export interface TableBoardProps {
 
     // Styling
     cardBackStyle: CardBackStyle;
-    tableTheme: TableTheme;
+    tableTheme?: TableTheme;
 }
 
 export const TableBoard: React.FC<TableBoardProps> = ({
@@ -38,7 +38,7 @@ export const TableBoard: React.FC<TableBoardProps> = ({
     communityCards,
     isSitAndGoWaitingForPlayers,
     cardBackStyle,
-    tableTheme
+    tableTheme = "modern"
 }) => {
     // Memoize community cards rendering
     const communityCardsElements = useMemo(() => {

--- a/src/components/playPage/Table/components/index.ts
+++ b/src/components/playPage/Table/components/index.ts
@@ -8,7 +8,7 @@ export { TableHeader } from "./TableHeader";
 export type { TableHeaderProps } from "./TableHeader";
 
 export { TableBoard } from "./TableBoard";
-export type { TableBoardProps } from "./TableBoard";
+export type { TableBoardProps, TableTheme } from "./TableBoard";
 
 export { TableSidebar } from "./TableSidebar";
 export type { TableSidebarProps } from "./TableSidebar";


### PR DESCRIPTION
## Summary

- Adds **Nouns** as a third table style (cycle with the bottom-left toggle: Modern → Classic → Nouns)
- Replaces the club logo with the iconic **Nouns DAO pixel-art glasses** (inline SVG, no external images)
- Dark felt surface with subtle pixel-grid overlay and red/blue accent glow
- Nouns-themed outer rail, border colors, and background
- **Silkscreen** pixel font loaded for pot displays when in Nouns mode
- Glasses animate in with a bouncy drop-in on table load
- Respects `prefers-reduced-motion`

References: [nouns.poker repo](https://github.com/block52/nouns.poker) | [nouns.com](https://www.nouns.com)

Closes #1946 (in poker-vm repo)

## Files Changed

| File | What |
|------|------|
| `NounsGlasses.tsx` | New SVG component — pixel-art Nouns glasses |
| `TableBoard.tsx` | Accepts `tableTheme` prop, renders glasses or image logo |
| `Table.tsx` | 3-way style toggle, Nouns-specific rail/felt/background |
| `Table.css` | Nouns felt, pixel-grid, background, pot display, animation |
| `index.html` | Loads Silkscreen font from Google Fonts |

## Test plan

- [ ] Toggle table style to "Nouns" — glasses should appear centered on felt
- [ ] Verify pixel-grid overlay visible on felt surface
- [ ] Check pot displays use Silkscreen font in Nouns mode
- [ ] Toggle back to Modern/Classic — standard club logo returns
- [ ] Test on mobile viewport
- [ ] Verify `prefers-reduced-motion` disables glasses animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)