### PR TITLE
Fix/vite meta env build time

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -14,7 +14,7 @@ services:
         rewrite: /index.html
     envs:
       - key: REACT_APP_PROXY_URL
-        scope: BUILD_TIME
+        value: https://proxy.block52.xyz
       - key: VITE_APP_TITLE
         scope: BUILD_TIME
       - key: VITE_APP_DESCRIPTION

--- a/app.yaml
+++ b/app.yaml
@@ -14,4 +14,14 @@ services:
         rewrite: /index.html
     envs:
       - key: REACT_APP_PROXY_URL
-        value: https://proxy.block52.xyz
+        scope: BUILD_TIME
+      - key: VITE_APP_TITLE
+        scope: BUILD_TIME
+      - key: VITE_APP_DESCRIPTION
+        scope: BUILD_TIME
+      - key: VITE_APP_URL
+        scope: BUILD_TIME
+      - key: VITE_APP_DOMAIN
+        scope: BUILD_TIME
+      - key: VITE_APP_IMAGE
+        scope: BUILD_TIME


### PR DESCRIPTION
Sharing a table link on Telegram (and other platforms) was showing the raw placeholder %VITE_APP_DESCRIPTION% instead of the actual app description, and the OG image was not loading.

Vite substitutes %VITE_*% tokens in [index.html](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) at build time. Digital Ocean runs a fresh yarn build on every deploy, but [app.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — which DO treats as the authoritative app spec — only declared REACT_APP_PROXY_URL. All other VITE_* vars set in the DO dashboard were being ignored during the build, leaving the tokens unsubstituted in the deployed HTML.

Fix: Added all VITE_APP_* meta vars to [app.yaml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with scope: BUILD_TIME and no hardcoded values. This tells DO to inject them during yarn build so Vite can substitute them correctly. Values remain in the DO dashboard per deployment, so each fork (Texas HODL, Block 52, etc.) can configure its own title, description, image, and URL without changing the shared codebase.