### PR TITLE
feat(ui): readonly share link via ?hand & ?index params (#2025)

### DIFF
--- a/src/apis/Api.ts
+++ b/src/apis/Api.ts
@@ -24,6 +24,8 @@ export class CosmosApi extends HTTPClient {
         this.get(`block52/pokerchain/poker/v1/game_state/${gameId}`, {
             headers: { "x-cosmos-block-height": String(blockHeight) }
         });
+    public getGameStateAt = (gameId: string, handNumber: number, actionIndex: number) =>
+        this.get(`block52/pokerchain/poker/v1/game_state_at/${gameId}/${handNumber}/${actionIndex}`);
     public getWithdrawalRequests = () => this.get("/pokerchain/poker/withdrawal_requests");
     public getIsTxProcessed = (txHash: string) => this.get(`/block52/pokerchain/poker/v1/is_tx_processed/${txHash}`);
     public getNftAvatar = (cosmosAddress: string) => this.get(`/pokerchain/poker/nft_avatar/${cosmosAddress}`);

--- a/src/components/ActionsLog.tsx
+++ b/src/components/ActionsLog.tsx
@@ -9,7 +9,6 @@ import { formatActionName, formatRoundName, getActionLine, getWinnerLine, should
 import { FaCopy, FaCheck, FaFileDownload, FaShare } from "react-icons/fa";
 import { toast } from "react-toastify";
 import { useGameStateContext } from "../context/GameStateContext";
-import { useIndexerApi } from "../context/IndexerApiContext";
 import styles from "./ActionsLog.module.css";
 
 // Simple component to display only the action log
@@ -18,7 +17,6 @@ const ActionsLog: React.FC = () => {
     const { previousActions } = useGameProgress(id);
     const { gameState, gameFormat } = useGameStateContext();
     const { winnerInfo } = useWinnerInfo();
-    const indexerApi = useIndexerApi();
     const showWinnerSummary = shouldShowWinnerSummary(gameState, winnerInfo);
     const [copied, setCopied] = useState(false);
     const [copiedJSON, setCopiedJSON] = useState(false);
@@ -117,53 +115,29 @@ const ActionsLog: React.FC = () => {
         }
     };
 
-    const handleShareHand = async () => {
+    const handleShareHand = () => {
         if (!id || !gameState?.handNumber) {
             toast.info("No hand data available to share");
             return;
         }
-        try {
-            // Look up block height for current hand from indexer
-            const handData = await indexerApi.getHand(id, String(gameState.handNumber)) as { block_height?: number } | null;
-            const actionIndex = gameState.previousActions?.length || 0;
 
-            if (handData?.block_height) {
-                const shareUrl = `${window.location.origin}/table/${id}?blocknumber=${handData.block_height}&actionindex=${actionIndex}`;
-                copyTextToClipboard(
-                    shareUrl,
-                    () => {
-                        setCopiedShare(true);
-                        toast.success("Table replay URL copied to clipboard!");
-                        setTimeout(() => setCopiedShare(false), 2000);
-                    },
-                    "Failed to copy share URL"
-                );
-            } else {
-                // Fallback to explorer URL if block height not available
-                const shareUrl = `${window.location.origin}/explorer/hand/${id}/${gameState.handNumber}`;
-                copyTextToClipboard(
-                    shareUrl,
-                    () => {
-                        setCopiedShare(true);
-                        toast.success("Hand replay URL copied to clipboard!");
-                        setTimeout(() => setCopiedShare(false), 2000);
-                    },
-                    "Failed to copy share URL"
-                );
-            }
-        } catch {
-            // Fallback to explorer URL on error
-            const shareUrl = `${window.location.origin}/explorer/hand/${id}/${gameState.handNumber}`;
-            copyTextToClipboard(
-                shareUrl,
-                () => {
-                    setCopiedShare(true);
-                    toast.success("Hand replay URL copied to clipboard!");
-                    setTimeout(() => setCopiedShare(false), 2000);
-                },
-                "Failed to copy share URL"
-            );
-        }
+        // Build a readonly share link targeting the chain's GameStateAt RPC
+        // (pokerchain#160). We encode the global action index of the latest
+        // action in the current hand — NOT the array length — since the chain
+        // matches on ActionDTO.Index.
+        const actions = gameState.previousActions ?? [];
+        const latestActionIndex = actions.length > 0 ? actions[actions.length - 1].index : 0;
+        const shareUrl = `${window.location.origin}/table/${id}?hand=${gameState.handNumber}&index=${latestActionIndex}`;
+
+        copyTextToClipboard(
+            shareUrl,
+            () => {
+                setCopiedShare(true);
+                toast.success("Table replay URL copied to clipboard!");
+                setTimeout(() => setCopiedShare(false), 2000);
+            },
+            "Failed to copy share URL"
+        );
     };
 
     return (

--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -624,25 +624,25 @@ const GeometryToggleButton: React.FC = () => {
 const Table = React.memo(() => {
     const { id } = useParams<{ id: string }>();
     // Game state context and subscription
-    const { subscribeToTable, unsubscribeFromTable, gameState, gameFormat, validationError, error, loadHistoricalState, isReplayMode, replayBlockNumber } =
+    const { subscribeToTable, unsubscribeFromTable, gameState, gameFormat, validationError, error, loadHistoricalState, isReplayMode, replayHandNumber, replayActionIndex } =
         useGameStateContext();
     const { currentNetwork } = useNetwork();
 
-    // Replay mode — read blocknumber/actionindex query params
-    const { isReplayMode: hasReplayParams, blockNumber: replayBlockParam, actionIndex: replayActionIndex, clearReplayParams } = useReplayMode();
+    // Replay mode — read hand/index query params from the readonly share link.
+    const { isReplayMode: hasReplayParams, handNumber: replayHandParam, actionIndex: replayActionParam, clearReplayParams } = useReplayMode();
     const indexerApi = useIndexerApi();
 
     useEffect(() => {
         if (id) {
-            if (hasReplayParams && replayBlockParam) {
-                // Replay mode: fetch historical state from chain, no WebSocket
-                loadHistoricalState(id, replayBlockParam);
+            if (hasReplayParams && replayHandParam !== null && replayActionParam !== null) {
+                // Replay mode: fetch point-in-time snapshot from chain, no WebSocket.
+                loadHistoricalState(id, replayHandParam, replayActionParam);
             } else {
-                // Live mode: subscribe to WebSocket
+                // Live mode: subscribe to WebSocket.
                 subscribeToTable(id);
             }
         }
-    }, [id, hasReplayParams, replayBlockParam, subscribeToTable, loadHistoricalState]);
+    }, [id, hasReplayParams, replayHandParam, replayActionParam, subscribeToTable, loadHistoricalState]);
 
     // Card back style configuration - driven by VITE_CARD_BACK_URL env var
     // Options: "default", "block52", "custom", "legacy", or a full URL to a custom SVG
@@ -1128,14 +1128,14 @@ const Table = React.memo(() => {
     return (
         <div className="table-container">
             {/* Replay mode banner */}
-            {isReplayMode && replayBlockNumber && (
+            {isReplayMode && replayHandNumber != null && (
                 <div
                     className="fixed top-0 left-0 right-0 z-[100] flex items-center justify-center gap-4 py-2 px-4 text-sm"
                     style={{ background: "rgba(214, 60, 94, 0.9)", color: "#fff" }}
                 >
                     <span>
-                        Viewing hand at block #{replayBlockNumber}
-                        {replayActionIndex != null ? ` (action ${replayActionIndex})` : ""}
+                        Viewing hand #{replayHandNumber}
+                        {replayActionIndex != null ? ` at action ${replayActionIndex}` : ""}
                     </span>
                     <button
                         onClick={clearReplayParams}

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -44,11 +44,12 @@ interface GameStateContextType {
     validationError: ValidationError | null;
     pendingAction: PendingAction | null;
     isReplayMode: boolean;
-    replayBlockNumber: number | null;
+    replayHandNumber: number | null;
+    replayActionIndex: number | null;
     subscribeToTable: (tableId: string) => void;
     unsubscribeFromTable: () => void;
     sendAction: (action: string, amount?: string) => Promise<void>;
-    loadHistoricalState: (tableId: string, blockNumber: number) => Promise<void>;
+    loadHistoricalState: (tableId: string, handNumber: number, actionIndex: number) => Promise<void>;
 }
 
 const GameStateContext = createContext<GameStateContextType | null>(null);
@@ -66,7 +67,8 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
     const [validationError, setValidationError] = useState<ValidationError | null>(null);
     const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
     const [isReplayMode, setIsReplayMode] = useState<boolean>(false);
-    const [replayBlockNumber, setReplayBlockNumber] = useState<number | null>(null);
+    const [replayHandNumber, setReplayHandNumber] = useState<number | null>(null);
+    const [replayActionIndex, setReplayActionIndex] = useState<number | null>(null);
     const { currentNetwork } = useNetwork();
 
     // Use ref instead of state for currentTableId to prevent re-renders
@@ -346,10 +348,12 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
         []
     );
 
-    // Load historical game state from chain at a specific block height (replay mode)
+    // Load point-in-time snapshot from chain (replay mode for readonly share links).
+    // Uses pokerchain#160 GameStateAt RPC: previousActions is truncated to actions at
+    // or before actionIndex, hole cards and deck are masked (public view).
     const loadHistoricalState = useCallback(
-        async (tableId: string, blockNumber: number): Promise<void> => {
-            // Clean up any existing WebSocket connection
+        async (tableId: string, handNumber: number, actionIndex: number): Promise<void> => {
+            // Clean up any existing WebSocket connection — replay mode is a one-shot fetch.
             if (wsRef.current) {
                 wsRef.current.close();
                 wsRef.current = null;
@@ -359,21 +363,22 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
             setError(null);
             setValidationError(null);
             setIsReplayMode(true);
-            setReplayBlockNumber(blockNumber);
+            setReplayHandNumber(handNumber);
+            setReplayActionIndex(actionIndex);
             currentTableIdRef.current = tableId;
 
             try {
                 const cosmosApi = new CosmosApi({ baseUrl: currentNetwork.rest!, secure: false, timeout: 10000 });
-                const response = await cosmosApi.getGameStateAtBlock(tableId, blockNumber) as { game_state?: string };
+                const response = await cosmosApi.getGameStateAt(tableId, handNumber, actionIndex) as { game_state?: string };
 
                 if (!response || !response.game_state) {
-                    throw new Error(`No game state found at block ${blockNumber}`);
+                    throw new Error(`No game state found for hand ${handNumber} at action ${actionIndex}`);
                 }
 
                 const parsed = JSON.parse(response.game_state);
 
-                // The chain response may be a GameStateResponseDTO (with gameState nested)
-                // or the TexasHoldemStateDTO directly
+                // Chain may return a GameStateResponseDTO (with gameState nested)
+                // or TexasHoldemStateDTO directly.
                 const gameStateData = parsed.gameState || parsed;
                 const rawFormat = parsed.format;
                 const rawVariant = parsed.variant;
@@ -415,13 +420,14 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
             validationError,
             pendingAction,
             isReplayMode,
-            replayBlockNumber,
+            replayHandNumber,
+            replayActionIndex,
             subscribeToTable,
             unsubscribeFromTable,
             sendAction,
             loadHistoricalState
         }),
-        [gameState, gameFormat, gameVariant, isLoading, error, validationError, pendingAction, isReplayMode, replayBlockNumber, subscribeToTable, unsubscribeFromTable, sendAction, loadHistoricalState]
+        [gameState, gameFormat, gameVariant, isLoading, error, validationError, pendingAction, isReplayMode, replayHandNumber, replayActionIndex, subscribeToTable, unsubscribeFromTable, sendAction, loadHistoricalState]
     );
 
     return <GameStateContext.Provider value={contextValue}>{children}</GameStateContext.Provider>;

--- a/src/hooks/game/useReplayMode.ts
+++ b/src/hooks/game/useReplayMode.ts
@@ -3,40 +3,49 @@ import { useSearchParams } from "react-router-dom";
 
 interface UseReplayModeReturn {
     isReplayMode: boolean;
-    blockNumber: number | null;
+    handNumber: number | null;
     actionIndex: number | null;
     clearReplayParams: () => void;
 }
 
+/**
+ * Parses readonly share-link params from the URL.
+ *
+ * URL shape: `/table/{tableId}?hand={handNumber}&index={actionIndex}`
+ *
+ * Both params are required to enter replay mode. They drive the chain's
+ * GameStateAt RPC (poker-vm#2025, pokerchain#160) to reconstruct a
+ * point-in-time snapshot for social sharing.
+ */
 export const useReplayMode = (): UseReplayModeReturn => {
     const [searchParams, setSearchParams] = useSearchParams();
 
-    const blockNumber = useMemo(() => {
-        const param = searchParams.get("blocknumber");
+    const handNumber = useMemo(() => {
+        const param = searchParams.get("hand");
         if (!param) return null;
         const parsed = Number(param);
         return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
     }, [searchParams]);
 
     const actionIndex = useMemo(() => {
-        const param = searchParams.get("actionindex");
+        const param = searchParams.get("index");
         if (!param) return null;
         const parsed = Number(param);
         return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
     }, [searchParams]);
 
-    const isReplayMode = blockNumber !== null;
+    const isReplayMode = handNumber !== null && actionIndex !== null;
 
     const clearReplayParams = () => {
         const newParams = new URLSearchParams(searchParams);
-        newParams.delete("blocknumber");
-        newParams.delete("actionindex");
+        newParams.delete("hand");
+        newParams.delete("index");
         setSearchParams(newParams, { replace: true });
     };
 
     return {
         isReplayMode,
-        blockNumber,
+        handNumber,
         actionIndex,
         clearReplayParams
     };


### PR DESCRIPTION
## Summary

Migrates the share-link replay flow from Cosmos-block-height granularity to **per-action-index granularity**, using the new `GameStateAt` RPC that landed in [pokerchain#160](https://github.com/block52/pokerchain/pull/161). Implements the URL schema from [poker-vm#2025](https://github.com/block52/poker-vm/issues/2025).

### Before

```
/table/{id}?blocknumber={height}&actionindex={count}
```

- `blocknumber` queried state via `x-cosmos-block-height` header — block-boundary granularity only.
- `actionindex` was cosmetic (banner label). It could not actually slice state to a specific action within a block, so "share a specific hero-call moment" didn't pinpoint the moment.
- Depended on the indexer for `block_height` lookup.

### After

```
/table/{id}?hand={handNumber}&index={actionIndex}
```

- `handNumber` + global `ActionDTO.index` drive the chain's new public endpoint.
- Chain returns a `TexasHoldemStateDTO` with `previousActions` **truncated to entries at or before `index`**, hole cards + deck masked (public view).
- No indexer lookup needed.

## Changes

- **`apis/Api.ts`** — new `CosmosApi.getGameStateAt(gameId, hand, index)` targeting `block52/pokerchain/poker/v1/game_state_at/{game_id}/{hand}/{index}`.
- **`hooks/game/useReplayMode.ts`** — parse `?hand=` and `?index=`; both are required to enter replay mode.
- **`context/GameStateContext.tsx`** — `loadHistoricalState` signature is now `(tableId, handNumber, actionIndex)`; hits the new RPC; exposes `replayHandNumber` / `replayActionIndex` on context (replacing `replayBlockNumber`).
- **`components/playPage/Table.tsx`** — wires the new params through to `loadHistoricalState`; banner now shows "Viewing hand #{N} at action {K}".
- **`components/ActionsLog.tsx`** — emits the new URL shape using the latest action's **global** `index` field (the previous code used array length, which would have been wrong for this endpoint anyway).

## Known follow-up (not blocking)

Derived fields in the chain response (`pot`, `communityCards`, player stacks) currently reflect the live moment. For most share cases that's fine — the link is shared at or near the current action. But if a user clicks a link after the hand has advanced further, derived fields will be ahead of the snapshot action. A **client-side action replay** via the SDK engine is the clean fix and is tracked as follow-up in the parent issue.

## Test plan

- [x] `yarn tsc -b` — passes
- [x] `yarn lint` on changed files — 0 errors, pre-existing warnings only (no new issues introduced)
- [x] `yarn build` — passes
- [ ] Smoke test: load `/table/{liveGameId}?hand={currentHand}&index=0` — should enter replay mode, no WS, "Go Live" button clears params
- [ ] Smoke test: copy share URL from ActionsLog, open in new tab — renders replay view
- [ ] Smoke test: invalid hand/index — loads gracefully with error state

## Refs

- Fixes poker-vm#2025
- Consumes pokerchain#160 (merged/deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)