### PR TITLE
fix: entropy modal buttons cut off by overflow-hidden

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -148,7 +148,7 @@ export const Modal: React.FC<BaseModalProps> = React.memo(
 
                 {/* Modal Container */}
                 <div
-                    className={`relative p-6 rounded-xl shadow-2xl overflow-hidden ${widthClass} max-w-[95vw] ${className} ${styles.modalContainer}`}
+                    className={`relative p-6 rounded-xl shadow-2xl overflow-x-hidden overflow-y-auto max-h-[90vh] ${widthClass} max-w-[95vw] ${className} ${styles.modalContainer}`}
                 >
                     {/* Hexagon pattern background */}
                     {showHexagonPattern && <HexagonPattern patternId={patternId} />}


### PR DESCRIPTION
## Summary

- Replace `overflow-hidden` with `overflow-y-auto max-h-[90vh]` on the shared Modal container
- Fixes entropy modal (and any other tall modal) where buttons were clipped off the bottom

Closes #219

## Change

One-line fix in `src/components/common/Modal.tsx`:

```diff
- overflow-hidden
+ overflow-x-hidden overflow-y-auto max-h-[90vh]
```

## Test plan

- [ ] Open the Deal Entropy modal — verify Cancel and Deal Cards buttons are visible
- [ ] Enter a password to trigger the password hash section — buttons still visible
- [ ] Check other modals (Leave Table, Top Up, Buy Chips) are unaffected
- [ ] Test on mobile viewport — modal scrolls if content exceeds 90vh

🤖 Generated with [Claude Code](https://claude.com/claude-code)