### PR TITLE
issue-319

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -68,6 +68,8 @@ export interface BaseModalProps {
     closeOnEscape?: boolean;
     /** Whether to close on backdrop click (default: true when not processing) */
     closeOnBackdropClick?: boolean;
+    /** Whether the modal content should scroll when it overflows (default: true) */
+    scrollable?: boolean;
 }
 
 /**
@@ -112,7 +114,8 @@ export const Modal: React.FC<BaseModalProps> = React.memo(
         showCardSuits = true,
         patternId,
         closeOnEscape = true,
-        closeOnBackdropClick = true
+        closeOnBackdropClick = true,
+        scrollable = true
     }) => {
         // Handle Escape key press
         useEffect(() => {
@@ -148,7 +151,7 @@ export const Modal: React.FC<BaseModalProps> = React.memo(
 
                 {/* Modal Container */}
                 <div
-                    className={`relative p-6 rounded-xl shadow-2xl overflow-x-hidden overflow-y-auto max-h-[90vh] ${widthClass} max-w-[95vw] ${className} ${styles.modalContainer}`}
+                    className={`relative p-6 rounded-xl shadow-2xl overflow-x-hidden ${scrollable ? "overflow-y-auto max-h-[90vh]" : "overflow-y-hidden"} ${widthClass} max-w-[95vw] ${className} ${styles.modalContainer}`}
                 >
                     {/* Hexagon pattern background */}
                     {showHexagonPattern && <HexagonPattern patternId={patternId} />}

--- a/src/components/modals/DeleteTableModal.tsx
+++ b/src/components/modals/DeleteTableModal.tsx
@@ -39,6 +39,7 @@ const DeleteTableModal: React.FC<DeleteTableModalProps> = React.memo(({ isOpen, 
             error={error}
             isProcessing={isDeleting}
             patternId="hexagons-delete"
+            scrollable={false}
         >
             {/* Warning Message */}
             <div className="mb-6">

--- a/src/components/modals/LeaveTableModal.tsx
+++ b/src/components/modals/LeaveTableModal.tsx
@@ -34,6 +34,7 @@ const LeaveTableModal: React.FC<LeaveTableModalProps> = React.memo(({ isOpen, on
             error={error}
             isProcessing={isLeaving}
             patternId="hexagons-leave"
+            scrollable={false}
         >
             {/* Warning Message */}
             <div className="mb-6">

--- a/src/components/modals/TopUpModal.tsx
+++ b/src/components/modals/TopUpModal.tsx
@@ -113,6 +113,7 @@ const TopUpModal: React.FC<TopUpModalProps> = ({ currentStack, minBuyIn, maxBuyI
             error={topUpError}
             isProcessing={isProcessing}
             patternId="hexagons-topup"
+            scrollable={false}
         >
             {/* Current Stack */}
             <div className={`mb-2 rounded-lg ${styles.infoCard}`}>

--- a/src/components/playPage/Table/components/TableHeader.tsx
+++ b/src/components/playPage/Table/components/TableHeader.tsx
@@ -317,6 +317,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
                 titleIcon={<FaQrcode size={16} />}
                 widthClass="w-80"
                 patternId="hexagons-qr"
+                scrollable={false}
             >
                 <div className="flex flex-col items-center gap-4">
                     <div className="bg-white p-4 rounded-xl">


### PR DESCRIPTION
Introduce a scrollable prop on Modal (default: true) to control whether modal content should scroll when it overflows. The Modal now conditionally applies overflow-y and max-height classes based on this prop. Set scrollable={false} for DeleteTableModal, LeaveTableModal, TopUpModal, and the QR modal in TableHeader to prevent inner scrolling for these compact dialogs.