### PR TITLE
feat(ui): add slow roll button at showdown for winners who called

### DIFF
--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { NonPlayerActionType, PlayerActionType, PlayerDTO, PlayerStatus, TexasHoldemRound } from "@block52/poker-vm-sdk";
 import { parseMicroToBigInt, microBigIntToUsdc, usdcToMicroBigInt } from "../../constants/currency";
 
@@ -12,6 +12,7 @@ import { useAutoPostBlinds } from "../../hooks/playerActions/useAutoPostBlinds";
 import { useAutoNewHand } from "../../hooks/playerActions/useAutoNewHand";
 import { useAutoFold } from "../../hooks/playerActions/useAutoFold";
 import { usePlayerTimer } from "../../hooks/player/usePlayerTimer";
+import { useSlowRollEligibility } from "../../hooks/player/useSlowRollEligibility";
 
 // Import action handlers
 import {
@@ -50,6 +51,11 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({
 }) => {
     // Loading state for actions
     const [loadingAction, setLoadingAction] = useState<string | null>(null);
+
+    // Slow roll state
+    const [isSlowRolling, setIsSlowRolling] = useState(false);
+    const [slowRollCountdown, setSlowRollCountdown] = useState(10);
+    const slowRollTimerRef = useRef<NodeJS.Timeout | null>(null);
 
     // Detect mobile landscape orientation
     const [isMobileLandscape, setIsMobileLandscape] = useState(
@@ -104,6 +110,9 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({
     const hasShowAction = hasAction(legalActions, PlayerActionType.SHOW);
     const hasDealAction = hasAction(legalActions, NonPlayerActionType.DEAL);
     const hasNewHandAction = hasAction(legalActions, NonPlayerActionType.NEW_HAND);
+
+    // Check if player is eligible for slow roll (winner who called at showdown)
+    const canSlowRoll = useSlowRollEligibility();
 
     // Blind amounts - single source of truth from gameState.gameOptions (per Commandment 7)
     // Defined early so they can be used in useAutoPostBlinds hook
@@ -330,6 +339,53 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({
         });
     };
 
+    // Slow roll handler - starts countdown then executes show action
+    const handleSlowRoll = useCallback(() => {
+        if (!tableId || isSlowRolling) return;
+
+        setIsSlowRolling(true);
+        setSlowRollCountdown(10);
+
+        slowRollTimerRef.current = setInterval(() => {
+            setSlowRollCountdown((prev) => {
+                if (prev <= 1) {
+                    // Clear the interval
+                    if (slowRollTimerRef.current) {
+                        clearInterval(slowRollTimerRef.current);
+                        slowRollTimerRef.current = null;
+                    }
+                    // Execute the show action
+                    setIsSlowRolling(false);
+                    handleActionWithTransaction("show", () => handleShow(tableId, network));
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+    }, [tableId, isSlowRolling, handleActionWithTransaction, network]);
+
+    // Cleanup slow roll timer on unmount or when showdown ends
+    useEffect(() => {
+        return () => {
+            if (slowRollTimerRef.current) {
+                clearInterval(slowRollTimerRef.current);
+                slowRollTimerRef.current = null;
+            }
+        };
+    }, []);
+
+    // Reset slow roll state when showdown ends
+    useEffect(() => {
+        if (!hasShowAction && isSlowRolling) {
+            setIsSlowRolling(false);
+            setSlowRollCountdown(10);
+            if (slowRollTimerRef.current) {
+                clearInterval(slowRollTimerRef.current);
+                slowRollTimerRef.current = null;
+            }
+        }
+    }, [hasShowAction, isSlowRolling]);
+
     // Calculate button visibility flags
     const { canFoldAnytime, showActionButtons, showSmallBlindButton, showBigBlindButton } = useMemo(() => {
         const showButtons = isUserInTable;
@@ -417,13 +473,17 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({
                 {!hideOtherButtons && (
                     <>
                         {/* Showdown Buttons */}
-                        {(hasMuckAction || hasShowAction) && (
+                        {(hasMuckAction || hasShowAction || isSlowRolling) && (
                             <ShowdownButtons
                                 canMuck={hasMuckAction}
                                 canShow={hasShowAction}
+                                canSlowRoll={canSlowRoll}
                                 loading={loadingAction}
+                                isSlowRolling={isSlowRolling}
+                                slowRollCountdown={slowRollCountdown}
                                 onMuck={() => handleActionWithTransaction("muck", () => handleMuck(tableId, network))}
                                 onShow={() => handleActionWithTransaction("show", () => handleShow(tableId, network))}
+                                onSlowRoll={handleSlowRoll}
                             />
                         )}
 

--- a/src/components/Footer/ShowdownButtons.tsx
+++ b/src/components/Footer/ShowdownButtons.tsx
@@ -5,13 +5,17 @@ import type { ShowdownButtonsProps } from "./types";
 export const ShowdownButtons: React.FC<ShowdownButtonsProps> = ({
     canMuck,
     canShow,
+    canSlowRoll,
     loading,
+    isSlowRolling,
+    slowRollCountdown,
     onMuck,
-    onShow
+    onShow,
+    onSlowRoll
 }) => {
     return (
         <div className="flex justify-center gap-2 mb-2 lg:mb-3">
-            {canMuck && (
+            {canMuck && !isSlowRolling && (
                 <ActionButton
                     action="muck"
                     label="MUCK CARDS"
@@ -21,7 +25,7 @@ export const ShowdownButtons: React.FC<ShowdownButtonsProps> = ({
                     className="px-4 lg:px-6 py-2 lg:py-3 text-sm lg:text-base"
                 />
             )}
-            {canShow && (
+            {canShow && !isSlowRolling && (
                 <ActionButton
                     action="show"
                     label="SHOW CARDS"
@@ -30,6 +34,21 @@ export const ShowdownButtons: React.FC<ShowdownButtonsProps> = ({
                     variant="success"
                     className="px-4 lg:px-6 py-2 lg:py-3 text-sm lg:text-base"
                 />
+            )}
+            {canSlowRoll && canShow && !isSlowRolling && (
+                <ActionButton
+                    action="slow-roll"
+                    label="SLOW ROLL"
+                    loading={false}
+                    onClick={onSlowRoll}
+                    variant="danger"
+                    className="px-4 lg:px-6 py-2 lg:py-3 text-sm lg:text-base"
+                />
+            )}
+            {isSlowRolling && (
+                <div className="flex items-center justify-center px-6 lg:px-8 py-2 lg:py-3 text-sm lg:text-base font-bold bg-red-600/80 border border-red-500 rounded-lg shadow-md backdrop-blur-sm animate-pulse">
+                    <span className="text-white">SLOW ROLLING... {slowRollCountdown}</span>
+                </div>
             )}
         </div>
     );

--- a/src/components/Footer/types.ts
+++ b/src/components/Footer/types.ts
@@ -89,9 +89,13 @@ export interface DealButtonGroupProps {
 export interface ShowdownButtonsProps {
     canMuck: boolean;
     canShow: boolean;
+    canSlowRoll: boolean;
     loading: string | null;
+    isSlowRolling: boolean;
+    slowRollCountdown: number;
     onMuck: () => void;
     onShow: () => void;
+    onSlowRoll: () => void;
 }
 
 /**

--- a/src/hooks/player/index.ts
+++ b/src/hooks/player/index.ts
@@ -18,3 +18,6 @@ export { useShowingCardsByAddress } from "./useShowingCardsByAddress";
 // Hand Strength & Equity
 export { useCardsForHandStrength } from "./useCardsForHandStrength";
 export { useAllInEquity } from "./useAllInEquity";
+
+// Showdown
+export { useSlowRollEligibility } from "./useSlowRollEligibility";

--- a/src/hooks/player/useSlowRollEligibility.ts
+++ b/src/hooks/player/useSlowRollEligibility.ts
@@ -1,0 +1,84 @@
+import { useMemo } from "react";
+import { PlayerActionType, TexasHoldemRound, ActionDTO } from "@block52/poker-vm-sdk";
+import { useGameStateContext } from "../../context/GameStateContext";
+import { useWinnerInfo } from "../game/useWinnerInfo";
+
+/**
+ * Hook to determine if the current player is eligible for a "slow roll"
+ *
+ * Slow roll eligibility requires:
+ * 1. Player is at showdown
+ * 2. Player has the SHOW action available (meaning they're in the showdown)
+ * 3. Player is a winner
+ * 4. Player's last action in the final betting round was a CALL (not a bet/raise)
+ *
+ * @returns Whether the player can slow roll
+ */
+export const useSlowRollEligibility = (): boolean => {
+    const { gameState } = useGameStateContext();
+    const { winnerInfo } = useWinnerInfo();
+
+    const userAddress = useMemo(
+        () => localStorage.getItem("user_cosmos_address")?.toLowerCase(),
+        []
+    );
+
+    const isEligible = useMemo(() => {
+        // Must have game state and be at showdown
+        if (!gameState || gameState.round !== TexasHoldemRound.SHOWDOWN) {
+            return false;
+        }
+
+        // Must have user address
+        if (!userAddress) {
+            return false;
+        }
+
+        // Must be a winner
+        const isWinner = winnerInfo?.some(
+            (winner) => winner.address?.toLowerCase() === userAddress
+        );
+
+        if (!isWinner) {
+            return false;
+        }
+
+        // Check if player's last betting action was a CALL
+        const previousActions = gameState.previousActions || [];
+
+        // Get the user's actions
+        const userActions = previousActions.filter(
+            (action: ActionDTO) => action.playerId?.toLowerCase() === userAddress
+        );
+
+        if (userActions.length === 0) {
+            return false;
+        }
+
+        // Find the last betting action (excluding show/muck)
+        const bettingActionTypes = [
+            PlayerActionType.BET,
+            PlayerActionType.RAISE,
+            PlayerActionType.CALL,
+            PlayerActionType.CHECK,
+            PlayerActionType.ALL_IN
+        ];
+
+        const userBettingActions = userActions.filter((action: ActionDTO) =>
+            bettingActionTypes.includes(action.action as PlayerActionType)
+        );
+
+        if (userBettingActions.length === 0) {
+            return false;
+        }
+
+        // Get the last betting action
+        const lastBettingAction = userBettingActions[userBettingActions.length - 1];
+
+        // Slow roll is only available if the last action was a CALL
+        // (meaning they didn't put in the final aggression)
+        return lastBettingAction.action === PlayerActionType.CALL;
+    }, [gameState, userAddress, winnerInfo]);
+
+    return isEligible;
+};


### PR DESCRIPTION
## Summary
- Add "SLOW ROLL" button at showdown for winners whose last action was a CALL
- 10-second countdown with pulsing red animation
- Auto-executes show action when countdown completes

## Test plan
- [ ] Join a table and reach showdown as the caller (not the aggressor)
- [ ] Win the hand and verify "SLOW ROLL" button appears alongside "SHOW CARDS"
- [ ] Click "SLOW ROLL" and verify countdown displays "SLOW ROLLING... 10, 9, 8..."
- [ ] Verify other buttons are hidden during countdown
- [ ] Verify show action executes automatically when countdown reaches 0
- [ ] Verify button does NOT appear when you bet/raised last (aggressor)

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)