### PR TITLE
Issue-212 Add auto-muck feature (hook, UI, setting)

### DIFF
--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -25,6 +25,7 @@ import { useAutoNewHand } from "../../hooks/playerActions/useAutoNewHand";
 import { useAutoFold } from "../../hooks/playerActions/useAutoFold";
 import { usePlayerTimer } from "../../hooks/player/usePlayerTimer";
 import { useAutoShowCards } from "../../hooks/playerActions/useAutoShowCards";
+import { useAutoMuck } from "../../hooks/playerActions/useAutoMuck";
 
 // Import action handlers
 import {
@@ -41,7 +42,7 @@ import {
 } from "../common/actionHandlers";
 
 // Import utils
-import { getActionByType, hasAction } from "../../utils/actionUtils";
+import { getActionByType } from "../../utils/actionUtils";
 import { getRaiseToAmount } from "../../utils/raiseUtils";
 
 // Import sub-components
@@ -93,6 +94,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         autoPostBlinds: autoPostBlindsEnabled,
         autoNewHand: autoNewHandEnabled,
         autoFold: autoFoldEnabled,
+        autoMuck: autoMuckEnabled,
         playerActionSounds
     } = useGameSettings();
 
@@ -203,6 +205,23 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
             }
         }, // onAutoShowComplete
         () => setLoadingAction(null) // onAutoShowError
+    );
+
+    // Auto-muck hook - automatically mucks cards at showdown when enabled in settings
+    useAutoMuck(
+        tableId,
+        network,
+        hasMuckAction,
+        isUsersTurn,
+        () => setLoadingAction("muck"), // onAutoMuckStarted
+        txHash => {
+            setLoadingAction(null);
+            if (onTransactionSubmitted) {
+                onTransactionSubmitted(txHash);
+            }
+        }, // onAutoMuckComplete
+        () => setLoadingAction(null), // onAutoMuckError
+        autoMuckEnabled
     );
 
     // Auto-new-hand hook - automatically triggers new hand when conditions are met

--- a/src/components/playPage/Table/components/TableSettingsSidebar.tsx
+++ b/src/components/playPage/Table/components/TableSettingsSidebar.tsx
@@ -47,8 +47,10 @@ export const TableSettingsSidebar: React.FC<TableSettingsSidebarProps> = ({ isOp
     const {
         turnNotificationSound,
         playerActionSounds,
+        autoMuck,
         toggleTurnNotificationSound,
-        togglePlayerActionSounds
+        togglePlayerActionSounds,
+        toggleAutoMuck
     } = useGameSettings();
 
     return (
@@ -72,6 +74,12 @@ export const TableSettingsSidebar: React.FC<TableSettingsSidebarProps> = ({ isOp
                         description="Play sounds when players perform actions such as bet, raise, call, fold, and check."
                         checked={playerActionSounds}
                         onToggle={togglePlayerActionSounds}
+                    />
+                    <ToggleRow
+                        label="Auto Muck"
+                        description="Automatically muck losing cards at showdown without prompting."
+                        checked={autoMuck}
+                        onToggle={toggleAutoMuck}
                     />
                 </div>
             </div>

--- a/src/context/GameSettingsContext.tsx
+++ b/src/context/GameSettingsContext.tsx
@@ -15,6 +15,7 @@ const LS_KEY_AUTO_DEAL = "setting_autodeal";
 const LS_KEY_AUTO_POST_BLINDS = "setting_autoblinds";
 const LS_KEY_AUTO_NEW_HAND = "setting_autonewhand";
 const LS_KEY_AUTO_FOLD = "setting_autofold";
+const LS_KEY_AUTO_MUCK = "setting_automuck";
 const LS_KEY_TURN_SOUND = "setting_turnsound";
 const LS_KEY_PLAYER_ACTION_SOUNDS = "setting_playeractionsounds";
 
@@ -29,6 +30,7 @@ export interface GameSettings {
     autoPostBlinds: boolean;
     autoNewHand: boolean;
     autoFold: boolean;
+    autoMuck: boolean;
     turnNotificationSound: boolean;
     playerActionSounds: boolean;
 }
@@ -38,6 +40,7 @@ export interface GameSettingsContextValue extends GameSettings {
     toggleAutoPostBlinds: () => void;
     toggleAutoNewHand: () => void;
     toggleAutoFold: () => void;
+    toggleAutoMuck: () => void;
     toggleTurnNotificationSound: () => void;
     togglePlayerActionSounds: () => void;
 }
@@ -56,6 +59,9 @@ export const GameSettingsProvider: React.FC<{ children: React.ReactNode }> = ({ 
     );
     const [autoFold, setAutoFold] = useState<boolean>(() =>
         readBoolSetting(LS_KEY_AUTO_FOLD, getAutoFoldEnabled())
+    );
+    const [autoMuck, setAutoMuck] = useState<boolean>(() =>
+        readBoolSetting(LS_KEY_AUTO_MUCK, false)
     );
     const [turnNotificationSound, setTurnNotificationSound] = useState<boolean>(() =>
         readBoolSetting(LS_KEY_TURN_SOUND, true)
@@ -96,6 +102,14 @@ export const GameSettingsProvider: React.FC<{ children: React.ReactNode }> = ({ 
         });
     }, []);
 
+    const toggleAutoMuck = useCallback(() => {
+        setAutoMuck(prev => {
+            const next = !prev;
+            localStorage.setItem(LS_KEY_AUTO_MUCK, String(next));
+            return next;
+        });
+    }, []);
+
     const toggleTurnNotificationSound = useCallback(() => {
         setTurnNotificationSound(prev => {
             const next = !prev;
@@ -119,12 +133,14 @@ export const GameSettingsProvider: React.FC<{ children: React.ReactNode }> = ({ 
                 autoPostBlinds,
                 autoNewHand,
                 autoFold,
+                autoMuck,
                 turnNotificationSound,
                 playerActionSounds,
                 toggleAutoDeal,
                 toggleAutoPostBlinds,
                 toggleAutoNewHand,
                 toggleAutoFold,
+                toggleAutoMuck,
                 toggleTurnNotificationSound,
                 togglePlayerActionSounds
             }}

--- a/src/hooks/playerActions/index.ts
+++ b/src/hooks/playerActions/index.ts
@@ -21,6 +21,7 @@ import { useAutoDeal } from "./useAutoDeal";
 import { useAutoPostBlinds } from "./useAutoPostBlinds";
 import { useAutoNewHand } from "./useAutoNewHand";
 import { useAutoFold } from "./useAutoFold";
+import { useAutoMuck } from "./useAutoMuck";
 
 export {
     betHand,
@@ -47,7 +48,8 @@ export {
     useAutoDeal,
     useAutoPostBlinds,
     useAutoNewHand,
-    useAutoFold
+    useAutoFold,
+    useAutoMuck
 };
 
 export type { OptimisticActionType, SitInMethod, SitOutMethod };

--- a/src/hooks/playerActions/useAutoMuck.ts
+++ b/src/hooks/playerActions/useAutoMuck.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useCallback } from "react";
+import type { NetworkEndpoints } from "../../context/NetworkContext";
+import { muckCards } from "./muckCards";
+import { isNullish } from "../../utils/guards";
+
+/**
+ * Hook to automatically muck cards at showdown when autoMuck is enabled.
+ *
+ * The `enabled` parameter is reactive — toggling it mid-session takes effect immediately.
+ *
+ * Triggers once per opportunity when:
+ * 1. `enabled` is true
+ * 2. The player has a MUCK action available
+ * 3. It is the user's turn
+ * 4. An auto-action has not already been triggered for this opportunity
+ *
+ * @param tableId - The table/game ID
+ * @param network - The network configuration
+ * @param hasMuckAction - Whether MUCK is available in legal actions
+ * @param isUsersTurn - Whether it is currently the user's turn
+ * @param onAutoMuckStarted - Optional callback when auto-muck starts
+ * @param onAutoMuckComplete - Optional callback when auto-muck completes
+ * @param onAutoMuckError - Optional callback when auto-muck fails
+ * @param enabled - Whether auto-muck is enabled (reactive)
+ */
+export function useAutoMuck(
+    tableId: string,
+    network: NetworkEndpoints,
+    hasMuckAction: boolean,
+    isUsersTurn: boolean,
+    onAutoMuckStarted?: () => void,
+    onAutoMuckComplete?: (txHash: string) => void,
+    onAutoMuckError?: (error: Error) => void,
+    enabled?: boolean
+): void {
+    const hasTriggeredRef = useRef<boolean>(false);
+    const isProcessingRef = useRef<boolean>(false);
+    const enabledRef = useRef<boolean>(enabled ?? false);
+
+    useEffect(() => {
+        if (!isNullish(enabled)) {
+            enabledRef.current = enabled;
+        }
+    }, [enabled]);
+
+    const triggerAutoMuck = useCallback(async () => {
+        if (!tableId || isProcessingRef.current) {
+            return;
+        }
+
+        isProcessingRef.current = true;
+        onAutoMuckStarted?.();
+
+        try {
+            const result = await muckCards(tableId, network);
+            onAutoMuckComplete?.(result.hash);
+        } catch (error) {
+            console.error("Auto-muck failed:", error);
+            onAutoMuckError?.(error instanceof Error ? error : new Error(String(error)));
+        } finally {
+            isProcessingRef.current = false;
+        }
+    }, [tableId, network, onAutoMuckStarted, onAutoMuckComplete, onAutoMuckError]);
+
+    useEffect(() => {
+        const shouldAutoMuck =
+            enabledRef.current &&
+            hasMuckAction &&
+            isUsersTurn &&
+            !hasTriggeredRef.current &&
+            !isProcessingRef.current;
+
+        if (shouldAutoMuck) {
+            hasTriggeredRef.current = true;
+            const timeoutId = setTimeout(() => {
+                triggerAutoMuck();
+            }, 500);
+            return () => clearTimeout(timeoutId);
+        }
+
+        if (!isUsersTurn) {
+            hasTriggeredRef.current = false;
+        }
+    }, [hasMuckAction, isUsersTurn, triggerAutoMuck]);
+}


### PR DESCRIPTION
Introduce automatic mucking at showdown: add a new useAutoMuck hook (uses muckCards, 500ms delay, and provides start/complete/error callbacks) and export it from the playerActions index. Wire the feature into PokerActionPanel to run when enabled and remove an unused import. Add persistent autoMuck setting to GameSettingsContext (LS_KEY_AUTO_MUCK, default false) with toggle logic and expose toggleAutoMuck. Add an "Auto Muck" toggle to the TableSettingsSidebar so users can enable/disable the feature.