### PR TITLE
Issue 310

### DIFF
--- a/src/components/playPage/common/Badge.tsx
+++ b/src/components/playPage/common/Badge.tsx
@@ -35,7 +35,7 @@ type BadgeProps = {
 const Badge: React.FC<BadgeProps> = React.memo(({
     count, value, color, canExtend, onExtend,
     tournamentPlace, tournamentPayout,
-    isWinner, winnerAmount, winnerHandDescription, isTurnTimerActive,
+    isWinner, winnerHandDescription, isTurnTimerActive,
     round, isFolded, isAllIn, isSeated, isSittingOut, playerEquity, onSitIn
 }) => {
     // Track previous banner mode so we can detect timer→action transitions
@@ -153,7 +153,7 @@ const Badge: React.FC<BadgeProps> = React.memo(({
                 return (
                     <div className="seat-banner-text flex flex-col items-center justify-center w-full mt-[14px] gap-0.5">
                         <span className="font-bold text-base leading-tight">
-                            WINS: {winnerAmount}
+                            WINS
                         </span>
                         {winnerHandDescription && (
                             <span className="font-semibold text-[0.65rem] uppercase tracking-wider leading-tight opacity-95">


### PR DESCRIPTION
This pull request makes a minor update to the `Badge` component by removing the display of the `winnerAmount` value and the associated prop. The "WINS" label is now shown without the amount.

- UI update:
  * The "WINS" label in the `Badge` component no longer displays the `winnerAmount` value; it simply shows "WINS" instead. (`src/components/playPage/common/Badge.tsx`)

- Prop cleanup:
  * The unused `winnerAmount` prop has been removed from the `Badge` component's props. (`src/components/playPage/common/Badge.tsx`)
<img width="609" height="469" alt="Screenshot 2026-04-20 at 12 35 44 pm" src="https://github.com/user-attachments/assets/1480b7ab-6233-40c7-9298-106f1dac1e12" />
