### PR TITLE
feat: make table style configurable via VITE_TABLE_STYLE env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ VITE_BTCPAY_BASIC_AUTH=
 VITE_CLUB_NAME="Block 52"
 VITE_CLUB_LOGO=/poker.svg
 VITE_FAVICON_URL=/b52favicon.svg
+VITE_TABLE_STYLE=modern                          # Table theme: "modern", "classic", or "nouns"
 VITE_RANDOMISE_SEAT_SELECTION=
 VITE_ETHERSCAN_API_KEY=
 

--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -632,7 +632,10 @@ const Table = React.memo(() => {
     const [isMobileLandscape, setIsMobileLandscape] = useState(
         window.innerWidth <= 1024 && window.innerWidth > window.innerHeight && window.innerHeight <= 600
     );
-    const [tableStyle, setTableStyle] = useState<"modern" | "classic" | "nouns">("modern");
+    const envTableStyle = import.meta.env.VITE_TABLE_STYLE;
+    const defaultTableStyle: "modern" | "classic" | "nouns" =
+        envTableStyle === "classic" || envTableStyle === "nouns" ? envTableStyle : "modern";
+    const [tableStyle, setTableStyle] = useState<"modern" | "classic" | "nouns">(defaultTableStyle);
 
     // Update viewport mode on window resize
     useEffect(() => {


### PR DESCRIPTION
## Summary
- Adds `VITE_TABLE_STYLE` environment variable (accepts `modern`, `classic`, or `nouns`)
- Table component reads the env var as its default style, falling back to `modern` if unset or invalid
- Users can still toggle between styles at runtime via the existing button

Closes #222

## How to use
Set in `.env`:
```
VITE_TABLE_STYLE=nouns
```

This lets deployments like nouns.poker default to their branded theme without code changes.

## Test plan
- [ ] Set `VITE_TABLE_STYLE=nouns` in `.env` and verify table loads with Nouns theme
- [ ] Set `VITE_TABLE_STYLE=classic` and verify Classic theme
- [ ] Omit `VITE_TABLE_STYLE` and verify Modern theme (default)
- [ ] Set invalid value (e.g. `VITE_TABLE_STYLE=foo`) and verify Modern fallback
- [ ] Verify toggle button still cycles through all three styles at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)