### PR TITLE
fix(ui): add baseURI fallback for NFT image resolution

### DIFF
--- a/src/utils/profile/nftImageResolver.ts
+++ b/src/utils/profile/nftImageResolver.ts
@@ -1,15 +1,21 @@
 /**
  * Resolve an NFT image URL directly from the contract's tokenURI.
  * Uses a public RPC endpoint — no wallet connection required.
+ *
+ * Supports multiple resolution strategies:
+ * 1. tokenURI(tokenId) - standard ERC-721
+ * 2. baseURI() + tokenId - for contracts using baseURI pattern (including proxies)
  */
 
 const ETH_RPC_URL = import.meta.env.VITE_MAINNET_RPC_URL || "";
 
-// ERC-721 tokenURI(uint256) selector: 0xc87b56dd
-const TOKEN_URI_SELECTOR = "0xc87b56dd";
+// ERC-721 function selectors
+const TOKEN_URI_SELECTOR = "0xc87b56dd";  // tokenURI(uint256)
+const BASE_URI_SELECTOR = "0x6c0360eb";   // baseURI()
 
 /**
  * Fetch the image URL for an NFT by calling tokenURI on the contract.
+ * Falls back to baseURI + tokenId pattern for proxy contracts.
  * Returns the image URL or null if it can't be resolved.
  */
 export async function resolveNftImageUrl(contractAddress: string, tokenId: string): Promise<string | null> {
@@ -18,32 +24,92 @@ export async function resolveNftImageUrl(contractAddress: string, tokenId: strin
         return null;
     }
 
+    // Try tokenURI(tokenId) first (standard ERC-721)
+    const tokenUriResult = await tryTokenUri(contractAddress, tokenId);
+    if (tokenUriResult) {
+        return tokenUriResult;
+    }
+
+    // Fallback: try baseURI() + tokenId pattern (common with proxy contracts)
+    const baseUriResult = await tryBaseUri(contractAddress, tokenId);
+    if (baseUriResult) {
+        return baseUriResult;
+    }
+
+    return null;
+}
+
+/**
+ * Try to resolve image using tokenURI(tokenId) call
+ */
+async function tryTokenUri(contractAddress: string, tokenId: string): Promise<string | null> {
     try {
-        // Encode tokenId as uint256 (left-padded to 32 bytes)
         const tokenIdHex = BigInt(tokenId).toString(16).padStart(64, "0");
         const callData = TOKEN_URI_SELECTOR + tokenIdHex;
 
-        const response = await fetch(ETH_RPC_URL, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                jsonrpc: "2.0",
-                id: 1,
-                method: "eth_call",
-                params: [{ to: contractAddress, data: callData }, "latest"]
-            })
-        });
-
-        const json = await response.json();
-        if (!json.result || json.result === "0x") {
+        const json = await ethCall(contractAddress, callData);
+        if (!json.result || json.result === "0x" || json.error) {
             return null;
         }
 
-        // Decode ABI-encoded string response
         const tokenUri = decodeAbiString(json.result);
         if (!tokenUri) return null;
 
-        // Fetch metadata from tokenURI
+        return fetchMetadataImage(tokenUri);
+    } catch (err) {
+        console.error("[nftImageResolver] tokenURI failed:", err);
+        return null;
+    }
+}
+
+/**
+ * Try to resolve image using baseURI() + tokenId pattern
+ * Common with proxy contracts and lazy-mint collections
+ */
+async function tryBaseUri(contractAddress: string, tokenId: string): Promise<string | null> {
+    try {
+        const json = await ethCall(contractAddress, BASE_URI_SELECTOR);
+        if (!json.result || json.result === "0x" || json.error) {
+            return null;
+        }
+
+        const baseUri = decodeAbiString(json.result);
+        if (!baseUri) return null;
+
+        // Construct full tokenURI: baseURI + tokenId
+        // Handle both "ipfs://xxx/" and "ipfs://xxx" patterns
+        const separator = baseUri.endsWith("/") ? "" : "/";
+        const tokenUri = baseUri + separator + tokenId;
+
+        return fetchMetadataImage(tokenUri);
+    } catch (err) {
+        console.error("[nftImageResolver] baseURI failed:", err);
+        return null;
+    }
+}
+
+/**
+ * Make an eth_call to the contract
+ */
+async function ethCall(contractAddress: string, callData: string): Promise<{ result?: string; error?: unknown }> {
+    const response = await fetch(ETH_RPC_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "eth_call",
+            params: [{ to: contractAddress, data: callData }, "latest"]
+        })
+    });
+    return response.json();
+}
+
+/**
+ * Fetch metadata from tokenURI and extract image URL
+ */
+async function fetchMetadataImage(tokenUri: string): Promise<string | null> {
+    try {
         const metadataUrl = resolveIpfsUrl(tokenUri);
         const metaResponse = await fetch(metadataUrl);
         if (!metaResponse.ok) return null;
@@ -53,7 +119,7 @@ export async function resolveNftImageUrl(contractAddress: string, tokenId: strin
 
         return imageUrl ? resolveIpfsUrl(imageUrl) : null;
     } catch (err) {
-        console.error("[nftImageResolver] Failed to resolve image:", err);
+        console.error("[nftImageResolver] Failed to fetch metadata:", err);
         return null;
     }
 }


### PR DESCRIPTION
## Summary

Some NFT contracts (especially EIP-1167 proxy contracts) don't implement `tokenURI(tokenId)` directly but use a `baseURI()` + tokenId pattern. This causes NFT avatars to fail to load for other players at the table.

## Changes

- Try `tokenURI(tokenId)` first (standard ERC-721)
- Fallback to `baseURI()` + tokenId pattern if tokenURI reverts/fails
- Refactor into smaller helper functions for maintainability
- Add proper typing for ethCall response

## How it works

1. Call `tokenURI(47)` on contract → if reverts, continue
2. Call `baseURI()` on contract → get `ipfs://QmXxx/`
3. Construct full URI: `ipfs://QmXxx/47`
4. Fetch metadata and extract image URL

## Test plan

- [ ] Test with standard ERC-721 NFT (tokenURI works directly)
- [ ] Test with proxy contract NFT (needs baseURI fallback)
- [ ] Verify other players can see NFT avatars at table

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)