### PR TITLE
Fix sidebar styling and behaviour + Index for App config and description

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <meta name="twitter:image" content="%VITE_APP_IMAGE%" />
 
         <link rel="manifest" href="/manifest.json" />
-        <title>Block 52</title>
+        <title>%VITE_APP_TITLE%</title>
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/ActionsLog.module.css
+++ b/src/components/ActionsLog.module.css
@@ -1,6 +1,5 @@
 .container {
   color: #ffffff;
-  background-color: color-mix(in srgb, var(--table-bg-base) 30%, transparent);
 }
 
 .header {

--- a/src/components/ActionsLog.tsx
+++ b/src/components/ActionsLog.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useGameProgress } from "../hooks/game/useGameProgress";
 import { useWinnerInfo } from "../hooks/game/useWinnerInfo";
-import { formatPlayerId, formatAmount } from "../utils/accountUtils";
+import { formatAmount } from "../utils/accountUtils";
 import { isTournamentFormat } from "../utils/gameFormatUtils";
 import { ActionDTO } from "@block52/poker-vm-sdk";
 import { formatActionName, formatRoundName, getActionLine, getWinnerLine, shouldShowWinnerSummary } from "./ActionsLog.utils";
@@ -181,18 +181,6 @@ const ActionsLog: React.FC = () => {
                             className={`text-xs py-1 border-b ${styles.actionRow}`}
                         >
                             <div className="flex justify-between">
-                                <span
-                                    className={`font-mono ${styles.playerId}`}
-                                >
-                                    {formatPlayerId(action.playerId)}
-                                </span>
-                                <span
-                                    className={`text-[10px] ${styles.secondaryText}`}
-                                >
-                                    Seat {action.seat}
-                                </span>
-                            </div>
-                            <div className="flex justify-between mt-0.5">
                                 <span className={styles.actionText}>
                                     {formatActionName(action.action)}
                                     {action.amount && ` ${formatAmount(action.amount, undefined, isTournamentFormat(gameFormat))}`}
@@ -200,7 +188,7 @@ const ActionsLog: React.FC = () => {
                                 <span
                                     className={`text-[10px] ${styles.secondaryText}`}
                                 >
-                                    {formatRoundName(action.round)}
+                                    Seat {action.seat} · {formatRoundName(action.round)}
                                 </span>
                             </div>
                         </div>
@@ -211,20 +199,12 @@ const ActionsLog: React.FC = () => {
                             className={`text-xs py-1 border-b ${styles.actionRow} ${styles.winnerRow}`}
                         >
                             <div className="flex justify-between">
-                                <span className={`font-mono ${styles.playerId}`}>
-                                    {formatPlayerId(w.address)}
-                                </span>
-                                <span className={`text-[10px] ${styles.secondaryText}`}>
-                                    Seat {w.seat}
-                                </span>
-                            </div>
-                            <div className="flex justify-between mt-0.5">
                                 <span className={styles.winnerText}>
                                     WINS {w.formattedAmount}
                                     {w.description && ` — ${w.description}`}
                                 </span>
                                 <span className={`text-[10px] ${styles.secondaryText}`}>
-                                    Showdown
+                                    Seat {w.seat} · Showdown
                                 </span>
                             </div>
                         </div>

--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -1000,13 +1000,19 @@ const Table = React.memo(() => {
     // useEffect(() => { ... }, [tableSize, id]);
 
     const onCloseSideBar = useCallback(() => {
-        setOpenSidebar(!openSidebar);
-    }, [openSidebar]);
+        setOpenSidebar(prev => {
+            if (!prev) setOpenSettings(false);
+            return !prev;
+        });
+    }, []);
 
     const [openSettings, setOpenSettings] = useState(false);
 
     const onToggleSettings = useCallback(() => {
-        setOpenSettings(prev => !prev);
+        setOpenSettings(prev => {
+            if (!prev) setOpenSidebar(false);
+            return !prev;
+        });
     }, []);
 
     // Memoize formatted balance - Cosmos returns microunits (6 decimals)

--- a/src/components/playPage/Table/components/TableSidebar.tsx
+++ b/src/components/playPage/Table/components/TableSidebar.tsx
@@ -15,7 +15,9 @@ export interface TableSidebarProps {
 export const TableSidebar: React.FC<TableSidebarProps> = ({ isOpen }) => {
     return (
         <div className={`action-log-overlay ${isOpen ? "action-log-open" : "action-log-closed"}`}>
-            <ActionsLog />
+            <div className="h-full bg-[#1a2234] border-l border-white/10 flex flex-col overflow-hidden">
+                <ActionsLog />
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
Fix sidebar panel mutex, align History panel styling with Settings, remove player addresses from action log, and make app metadata fully configurable via .env

  - **Panel mutex**: Settings and History sidebars are now mutually exclusive — opening one         
  automatically closes the other instead of both being open simultaneously.                         
  - **Consistent panel styling**: History panel now shares the same background (`#1a2234`), border, 
  and layout structure as the Settings panel.                                                       
  - **Remove player addresses**: Action history rows no longer display wallet addresses. Seat number
   and round are shown inline on a single line for a cleaner log.                                   
  - **App metadata configurable per deployment**: Fixed hardcoded `<title>Block 52</title>` in    
  `index.html` to use `%VITE_APP_TITLE%`. All social sharing metadata (title, description, image,   
  domain, URL) is now fully driven by `.env` variables at build time — enabling each club deployment
   to have its own branded link previews in Slack, Telegram, iMessage, etc.                         
                                                                                                  
  ## Files Changed

  - `src/components/playPage/Table.tsx` — panel mutex logic                                         
  - `src/components/playPage/Table/components/TableSidebar.tsx` — matching background wrapper
  - `src/components/ActionsLog.tsx` — removed player addresses, cleaned up unused import            
  - `src/components/ActionsLog.module.css` — removed background (now owned by wrapper)              
  - `index.html` — `<title>` now uses `%VITE_APP_TITLE%` token                                      
                                                                                                    
  ## Deployment Note                                                                                
                                                                                                    
  For custom club deployments, ensure the following are set in `.env` before building:              
  VITE_APP_TITLE="Your Club Name"
  VITE_APP_DESCRIPTION="Your description."                                                          
  VITE_APP_DOMAIN=yourclub.com                                                                    
  VITE_APP_URL=https://yourclub.com                                                                 
  VITE_APP_IMAGE=https://... (preview image URL)

https://github.com/user-attachments/assets/b554bdda-3bed-4662-80bc-0280356683ba

