### PR TITLE
feat(ui): SNG blind level countdown timer

### DIFF
--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -777,8 +777,11 @@ const Table = React.memo(() => {
     // Add the useGameOptions hook
     const { gameOptions } = useGameOptions();
 
-    // Blind level info for SNG/Tournament games
-    const blindLevel = useBlindLevel();
+    // Blind level info for SNG/Tournament games.
+    // levelStartTime is expected on gameOptions.otherOptions until promoted to a first-class field on GameOptionsDTO.
+    // While missing, hasTimer stays false and the countdown is hidden.
+    const levelStartTime = gameOptions?.otherOptions?.levelStartTime as number | undefined;
+    const blindLevel = useBlindLevel(levelStartTime);
 
     // Add the useGameResults hook
     const { results } = useGameResults();

--- a/src/components/playPage/Table/components/TableHeader.tsx
+++ b/src/components/playPage/Table/components/TableHeader.tsx
@@ -22,6 +22,13 @@ import { GameFormat, GameOptionsDTO, PlayerDTO } from "@block52/poker-vm-sdk";
 import { BlindLevelInfo } from "../../../../hooks/game/useBlindLevel";
 import styles from "./TableHeader.module.css";
 
+const formatBlindCountdown = (secondsRemaining: number): string => {
+    const safe = Math.max(0, secondsRemaining);
+    const minutes = Math.floor(safe / 60);
+    const seconds = safe % 60;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+};
+
 export interface TableHeaderProps {
     // Table info
     tableId: string;
@@ -236,7 +243,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
                         <div className="flex items-center space-x-1 sm:space-x-2">
                             {blindLevel.isActive ? (
                                 <span className={`text-[10px] sm:text-[15px] font-semibold ${styles.secondaryText}`}>
-                                    {blindLevel.level !== undefined && `Level ${blindLevel.level + 1} `}{blindLevel.currentBlindsFormatted} Next {blindLevel.nextBlindsFormatted}
+                                    {blindLevel.level !== undefined && `Level ${blindLevel.level + 1} `}{blindLevel.currentBlindsFormatted} Next {blindLevel.nextBlindsFormatted}{blindLevel.hasTimer && ` (${formatBlindCountdown(blindLevel.secondsRemaining)})`}
                                 </span>
                             ) : (
                                 <span className={`text-[10px] sm:text-[15px] font-semibold ${styles.secondaryText}`}>


### PR DESCRIPTION
## Summary
- Closes #330
- Wires up the existing `useBlindLevel` countdown that was left dormant since #263
- Reads `levelStartTime` (epoch ms) from `gameOptions.otherOptions` and passes it into the hook
- Renders `mm:ss` next to the blinds in the table sub-header when `blindLevel.hasTimer` is true

Result: `Level 2 25/50 Next 50/100 (4:32)` while the chain supplies the timestamp; otherwise unchanged.

## Backend dependency
The chain (poker-vm) needs to populate `gameOptions.otherOptions.levelStartTime` (or eventually a first-class `levelStartTime: number` on `GameOptionsDTO`). Until that ships, `hasTimer` stays false and the countdown is hidden — no client-side fakes (Commandment 7).

## Test plan
- [ ] SNG table where backend supplies `otherOptions.levelStartTime` → countdown displays and ticks down each second
- [ ] SNG table where backend omits the field → blinds line renders without `(mm:ss)` (no `Next 0/0`, no NaN)
- [ ] Cash game → unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)