### PR TITLE
Add Hand Distribution and Nodes links to top menu

### DIFF
--- a/src/components/GlobalHeader.tsx
+++ b/src/components/GlobalHeader.tsx
@@ -110,7 +110,9 @@ export const GlobalHeader: React.FC = () => {
     // Note: Withdrawals moved to Admin > Bridge Management section
     const userMenuItems: MenuItem[] = [
         { path: "/admin/tables", label: "Tables", icon: "M4 6h16M4 10h16M4 14h16M4 18h16" },
-        { path: "/explorer", label: "Block Explorer", icon: "M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" }
+        { path: "/explorer", label: "Block Explorer", icon: "M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" },
+        { path: "/explorer/distribution", label: "Hand Distribution", icon: "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" },
+        { path: "/nodes", label: "Nodes", icon: "M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" }
     ];
 
     // Admin/dev menu items - icon only for discreet access


### PR DESCRIPTION
## Summary
- Add **Hand Distribution** (`/explorer/distribution`) and **Nodes** (`/nodes`) entries to `userMenuItems` in `GlobalHeader.tsx`, positioned right after Block Explorer
- Icons reused from `ExplorerHeader.tsx` for visual consistency
- Both desktop and mobile menus render from the same array, so both layouts pick up the new links automatically

Closes #336

## Test plan
- [ ] Both new links render in the desktop header next to Block Explorer
- [ ] Both new links render in the mobile menu
- [ ] Active-state styling triggers on `/explorer/distribution` and `/nodes`
- [ ] Navigation works from any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)