### PR TITLE
feat(ui): block mobile portrait on table page (#200)

### DIFF
--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -141,6 +141,10 @@ import { useDealerPosition } from "../../hooks/game/useDealerPosition";
 // Turn Notification
 import { useTurnNotification } from "../../hooks/notifications/useTurnNotification";
 
+// Mobile Portrait Blocking (#200)
+import { useMobileFullscreen } from "../../hooks/game/useMobileFullscreen";
+import { MobileOrientationOverlay } from "./Table/components/MobileOrientationOverlay";
+
 //* Here's the typical sequence of a poker hand:
 //* ANTE - Initial forced bets
 //* PREFLOP - Players get their hole cards, betting round
@@ -759,6 +763,9 @@ const Table = React.memo(() => {
     // StageGeometry layout system — supports 2/4/6/9 tables, auto-fit to any viewport
     const tableLayout = useTableLayout((tableSize as 2 | 4 | 6 | 9) || 9, tableContainerRef);
     const { dealerSeat } = useDealerPosition();
+
+    // Mobile portrait blocking (#200)
+    const { isPortraitBlocked } = useMobileFullscreen();
 
     // Add the useGameProgress hook
     const { isGameInProgress, handNumber, actionCount, nextToAct } = useGameProgress(id);
@@ -1436,6 +1443,9 @@ const Table = React.memo(() => {
                 currentPlayerStack={currentPlayerData?.stack || "0"}
                 isInActiveHand={isGameInProgress && currentUserSeat > 0}
             />
+
+            {/* Mobile Portrait Blocking (#200) */}
+            <MobileOrientationOverlay isPortraitBlocked={isPortraitBlocked} onGoToLobby={handleLobbyClick} />
         </div>
     );
 });

--- a/src/components/playPage/Table/components/MobileOrientationOverlay.tsx
+++ b/src/components/playPage/Table/components/MobileOrientationOverlay.tsx
@@ -1,0 +1,69 @@
+/**
+ * MobileOrientationOverlay
+ *
+ * Blocks mobile portrait mode on the table page with a "rotate your phone" animation.
+ * Provides a "Back to Lobby" button as the only action.
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+
+export interface MobileOrientationOverlayProps {
+    isPortraitBlocked: boolean;
+    onGoToLobby: () => void;
+}
+
+export const MobileOrientationOverlay: React.FC<MobileOrientationOverlayProps> = ({
+    isPortraitBlocked,
+    onGoToLobby
+}) => {
+    if (!isPortraitBlocked) return null;
+
+    return ReactDOM.createPortal(
+        <div
+            className="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-black"
+            style={{ width: "100vw", height: "100dvh", top: 0, left: 0 }}
+        >
+            {/* Animated phone rotation */}
+            <div className="mb-8 relative">
+                <svg
+                    width="80"
+                    height="120"
+                    viewBox="0 0 80 120"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    style={{ animation: "phone-rotate 3s ease-in-out infinite", transformOrigin: "center center" }}
+                >
+                    <rect x="10" y="5" width="60" height="110" rx="10" ry="10" stroke="white" strokeWidth="3" fill="none" />
+                    <rect x="16" y="20" width="48" height="75" rx="2" fill="rgba(255,255,255,0.1)" />
+                    <circle cx="40" cy="107" r="5" stroke="white" strokeWidth="2" fill="none" />
+                </svg>
+                {/* Rotation arrow */}
+                <svg
+                    width="40"
+                    height="40"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    className="absolute -right-6 top-1/2 -translate-y-1/2 text-green-400 animate-pulse"
+                >
+                    <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z" fill="currentColor" />
+                </svg>
+            </div>
+
+            <h2 className="text-white text-xl font-bold mb-3 text-center px-8">
+                Rotate to Play
+            </h2>
+            <p className="text-gray-400 text-sm text-center px-12 mb-10">
+                Turn your phone sideways for the best experience
+            </p>
+
+            <button
+                onClick={onGoToLobby}
+                className="px-6 py-3 rounded-lg bg-white bg-opacity-10 hover:bg-opacity-20 text-white text-sm font-medium transition-all"
+            >
+                Back to Lobby
+            </button>
+        </div>,
+        document.body
+    );
+};

--- a/src/hooks/game/useMobileFullscreen.ts
+++ b/src/hooks/game/useMobileFullscreen.ts
@@ -1,0 +1,43 @@
+/**
+ * Hook that detects mobile portrait orientation on the table page.
+ * Returns isPortraitBlocked = true when mobile device is in portrait.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+function isMobile(): boolean {
+    if (typeof navigator === "undefined") return false;
+    const ua = /Android.*Mobile|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    if (ua) return true;
+    if (typeof window !== "undefined") {
+        return Math.min(window.innerWidth, window.innerHeight) <= 500;
+    }
+    return false;
+}
+
+function isPortrait(): boolean {
+    if (typeof window === "undefined") return false;
+    return window.innerHeight > window.innerWidth;
+}
+
+export const useMobileFullscreen = () => {
+    const [isPortraitBlocked, setIsPortraitBlocked] = useState(isMobile() && isPortrait());
+
+    const check = useCallback(() => {
+        setIsPortraitBlocked(isMobile() && isPortrait());
+    }, []);
+
+    useEffect(() => {
+        const handle = () => setTimeout(check, 100);
+
+        window.addEventListener("resize", handle);
+        window.addEventListener("orientationchange", handle);
+
+        return () => {
+            window.removeEventListener("resize", handle);
+            window.removeEventListener("orientationchange", handle);
+        };
+    }, [check]);
+
+    return { isPortraitBlocked };
+};


### PR DESCRIPTION
## Summary

- Block mobile portrait orientation on the table page with a "Rotate to Play" overlay
- Animated phone rotation icon with pulsing green arrow guides the user
- "Back to Lobby" button provides an escape route
- Overlay disappears automatically when user rotates to landscape
- No effect on desktop — hook returns `isPortraitBlocked: false`

### Files changed (3 files, 122 lines)

| File | Lines | Purpose |
|------|-------|---------|
| `Table.tsx` | +10 | Import hook + component, wire up |
| `useMobileFullscreen.ts` | +43 | Detects mobile + portrait orientation |
| `MobileOrientationOverlay.tsx` | +69 | Portal-rendered rotate overlay |

## Test plan

- [ ] Desktop browser: no overlay, no change in behavior
- [ ] Mobile portrait (real device or DevTools): black overlay with rotate animation + "Back to Lobby"
- [ ] Mobile landscape: overlay disappears, table renders normally
- [ ] Rotate phone back to portrait: overlay reappears
- [ ] "Back to Lobby" navigates to home page

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)