### PR TITLE
Issue-275 Hide cards when folded

### DIFF
--- a/src/components/playPage/Players/OppositePlayer.tsx
+++ b/src/components/playPage/Players/OppositePlayer.tsx
@@ -128,7 +128,7 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
                     </div>
                 )}
                 <div className="flex justify-center gap-1">
-                    {holeCards && holeCards.length === 2 ? (
+                    {holeCards && holeCards.length === 2 && !isFolded? (
                         isShowingCards && showingCards ? (
                             // Show the actual cards if player is showing
                             <>

--- a/src/hooks/player/usePlayerData.ts
+++ b/src/hooks/player/usePlayerData.ts
@@ -57,7 +57,7 @@ export const usePlayerData = (seatIndex?: number): PlayerDataReturn => {
       const converted = convertUSDCToNumber(playerData.stack);
       return converted;
     }
-  }, [playerData?.stack, isTournament]);
+  }, [playerData, isTournament]);
   
   // Calculate derived properties
   const isFolded = React.useMemo((): boolean => {


### PR DESCRIPTION
hide cards when opposite player fold, only opposite player cards will hide, not for current player
<img width="911" height="1659" alt="Screenshot 2026-04-13 at 11 17 31 am" src="https://github.com/user-attachments/assets/1905781f-8cd9-4dc8-b334-19de3b2bd919" />
<img width="1199" height="870" alt="Screenshot 2026-04-13 at 11 17 38 am" src="https://github.com/user-attachments/assets/8f01b22f-15f3-4858-973a-8736da6b3b08" />
<img width="882" height="1646" alt="Screenshot 2026-04-13 at 11 17 35 am" src="https://github.com/user-attachments/assets/0df11dab-f978-4f1e-b805-8c336baa0f47" />
