### PR TITLE
Issue-326 fix: TableHeader share button still generates /explorer/hand/ URL instead of replay table

### DIFF
--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -1056,7 +1056,9 @@ const Table = React.memo(() => {
             return;
         }
         try {
-            const shareUrl = `${window.location.origin}/explorer/hand/${id}/${handNumber}`;
+             const actions = gameState?.previousActions ?? [];
+            const latestActionIndex = actions.length > 0 ? actions[actions.length - 1].index : 0;
+            const shareUrl = `${window.location.origin}/table/${id}?hand=${handNumber}&index=${latestActionIndex}`;
             await navigator.clipboard.writeText(shareUrl);
             toast.success("Hand link copied to clipboard!", {
                 position: "top-right",
@@ -1065,7 +1067,7 @@ const Table = React.memo(() => {
         } catch {
             toast.error("Failed to copy share URL.");
         }
-    }, [id, handNumber]);
+    }, [id, handNumber, gameState?.previousActions]);
 
     // Memoize event handlers to prevent re-renders
     const handleLobbyClick = useCallback(() => {


### PR DESCRIPTION
Build the shared link to point to /table/:id with hand and index query params instead of the old /explorer/hand path. The code now computes latestActionIndex from gameState?.previousActions (falls back to 0) and appends it as ?hand=<handNumber>&index=<latestActionIndex>. Also updated the hook dependency array to include gameState?.previousActions so the memoized callback updates when actions change. Toast behavior and clipboard write remain unchanged.