### PR TITLE
feat: sit-in button reconfigure (#278)

### DIFF
--- a/src/components/playPage/Players/Player.tsx
+++ b/src/components/playPage/Players/Player.tsx
@@ -13,6 +13,9 @@ import { getCardImageUrl } from "../../../utils/cardImages";
 import { useSitAndGoPlayerResults } from "../../../hooks/game/useSitAndGoPlayerResults";
 import { useAllInEquity } from "../../../hooks/player/useAllInEquity";
 import { useProfileAvatar } from "../../../context/profile/ProfileAvatarContext";
+import { useNetwork } from "../../../context/NetworkContext";
+import { handleSitIn } from "../../common/actionHandlers";
+import { SIT_IN_METHOD_POST_NOW } from "../../../hooks/playerActions";
 import styles from "./PlayersCommon.module.css";
 
 const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
@@ -25,6 +28,14 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
         const { dealerSeat } = useDealerPosition();
         const { equities, shouldShow: shouldShowEquity } = useAllInEquity();
         const { getAvatarForAddress } = useProfileAvatar();
+        const { currentNetwork } = useNetwork();
+
+        // Callback for "I'm Back" button on badge
+        const handleSitInFromBadge = useCallback(() => {
+            if (id) {
+                handleSitIn(id, currentNetwork, SIT_IN_METHOD_POST_NOW);
+            }
+        }, [id, currentNetwork]);
 
         // Check if this seat is the dealer
         const isDealer = dealerSeat === index;
@@ -189,6 +200,7 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
                             isSeated={isSeated}
                             isSittingOut={isSittingOut}
                             playerEquity={playerEquity}
+                            onSitIn={isSittingOut ? handleSitInFromBadge : undefined}
                         />
                     </div>
 

--- a/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
@@ -94,7 +94,7 @@ describe("PlayerActionButtons", () => {
         expect(screen.getByText("Waiting for players to join...")).toBeInTheDocument();
     });
 
-    it("renders sit-in radio for sit-in-options", () => {
+    it("renders sit-in button for sit-in-options", () => {
         render(
             <PlayerActionButtons
                 {...baseProps}
@@ -104,11 +104,10 @@ describe("PlayerActionButtons", () => {
                 hasActivePlayers={true}
             />
         );
-        expect(screen.getByRole("radio")).toBeInTheDocument();
-        expect(screen.getByText("Sit in on Next Available Hand and Post Required Blinds")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Sit In Next Hand" })).toBeInTheDocument();
     });
 
-    it("sit-in radio calls handleSitIn with POST_NOW", () => {
+    it("sit-in button calls handleSitIn with POST_NOW", () => {
         render(
             <PlayerActionButtons
                 {...baseProps}
@@ -118,7 +117,7 @@ describe("PlayerActionButtons", () => {
                 hasActivePlayers={true}
             />
         );
-        fireEvent.click(screen.getByRole("radio"));
+        fireEvent.click(screen.getByRole("button", { name: "Sit In Next Hand" }));
         expect(mockHandleSitIn).toHaveBeenCalledWith(
             "table-123",
             mockNetwork,

--- a/src/components/playPage/Table/components/PlayerActionButtons.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.tsx
@@ -155,23 +155,24 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
                 <>
                     {buyChipsElement}
                     <div className={`fixed z-30 ${positionClass}`}>
-                        <div className={`backdrop-blur-sm rounded-lg shadow-lg border border-white/20 bg-black/60 ${isCompact ? "p-2" : "p-3"}`}>
-                            <label className="flex items-center cursor-pointer" onClick={handleSitInClick}>
-                                <input
-                                    type="radio"
-                                    name="sit-in-method"
-                                    onChange={handleSitInClick}
-                                    checked={optimisticSitIn}
-                                    onClick={() => {
-                                        console.log("🎯 Radio onClick fired! TableId:", tableId, "Network:", currentNetwork);
-                                    }}
-                                    className="form-radio h-4 w-4 text-green-500 border-gray-500 focus:ring-0"
-                                />
-                                <span className={`ml-2 text-white ${isCompact ? "text-xs" : "text-sm"}`}>
-                                    {optimisticSitIn ? "Sitting in..." : "Sit in on Next Available Hand and Post Required Blinds"}
-                                </span>
-                            </label>
-                        </div>
+                        <button
+                            onClick={handleSitInClick}
+                            disabled={optimisticSitIn}
+                            className={`flex items-center gap-2 rounded-lg shadow-lg border-2 font-bold tracking-wide uppercase transition-all duration-150 ${
+                                optimisticSitIn
+                                    ? "bg-green-700 border-green-600 text-green-200 cursor-wait"
+                                    : "bg-green-600 border-green-400 text-white hover:bg-green-500 hover:border-green-300 hover:scale-105 active:scale-95 animate-pulse"
+                            } ${isCompact ? "px-3 py-2 text-xs" : "px-5 py-3 text-sm"}`}
+                        >
+                            {optimisticSitIn ? (
+                                <>
+                                    <div className="w-3 h-3 border-2 border-green-200 border-t-transparent rounded-full animate-spin" />
+                                    Sitting in...
+                                </>
+                            ) : (
+                                "Sit In Next Hand"
+                            )}
+                        </button>
                     </div>
                 </>
             );

--- a/src/components/playPage/common/Badge.css
+++ b/src/components/playPage/common/Badge.css
@@ -289,6 +289,46 @@
   }
 }
 
+/* Sit-In "I'm Back" Button on Badge */
+.sit-in-badge-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  margin-top: auto;
+  margin-bottom: 0.25rem;
+  padding: 0.2rem 0.5rem;
+  background-color: #22c55e;
+  color: #fff;
+  font-weight: 800;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease, transform 0.1s ease;
+  animation: sitInBadgePulse 2s ease-in-out infinite;
+}
+
+.sit-in-badge-button:hover {
+  background-color: #16a34a;
+  transform: scale(1.05);
+}
+
+.sit-in-badge-button:active {
+  transform: scale(0.97);
+}
+
+@keyframes sitInBadgePulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 8px 3px rgba(34, 197, 94, 0.35);
+  }
+}
+
 /* Tournament Results Styles */
 .badge-tournament-results {
   position: absolute;

--- a/src/components/playPage/common/Badge.tsx
+++ b/src/components/playPage/common/Badge.tsx
@@ -28,13 +28,14 @@ type BadgeProps = {
     isSeated?: boolean;
     isSittingOut?: boolean;
     playerEquity?: number | null;
+    onSitIn?: () => void;
 };
 
 const Badge: React.FC<BadgeProps> = React.memo(({
     count, value, color, canExtend, onExtend,
     tournamentPlace, tournamentPayout,
     isWinner, winnerAmount, isTurnTimerActive,
-    round, isFolded, isAllIn, isSeated, isSittingOut, playerEquity
+    round, isFolded, isAllIn, isSeated, isSittingOut, playerEquity, onSitIn
 }) => {
     // Track previous banner mode so we can detect timer→action transitions
     const prevBannerModeRef = React.useRef<string>("hidden");
@@ -188,9 +189,18 @@ const Badge: React.FC<BadgeProps> = React.memo(({
                             </span>
                         )}
                         {isSittingOut && (
-                            <span className="seat-banner-text font-bold animate-progress delay-2000 flex items-center w-full h-2 mb-2 mt-auto gap-2 justify-center">
-                                SITTING OUT
-                            </span>
+                            onSitIn ? (
+                                <button
+                                    className="sit-in-badge-button"
+                                    onClick={(e) => { e.stopPropagation(); onSitIn(); }}
+                                >
+                                    I'm Back
+                                </button>
+                            ) : (
+                                <span className="seat-banner-text font-bold animate-progress delay-2000 flex items-center w-full h-2 mb-2 mt-auto gap-2 justify-center">
+                                    SITTING OUT
+                                </span>
+                            )
                         )}
                         {isFolded && (
                             <span className="seat-banner-text animate-progress delay-2000 flex items-center w-full h-2 mb-2 mt-auto gap-2 justify-center">


### PR DESCRIPTION
## Summary
- Adds a green **"I'm Back"** button directly on the player's seat badge when sitting out, replacing static "SITTING OUT" text (current user only — other players still see "SITTING OUT")
- Replaces the small radio button sit-in control (bottom-left) with a prominent green **"Sit In Next Hand"** button with pulse animation and hover effects
- No backend changes — reuses existing `handleSitIn` action handler

## Test plan
- [ ] Sit out at a table, verify "I'm Back" button appears on your seat badge with green pulsing glow
- [ ] Click "I'm Back" on the badge — confirm sit-in action fires and player rejoins
- [ ] Verify other players' badges still show "SITTING OUT" text (not the button)
- [ ] Verify the bottom-left "Sit In Next Hand" button is large, green, and prominent
- [ ] Click the bottom-left button — confirm spinner + "Sitting in..." state appears
- [ ] Test on mobile viewport — verify compact sizing works

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)