### PR TITLE
feat: make site password optional via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,3 +80,6 @@ VITE_UI_BG_DARK=#1f2937                       # Gray-800
 VITE_UI_BG_MEDIUM=#374151                     # Gray-700
 VITE_UI_BORDER_COLOR=rgba(59,130,246,0.2)     # Blue border with opacity
 VITE_UI_TEXT_SECONDARY=#9ca3af                # Gray-400 for secondary text
+
+# Site password protection (optional) - if not set, no password is required
+VITE_SITE_PASSWORD=

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -33,6 +33,7 @@ import { isTournamentFormat } from "../utils/gameFormatUtils";
 // Password protection utils
 import {
     checkAuthCookie,
+    isPasswordProtectionEnabled,
     handlePasswordSubmit as utilHandlePasswordSubmit,
     handlePasswordKeyPress as utilHandlePasswordKeyPress
 } from "../utils/passwordProtectionUtils";
@@ -48,8 +49,9 @@ const Dashboard: React.FC = () => {
     // Removed: Game selection state variables - now handled in Create Game modal
     // Removed: Ethereum wallet state - now using Cosmos wallet only
 
-    // Password protection states
-    const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+    // Password protection states - skip if no password configured in env
+    const passwordEnabled = isPasswordProtectionEnabled();
+    const [isAuthenticated, setIsAuthenticated] = useState<boolean>(!passwordEnabled);
     const [passwordInput, setPasswordInput] = useState<string>("");
     const [passwordError, setPasswordError] = useState<string>("");
     const [showPassword, setShowPassword] = useState<boolean>(false);
@@ -131,10 +133,10 @@ const Dashboard: React.FC = () => {
 
     // Check for existing auth cookie on component mount
     useEffect(() => {
-        if (checkAuthCookie()) {
+        if (passwordEnabled && checkAuthCookie()) {
             setIsAuthenticated(true);
         }
-    }, []);
+    }, [passwordEnabled]);
 
     const DEFAULT_GAME_CONTRACT = "0x4c1d6ea77a2ba47dcd0771b7cde0df30a6df1bfaa7"; // Example address
 

--- a/src/utils/passwordProtectionUtils.ts
+++ b/src/utils/passwordProtectionUtils.ts
@@ -29,9 +29,17 @@ export const checkAuthCookie = (): boolean => {
     return false;
 };
 
+// Check if password protection is enabled via env variable
+export const isPasswordProtectionEnabled = (): boolean => {
+    const envPassword = import.meta.env.VITE_SITE_PASSWORD;
+    return typeof envPassword === "string" && envPassword.length > 0;
+};
+
 // Password validation function
 export const validatePassword = (password: string): boolean => {
-    return password === "123";
+    const envPassword = import.meta.env.VITE_SITE_PASSWORD;
+    if (!envPassword) return false;
+    return password === envPassword;
 };
 
 // Handle password submission


### PR DESCRIPTION
## Summary
- Moves hardcoded password (`"123"`) to `VITE_SITE_PASSWORD` env variable
- When `VITE_SITE_PASSWORD` is not set, the password modal is skipped entirely — site is immediately accessible
- When `VITE_SITE_PASSWORD` is set, the password modal works as before, validating against the env value

Closes #293

## Test plan
- [ ] Deploy without `VITE_SITE_PASSWORD` set → verify no password modal appears
- [ ] Deploy with `VITE_SITE_PASSWORD=mysecret` → verify password modal appears and only accepts `mysecret`
- [ ] Verify auth cookie still works when password is enabled (persists across refreshes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)