### PR TITLE
fix(useBlindLevel): throw when next blinds missing for SNG/Tournament

### DIFF
--- a/src/hooks/game/useBlindLevel.ts
+++ b/src/hooks/game/useBlindLevel.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useGameStateContext } from "../../context/GameStateContext";
 import { isSitAndGoFormat, isTournamentFormat } from "../../utils/gameFormatUtils";
 import { formatChipCount } from "../../utils/potDisplayUtils";
+import { hasContent, hasValue } from "../../utils/guards";
 
 export interface BlindLevelInfo {
     /** Current blind level (0-based), undefined if not provided by backend */
@@ -52,9 +53,17 @@ export const useBlindLevel = (startTime?: number): BlindLevelInfo => {
     // Blind level from backend
     const level = gameOptions?.blindLevel;
 
-    // Next blinds from backend
-    const nextSmallBlind = gameOptions?.nextSmallBlind ? Number(gameOptions.nextSmallBlind) : 0;
-    const nextBigBlind = gameOptions?.nextBigBlind ? Number(gameOptions.nextBigBlind) : 0;
+    // Next blinds from backend — required for SNG/Tournament games
+    if (isActive && hasValue(gameOptions)) {
+        if (!hasContent(gameOptions.nextSmallBlind)) {
+            throw new Error("gameOptions.nextSmallBlind is required for SNG/Tournament games");
+        }
+        if (!hasContent(gameOptions.nextBigBlind)) {
+            throw new Error("gameOptions.nextBigBlind is required for SNG/Tournament games");
+        }
+    }
+    const nextSmallBlind = hasContent(gameOptions?.nextSmallBlind) ? Number(gameOptions.nextSmallBlind) : 0;
+    const nextBigBlind = hasContent(gameOptions?.nextBigBlind) ? Number(gameOptions.nextBigBlind) : 0;
 
     // Blind level duration in seconds
     const blindLevelDuration = gameOptions?.blindLevelDuration;


### PR DESCRIPTION
## Summary
- Closes #331
- `useBlindLevel` previously defaulted missing `nextSmallBlind` / `nextBigBlind` to `0`, producing `Next 0/0` in the table sub-header for Sit and Go games
- Now validates via `hasValue` / `hasContent` guards and throws when these fields are missing on a SNG/Tournament game — surfaces the chain-level bug instead of hiding it in the UI (per Commandment 7: No Defaults Policy)

## Backend dependency
The chain (poker-vm) must populate `nextSmallBlind` and `nextBigBlind` on `GameOptionsDTO` for SNG games. Until that ships, this hook will throw on SNG tables — that's the intended behavior.

## Test plan
- [ ] Open a Sit and Go table with backend that populates next blinds → sub-header reads `Level N X/Y Next A/B` correctly
- [ ] Open a Sit and Go table with backend that omits next blinds → hook throws (visible in error boundary / console) instead of rendering `Next 0/0`
- [ ] Open a cash game → unchanged (guards skipped because `isActive` is false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)