### PR TITLE
Show winner hand strength at showdown and in history (#276)

### DIFF
--- a/src/components/ActionsLog.module.css
+++ b/src/components/ActionsLog.module.css
@@ -30,3 +30,12 @@
 .actionText {
   color: #e5e7eb;
 }
+
+.winnerRow {
+  background-color: color-mix(in srgb, var(--accent-success) 12%, transparent);
+}
+
+.winnerText {
+  color: var(--accent-success);
+  font-weight: 700;
+}

--- a/src/components/ActionsLog.tsx
+++ b/src/components/ActionsLog.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useGameProgress } from "../hooks/game/useGameProgress";
+import { useWinnerInfo } from "../hooks/game/useWinnerInfo";
 import { formatPlayerId, formatAmount } from "../utils/accountUtils";
 import { isTournamentFormat } from "../utils/gameFormatUtils";
 import { ActionDTO } from "@block52/poker-vm-sdk";
@@ -79,7 +80,9 @@ const ActionsLog: React.FC = () => {
     const { id } = useParams<{ id: string }>();
     const { previousActions } = useGameProgress(id);
     const { gameState, gameFormat } = useGameStateContext();
+    const { winnerInfo } = useWinnerInfo();
     const indexerApi = useIndexerApi();
+    const showWinnerSummary = gameState?.round === "end" && Array.isArray(winnerInfo) && winnerInfo.length > 0;
     const [copied, setCopied] = useState(false);
     const [copiedJSON, setCopiedJSON] = useState(false);
     const [copiedShare, setCopiedShare] = useState(false);
@@ -130,16 +133,25 @@ const ActionsLog: React.FC = () => {
         }
 
         // Format actions for clipboard
-        const logText = previousActions
-            .map((action: ActionDTO) => {
-                const player = formatPlayerId(action.playerId);
-                const actionName = formatActionName(action.action);
-                const amount = action.amount ? ` ${formatAmount(action.amount, undefined, isTournamentFormat(gameFormat))}` : "";
-                const round = formatRoundName(action.round);
-                const seat = action.seat;
-                return `${player} (Seat ${seat}): ${actionName}${amount} - ${round}`;
+        const actionLines = previousActions.map((action: ActionDTO) => {
+            const player = formatPlayerId(action.playerId);
+            const actionName = formatActionName(action.action);
+            const amount = action.amount ? ` ${formatAmount(action.amount, undefined, isTournamentFormat(gameFormat))}` : "";
+            const round = formatRoundName(action.round);
+            const seat = action.seat;
+            return `${player} (Seat ${seat}): ${actionName}${amount} - ${round}`;
+        });
+
+        // Append winner summary rows when the hand has ended
+        const winnerLines = showWinnerSummary && winnerInfo
+            ? winnerInfo.map(w => {
+                const player = formatPlayerId(w.address);
+                const hand = w.description ? `${w.description} — ` : "";
+                return `${player} (Seat ${w.seat}): WINS ${hand}${w.formattedAmount}`;
             })
-            .join("\n");
+            : [];
+
+        const logText = [...actionLines, ...winnerLines].join("\n");
 
         copyTextToClipboard(
             logText,
@@ -263,17 +275,17 @@ const ActionsLog: React.FC = () => {
             {previousActions && previousActions.length > 0 ? (
                 <div className="space-y-0.5 p-2">
                     {previousActions.map((action: ActionDTO, index: number) => (
-                        <div 
-                            key={index} 
+                        <div
+                            key={index}
                             className={`text-xs py-1 border-b ${styles.actionRow}`}
                         >
                             <div className="flex justify-between">
-                                <span 
+                                <span
                                     className={`font-mono ${styles.playerId}`}
                                 >
                                     {formatPlayerId(action.playerId)}
                                 </span>
-                                <span 
+                                <span
                                     className={`text-[10px] ${styles.secondaryText}`}
                                 >
                                     Seat {action.seat}
@@ -284,10 +296,34 @@ const ActionsLog: React.FC = () => {
                                     {formatActionName(action.action)}
                                     {action.amount && ` ${formatAmount(action.amount, undefined, isTournamentFormat(gameFormat))}`}
                                 </span>
-                                <span 
+                                <span
                                     className={`text-[10px] ${styles.secondaryText}`}
                                 >
                                     {formatRoundName(action.round)}
+                                </span>
+                            </div>
+                        </div>
+                    ))}
+                    {showWinnerSummary && winnerInfo?.map((w, i) => (
+                        <div
+                            key={`winner-${i}`}
+                            className={`text-xs py-1 border-b ${styles.actionRow} ${styles.winnerRow}`}
+                        >
+                            <div className="flex justify-between">
+                                <span className={`font-mono ${styles.playerId}`}>
+                                    {formatPlayerId(w.address)}
+                                </span>
+                                <span className={`text-[10px] ${styles.secondaryText}`}>
+                                    Seat {w.seat}
+                                </span>
+                            </div>
+                            <div className="flex justify-between mt-0.5">
+                                <span className={styles.winnerText}>
+                                    WINS {w.formattedAmount}
+                                    {w.description && ` — ${w.description}`}
+                                </span>
+                                <span className={`text-[10px] ${styles.secondaryText}`}>
+                                    Showdown
                                 </span>
                             </div>
                         </div>

--- a/src/components/ActionsLog.tsx
+++ b/src/components/ActionsLog.tsx
@@ -4,7 +4,7 @@ import { useGameProgress } from "../hooks/game/useGameProgress";
 import { useWinnerInfo } from "../hooks/game/useWinnerInfo";
 import { formatPlayerId, formatAmount } from "../utils/accountUtils";
 import { isTournamentFormat } from "../utils/gameFormatUtils";
-import { ActionDTO } from "@block52/poker-vm-sdk";
+import { ActionDTO, TexasHoldemRound } from "@block52/poker-vm-sdk";
 import { FaCopy, FaCheck, FaFileDownload, FaShare } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { useGameStateContext } from "../context/GameStateContext";
@@ -82,7 +82,7 @@ const ActionsLog: React.FC = () => {
     const { gameState, gameFormat } = useGameStateContext();
     const { winnerInfo } = useWinnerInfo();
     const indexerApi = useIndexerApi();
-    const showWinnerSummary = gameState?.round === "end" && Array.isArray(winnerInfo) && winnerInfo.length > 0;
+    const showWinnerSummary = gameState?.round === TexasHoldemRound.END && Array.isArray(winnerInfo) && winnerInfo.length > 0;
     const [copied, setCopied] = useState(false);
     const [copiedJSON, setCopiedJSON] = useState(false);
     const [copiedShare, setCopiedShare] = useState(false);

--- a/src/components/ActionsLog.tsx
+++ b/src/components/ActionsLog.tsx
@@ -4,76 +4,13 @@ import { useGameProgress } from "../hooks/game/useGameProgress";
 import { useWinnerInfo } from "../hooks/game/useWinnerInfo";
 import { formatPlayerId, formatAmount } from "../utils/accountUtils";
 import { isTournamentFormat } from "../utils/gameFormatUtils";
-import { ActionDTO, TexasHoldemRound } from "@block52/poker-vm-sdk";
+import { ActionDTO } from "@block52/poker-vm-sdk";
+import { formatActionName, formatRoundName, getActionLine, getWinnerLine, shouldShowWinnerSummary } from "./ActionsLog.utils";
 import { FaCopy, FaCheck, FaFileDownload, FaShare } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { useGameStateContext } from "../context/GameStateContext";
 import { useIndexerApi } from "../context/IndexerApiContext";
 import styles from "./ActionsLog.module.css";
-
-// Function to format action names with proper capitalization and spacing
-const formatActionName = (action: string): string => {
-    switch (action.toLowerCase()) {
-        case "join":
-            return "Join";
-        case "post-small-blind":
-            return "Post Small Blind";
-        case "post-big-blind":
-            return "Post Big Blind";
-        case "deal":
-            return "Deal";
-        case "call":
-            return "Call";
-        case "check":
-            return "Check";
-        case "bet":
-            return "Bet";
-        case "raise":
-            return "Raise";
-        case "fold":
-            return "Fold";
-        case "show":
-            return "Show";
-        case "muck":
-            return "Muck";
-        case "all-in":
-            return "All In";
-        case "leave":
-            return "Leave";
-        case "sit-out":
-            return "Sit Out";
-        case "sit-in":
-            return "Sit In";
-        case "new-hand":
-            return "New Hand";
-        default:
-            // Fallback: capitalize first letter and replace hyphens with spaces
-            return action.charAt(0).toUpperCase() + action.slice(1).replace(/-/g, " ");
-    }
-};
-
-// Function to format round names with proper poker terminology
-const formatRoundName = (round: string): string => {
-    switch (round.toLowerCase()) {
-        case "ante":
-            return "Ante";
-        case "preflop":
-            return "Pre-flop";
-        case "flop":
-            return "Flop";
-        case "turn":
-            return "Turn";
-        case "river":
-            return "River";
-        case "showdown":
-            return "Showdown";
-        case "end":
-            return "End";
-        default:
-            // Fallback: capitalize first letter
-            return round.charAt(0).toUpperCase() + round.slice(1);
-    }
-};
 
 // Simple component to display only the action log
 const ActionsLog: React.FC = () => {
@@ -82,7 +19,7 @@ const ActionsLog: React.FC = () => {
     const { gameState, gameFormat } = useGameStateContext();
     const { winnerInfo } = useWinnerInfo();
     const indexerApi = useIndexerApi();
-    const showWinnerSummary = gameState?.round === TexasHoldemRound.END && Array.isArray(winnerInfo) && winnerInfo.length > 0;
+    const showWinnerSummary = shouldShowWinnerSummary(gameState, winnerInfo);
     const [copied, setCopied] = useState(false);
     const [copiedJSON, setCopiedJSON] = useState(false);
     const [copiedShare, setCopiedShare] = useState(false);
@@ -133,22 +70,12 @@ const ActionsLog: React.FC = () => {
         }
 
         // Format actions for clipboard
-        const actionLines = previousActions.map((action: ActionDTO) => {
-            const player = formatPlayerId(action.playerId);
-            const actionName = formatActionName(action.action);
-            const amount = action.amount ? ` ${formatAmount(action.amount, undefined, isTournamentFormat(gameFormat))}` : "";
-            const round = formatRoundName(action.round);
-            const seat = action.seat;
-            return `${player} (Seat ${seat}): ${actionName}${amount} - ${round}`;
-        });
+        const isTournament = isTournamentFormat(gameFormat);
+        const actionLines = previousActions.map((action: ActionDTO) => getActionLine(action, isTournament));
 
         // Append winner summary rows when the hand has ended
         const winnerLines = showWinnerSummary && winnerInfo
-            ? winnerInfo.map(w => {
-                const player = formatPlayerId(w.address);
-                const hand = w.description ? `${w.description} — ` : "";
-                return `${player} (Seat ${w.seat}): WINS ${hand}${w.formattedAmount}`;
-            })
+            ? winnerInfo.map(getWinnerLine)
             : [];
 
         const logText = [...actionLines, ...winnerLines].join("\n");

--- a/src/components/ActionsLog.utils.test.ts
+++ b/src/components/ActionsLog.utils.test.ts
@@ -1,0 +1,100 @@
+import { ActionDTO, TexasHoldemRound, TexasHoldemStateDTO, PlayerActionType } from "@block52/poker-vm-sdk";
+import { getActionLine, getWinnerLine, shouldShowWinnerSummary } from "./ActionsLog.utils";
+import { WinnerInfo } from "../types/index";
+
+const buildAction = (overrides: Partial<ActionDTO> = {}): ActionDTO => ({
+    playerId: "0x1234567890abcdef1234567890abcdef12345678",
+    seat: 3,
+    action: "call" as PlayerActionType,
+    amount: "1000000",
+    round: TexasHoldemRound.FLOP,
+    index: 0,
+    timestamp: 0,
+    ...overrides
+});
+
+describe("getActionLine", () => {
+    it("formats a cash-game action with player, seat, action name, amount, and round", () => {
+        const line = getActionLine(buildAction(), false);
+        expect(line).toBe("0x1234...5678 (Seat 3): Call $1.00 - Flop");
+    });
+
+    it("omits the amount segment when action.amount is empty", () => {
+        const line = getActionLine(
+            buildAction({ amount: "", action: "check" as PlayerActionType, round: TexasHoldemRound.TURN }),
+            false
+        );
+        expect(line).toBe("0x1234...5678 (Seat 3): Check - Turn");
+    });
+
+    it("formats hyphenated action names to title case with spaces", () => {
+        const line = getActionLine(
+            buildAction({ action: "post-big-blind" as PlayerActionType, amount: "2000000", round: TexasHoldemRound.PREFLOP }),
+            false
+        );
+        expect(line).toBe("0x1234...5678 (Seat 3): Post Big Blind $2.00 - Pre-flop");
+    });
+
+    it("uses chip formatting for tournament games", () => {
+        const line = getActionLine(
+            buildAction({ action: "raise" as PlayerActionType, amount: "1500", round: TexasHoldemRound.RIVER }),
+            true
+        );
+        expect(line).toBe("0x1234...5678 (Seat 3): Raise 1,500 chips - River");
+    });
+});
+
+describe("getWinnerLine", () => {
+    it("includes the hand description when present", () => {
+        const line = getWinnerLine({
+            seat: 2,
+            address: "0x1234567890abcdef1234567890abcdef12345678",
+            amount: "5000000",
+            formattedAmount: "$5.00",
+            description: "Full House"
+        });
+        expect(line).toBe("0x1234...5678 (Seat 2): WINS Full House — $5.00");
+    });
+
+    it("omits the hand description when absent (uncontested win)", () => {
+        const line = getWinnerLine({
+            seat: 2,
+            address: "0x1234567890abcdef1234567890abcdef12345678",
+            amount: "5000000",
+            formattedAmount: "$5.00"
+        });
+        expect(line).toBe("0x1234...5678 (Seat 2): WINS $5.00");
+    });
+});
+
+describe("shouldShowWinnerSummary", () => {
+    const winner: WinnerInfo = {
+        seat: 1,
+        address: "0xabc",
+        amount: "1000000",
+        formattedAmount: "$1.00"
+    };
+
+    const stateAtRound = (round: TexasHoldemRound): TexasHoldemStateDTO =>
+        ({ round } as TexasHoldemStateDTO);
+
+    it("returns true when round is END and there is at least one winner", () => {
+        expect(shouldShowWinnerSummary(stateAtRound(TexasHoldemRound.END), [winner])).toBe(true);
+    });
+
+    it("returns false before the hand has ended", () => {
+        expect(shouldShowWinnerSummary(stateAtRound(TexasHoldemRound.RIVER), [winner])).toBe(false);
+        expect(shouldShowWinnerSummary(stateAtRound(TexasHoldemRound.SHOWDOWN), [winner])).toBe(false);
+    });
+
+    it("returns false when winnerInfo is empty or null", () => {
+        expect(shouldShowWinnerSummary(stateAtRound(TexasHoldemRound.END), [])).toBe(false);
+        expect(shouldShowWinnerSummary(stateAtRound(TexasHoldemRound.END), null)).toBe(false);
+        expect(shouldShowWinnerSummary(stateAtRound(TexasHoldemRound.END), undefined)).toBe(false);
+    });
+
+    it("returns false when gameState is missing", () => {
+        expect(shouldShowWinnerSummary(null, [winner])).toBe(false);
+        expect(shouldShowWinnerSummary(undefined, [winner])).toBe(false);
+    });
+});

--- a/src/components/ActionsLog.utils.ts
+++ b/src/components/ActionsLog.utils.ts
@@ -1,0 +1,86 @@
+import { ActionDTO, TexasHoldemRound, TexasHoldemStateDTO } from "@block52/poker-vm-sdk";
+import { formatPlayerId, formatAmount } from "../utils/accountUtils";
+import { WinnerInfo } from "../types/index";
+
+export const formatActionName = (action: string): string => {
+    switch (action.toLowerCase()) {
+        case "join":
+            return "Join";
+        case "post-small-blind":
+            return "Post Small Blind";
+        case "post-big-blind":
+            return "Post Big Blind";
+        case "deal":
+            return "Deal";
+        case "call":
+            return "Call";
+        case "check":
+            return "Check";
+        case "bet":
+            return "Bet";
+        case "raise":
+            return "Raise";
+        case "fold":
+            return "Fold";
+        case "show":
+            return "Show";
+        case "muck":
+            return "Muck";
+        case "all-in":
+            return "All In";
+        case "leave":
+            return "Leave";
+        case "sit-out":
+            return "Sit Out";
+        case "sit-in":
+            return "Sit In";
+        case "new-hand":
+            return "New Hand";
+        default:
+            return action.charAt(0).toUpperCase() + action.slice(1).replace(/-/g, " ");
+    }
+};
+
+export const formatRoundName = (round: string): string => {
+    switch (round.toLowerCase()) {
+        case "ante":
+            return "Ante";
+        case "preflop":
+            return "Pre-flop";
+        case "flop":
+            return "Flop";
+        case "turn":
+            return "Turn";
+        case "river":
+            return "River";
+        case "showdown":
+            return "Showdown";
+        case "end":
+            return "End";
+        default:
+            return round.charAt(0).toUpperCase() + round.slice(1);
+    }
+};
+
+export const getActionLine = (action: ActionDTO, isTournament: boolean): string => {
+    const player = formatPlayerId(action.playerId);
+    const actionName = formatActionName(action.action);
+    const amount = action.amount ? ` ${formatAmount(action.amount, undefined, isTournament)}` : "";
+    const round = formatRoundName(action.round);
+    return `${player} (Seat ${action.seat}): ${actionName}${amount} - ${round}`;
+};
+
+export const getWinnerLine = (winner: WinnerInfo): string => {
+    const player = formatPlayerId(winner.address);
+    const hand = winner.description ? `${winner.description} — ` : "";
+    return `${player} (Seat ${winner.seat}): WINS ${hand}${winner.formattedAmount}`;
+};
+
+export const shouldShowWinnerSummary = (
+    gameState: TexasHoldemStateDTO | null | undefined,
+    winnerInfo: WinnerInfo[] | null | undefined
+): boolean => {
+    return gameState?.round === TexasHoldemRound.END
+        && Array.isArray(winnerInfo)
+        && winnerInfo.length > 0;
+};

--- a/src/components/playPage/Players/OppositePlayer.tsx
+++ b/src/components/playPage/Players/OppositePlayer.tsx
@@ -85,7 +85,7 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
     // Get winner hand description (e.g. "Full House") if this player is a winner
     const winnerHandDescription = React.useMemo(() => {
         if (!isWinner || !winnerInfo) return null;
-        const winner = winnerInfo.find((w: any) => w.seat === index);
+        const winner = winnerInfo.find(w => w.seat === index);
         return winner?.description ?? null;
     }, [isWinner, winnerInfo, index]);
 

--- a/src/components/playPage/Players/OppositePlayer.tsx
+++ b/src/components/playPage/Players/OppositePlayer.tsx
@@ -82,6 +82,13 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
         return winner ? winner.formattedAmount : null;
     }, [isWinner, winnerInfo, index]);
 
+    // Get winner hand description (e.g. "Full House") if this player is a winner
+    const winnerHandDescription = React.useMemo(() => {
+        if (!isWinner || !winnerInfo) return null;
+        const winner = winnerInfo.find((w: any) => w.seat === index);
+        return winner?.description ?? null;
+    }, [isWinner, winnerInfo, index]);
+
     // Check if this player is showing cards
     const isShowingCards = React.useMemo(() => {
         if (!showingPlayers || !playerData) return false;
@@ -173,6 +180,7 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
                             tournamentPayout={tournamentResult?.payout}
                             isWinner={isWinner}
                             winnerAmount={winnerAmount}
+                            winnerHandDescription={winnerHandDescription}
                             isTurnTimerActive={isTurnTimerActive}
                             round={round}
                             isFolded={isFolded}

--- a/src/components/playPage/Players/Player.tsx
+++ b/src/components/playPage/Players/Player.tsx
@@ -102,7 +102,7 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
         // 4b) memoize winner hand description (e.g. "Full House")
         const winnerHandDescription = useMemo(() => {
             if (!isWinner || !winnerInfo) return null;
-            const winner = winnerInfo.find((w: any) => w.seat === index);
+            const winner = winnerInfo.find(w => w.seat === index);
             return winner?.description ?? null;
         }, [isWinner, winnerInfo, index]);
 

--- a/src/components/playPage/Players/Player.tsx
+++ b/src/components/playPage/Players/Player.tsx
@@ -99,6 +99,13 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
             return winner?.formattedAmount ?? null;
         }, [isWinner, winnerInfo, index]);
 
+        // 4b) memoize winner hand description (e.g. "Full House")
+        const winnerHandDescription = useMemo(() => {
+            if (!isWinner || !winnerInfo) return null;
+            const winner = winnerInfo.find((w: any) => w.seat === index);
+            return winner?.description ?? null;
+        }, [isWinner, winnerInfo, index]);
+
         // 5) render hole cards
         const renderCards = useCallback(() => {
             if (!holeCards || holeCards.length !== 2) {
@@ -193,6 +200,7 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
                             tournamentPayout={tournamentResult?.payout}
                             isWinner={isWinner}
                             winnerAmount={winnerAmount}
+                            winnerHandDescription={winnerHandDescription}
                             isTurnTimerActive={isTurnTimerActive}
                             round={round}
                             isFolded={isFolded}

--- a/src/components/playPage/common/Badge.tsx
+++ b/src/components/playPage/common/Badge.tsx
@@ -21,6 +21,7 @@ type BadgeProps = {
     // Seat banner state — passed from parent player component
     isWinner?: boolean;
     winnerAmount?: string | null;
+    winnerHandDescription?: string | null;
     isTurnTimerActive?: boolean;
     round?: string | null;
     isFolded?: boolean;
@@ -34,7 +35,7 @@ type BadgeProps = {
 const Badge: React.FC<BadgeProps> = React.memo(({
     count, value, color, canExtend, onExtend,
     tournamentPlace, tournamentPayout,
-    isWinner, winnerAmount, isTurnTimerActive,
+    isWinner, winnerAmount, winnerHandDescription, isTurnTimerActive,
     round, isFolded, isAllIn, isSeated, isSittingOut, playerEquity, onSitIn
 }) => {
     // Track previous banner mode so we can detect timer→action transitions
@@ -150,9 +151,16 @@ const Badge: React.FC<BadgeProps> = React.memo(({
         switch (bannerMode) {
             case "winner":
                 return (
-                    <span className="seat-banner-text font-bold flex items-center justify-center w-full h-8 mt-[22px] gap-1 text-base">
-                        WINS: {winnerAmount}
-                    </span>
+                    <div className="seat-banner-text flex flex-col items-center justify-center w-full mt-[14px] gap-0.5">
+                        <span className="font-bold text-base leading-tight">
+                            WINS: {winnerAmount}
+                        </span>
+                        {winnerHandDescription && (
+                            <span className="font-semibold text-[0.65rem] uppercase tracking-wider leading-tight opacity-95">
+                                {winnerHandDescription}
+                            </span>
+                        )}
+                    </div>
                 );
 
             case "action":

--- a/src/hooks/game/useWinnerInfo.ts
+++ b/src/hooks/game/useWinnerInfo.ts
@@ -1,7 +1,7 @@
 import { useGameStateContext } from "../../context/GameStateContext";
 import { PlayerDTO, TexasHoldemStateDTO, WinnerDTO } from "@block52/poker-vm-sdk";
 import { formatUSDCToSimpleDollars } from "../../utils/numberUtils";
-import { WinnerInfoReturn } from "../../types/index";
+import { WinnerInfo, WinnerInfoReturn } from "../../types/index";
 
 /**
  * Extract winner information from game state
@@ -22,7 +22,10 @@ function getWinnerInfo(gameData: TexasHoldemStateDTO) {
                 address: winner.address,
                 amount: winner.amount.toString(),
                 formattedAmount: formatUSDCToSimpleDollars(winner.amount.toString()),
-                winType: "showdown"
+                winType: "showdown",
+                description: winner.description,
+                handName: winner.name,
+                cards: winner.cards
             };
         });
     }
@@ -42,15 +45,7 @@ export const useWinnerInfo = (): WinnerInfoReturn => {
 
     // Default values in case of error or loading
     const defaultState: WinnerInfoReturn = {
-        winnerInfo: null as
-            | {
-                  seat: number;
-                  address: string;
-                  amount: string | number;
-                  formattedAmount: string;
-                  winType?: string;
-              }[]
-            | null,
+        winnerInfo: null as WinnerInfo[] | null,
         error
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -431,6 +431,9 @@ export interface WinnerInfo {
     amount: string | number;
     formattedAmount: string;
     winType?: string;
+    description?: string;
+    handName?: string;
+    cards?: string[];
 }
 
 export interface WinnerInfoReturn {


### PR DESCRIPTION
## Summary
- Surface `description`, `name`, and `cards` from the SDK's `WinnerDTO` through `useWinnerInfo` — these were being discarded
- Render the hand strength (e.g. "Full House") under the existing gold WINS banner on each winning player
- Append an inline winner row to `ActionsLog` when the hand ends, included in the text-copy export

Per collaborator feedback on the issue: kept the existing gold WINS banner style (no new component), appended inline to history (no separated summary section), and did not surface losers' hands.

Closes #276

## Test plan
- [ ] Verify WINS banner shows the hand description ("Full House", etc.) at showdown in a cash game
- [ ] Verify the same in a tournament / Sit & Go
- [ ] Verify split-pot rendering — each winner shows their own hand, all appear in history
- [ ] Verify uncontested wins (everyone folds) degrade gracefully — no hand description, just the WINS amount
- [ ] Verify copy-history includes the winner row(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)