### PR TITLE
feat: SNG payout positions panel (#350)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "=https://paymentservice.texashodl.net",
   "dependencies": {
-    "@block52/poker-vm-sdk": "1.1.17",
+    "@block52/poker-vm-sdk": "1.1.18",
     "@metamask/sdk": "^0.34.0",
     "@reown/appkit": "1.6.7",
     "@reown/appkit-adapter-ethers": "1.6.7",

--- a/src/components/playPage/SngPayoutPanel.tsx
+++ b/src/components/playPage/SngPayoutPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useSitAndGoPayouts } from "../../hooks/game/useSitAndGoPayouts";
 import { convertUSDCToNumber, formatForCashGame } from "../../utils/numberUtils";
+import { hasContent, isEmpty } from "../../utils/guards";
 
 const PLACE_LABELS = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th"];
 
@@ -9,7 +10,7 @@ const ordinal = (place: number): string => PLACE_LABELS[place - 1] ?? `${place}t
 const SngPayoutPanel: React.FC = () => {
     const { isSitAndGo, prizePool, places } = useSitAndGoPayouts();
 
-    if (!isSitAndGo || !prizePool || places.length === 0) {
+    if (!isSitAndGo || !hasContent(prizePool) || isEmpty(places)) {
         return null;
     }
 

--- a/src/components/playPage/SngPayoutPanel.tsx
+++ b/src/components/playPage/SngPayoutPanel.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { useSitAndGoPayouts } from "../../hooks/game/useSitAndGoPayouts";
+import { convertUSDCToNumber, formatForCashGame } from "../../utils/numberUtils";
+
+const PLACE_LABELS = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th"];
+
+const ordinal = (place: number): string => PLACE_LABELS[place - 1] ?? `${place}th`;
+
+const SngPayoutPanel: React.FC = () => {
+    const { isSitAndGo, prizePool, places } = useSitAndGoPayouts();
+
+    if (!isSitAndGo || !prizePool || places.length === 0) {
+        return null;
+    }
+
+    return (
+        <div
+            className="absolute bottom-4 right-4 z-30 hidden sm:block rounded-lg border border-blue-400/20 bg-gray-900/80 px-3 py-2 text-white shadow-lg backdrop-blur-sm"
+            data-testid="sng-payout-panel"
+        >
+            <div className="mb-1 flex items-baseline justify-between gap-3">
+                <span className="text-xs font-semibold uppercase tracking-wide text-blue-300">Payouts</span>
+                <span className="text-xs text-gray-300">Pool {formatForCashGame(convertUSDCToNumber(prizePool))}</span>
+            </div>
+            <ul className="space-y-0.5 text-sm">
+                {places.map(({ place, payout, percentBasisPoints }) => (
+                    <li key={place} className="flex items-baseline justify-between gap-4">
+                        <span className="text-gray-200">
+                            {ordinal(place)} <span className="text-gray-400">({percentBasisPoints / 100}%)</span>
+                        </span>
+                        <span className="font-mono tabular-nums">{formatForCashGame(convertUSDCToNumber(payout))}</span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+export default SngPayoutPanel;

--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -794,10 +794,8 @@ const Table = React.memo(() => {
     const { gameOptions } = useGameOptions();
 
     // Blind level info for SNG/Tournament games.
-    // levelStartTime is expected on gameOptions.otherOptions until promoted to a first-class field on GameOptionsDTO.
-    // While missing, hasTimer stays false and the countdown is hidden.
-    const levelStartTime = gameOptions?.otherOptions?.levelStartTime as number | undefined;
-    const blindLevel = useBlindLevel(levelStartTime);
+    // When the chain doesn't supply levelStartTime, hasTimer stays false and the countdown is hidden.
+    const blindLevel = useBlindLevel(gameOptions?.levelStartTime);
 
     // Add the useGameResults hook
     const { results } = useGameResults();

--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -113,6 +113,7 @@ import { useGameSettings } from "../../context/GameSettingsContext";
 import { useNetwork } from "../../context/NetworkContext";
 import { PlayerDTO, PlayerStatus } from "@block52/poker-vm-sdk";
 import LiveHandStrengthDisplay from "./LiveHandStrengthDisplay";
+import SngPayoutPanel from "./SngPayoutPanel";
 import { useGameStateSounds } from "../../hooks/notifications/useGameStateSounds";
 import NoWalletOverlay from "./NoWalletOverlay";
 
@@ -1391,6 +1392,9 @@ const Table = React.memo(() => {
 
                 {/* Live Hand Strength Display */}
                 <LiveHandStrengthDisplay />
+
+                {/* SNG payout positions — lower-right of table body */}
+                <SngPayoutPanel />
             </div>
 
             {/*//! FOOTER — hidden in replay mode (read-only) */}

--- a/src/hooks/game/useSitAndGoPayouts.test.ts
+++ b/src/hooks/game/useSitAndGoPayouts.test.ts
@@ -1,0 +1,121 @@
+import { renderHook } from "@testing-library/react";
+import { GameFormat, GameOptionsDTO, TexasHoldemStateDTO, TexasHoldemRound } from "@block52/poker-vm-sdk";
+import { useSitAndGoPayouts } from "./useSitAndGoPayouts";
+
+const mockUseGameStateContext = jest.fn();
+jest.mock("../../context/GameStateContext", () => ({
+    useGameStateContext: () => mockUseGameStateContext()
+}));
+
+const buildOptions = (overrides: Partial<GameOptionsDTO> = {}): GameOptionsDTO => ({
+    minBuyIn: "10000000",
+    maxBuyIn: "10000000",
+    minPlayers: 2,
+    maxPlayers: 9,
+    smallBlind: "25",
+    bigBlind: "50",
+    timeout: 30,
+    ...overrides
+});
+
+const buildState = (options: GameOptionsDTO): TexasHoldemStateDTO => ({
+    gameOptions: options,
+    smallBlindPosition: 1,
+    bigBlindPosition: 2,
+    dealer: 1,
+    players: [],
+    communityCards: [],
+    deck: "",
+    pots: ["0"],
+    totalPot: "0",
+    nextToAct: 1,
+    previousActions: [],
+    actionCount: 0,
+    handNumber: 0,
+    round: TexasHoldemRound.ANTE,
+    winners: [],
+    results: [],
+    legalActions: [],
+    availableSeats: [],
+    signature: "sig"
+});
+
+const setContext = (
+    gameState: TexasHoldemStateDTO | undefined,
+    gameFormat: GameFormat | undefined = GameFormat.SIT_AND_GO
+) => {
+    mockUseGameStateContext.mockReturnValue({ gameState, gameFormat });
+};
+
+describe("useSitAndGoPayouts", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("returns empty struct when format is cash", () => {
+        setContext(buildState(buildOptions()), GameFormat.CASH);
+        const { result } = renderHook(() => useSitAndGoPayouts());
+        expect(result.current.isSitAndGo).toBe(false);
+        expect(result.current.places).toEqual([]);
+        expect(result.current.prizePool).toBeNull();
+    });
+
+    it("returns empty places when gameOptions is missing", () => {
+        setContext(undefined, GameFormat.SIT_AND_GO);
+        const { result } = renderHook(() => useSitAndGoPayouts());
+        expect(result.current.isSitAndGo).toBe(true);
+        expect(result.current.places).toEqual([]);
+        expect(result.current.prizePool).toBeNull();
+    });
+
+    it("heads-up (2 players): single 100% payout", () => {
+        const options = buildOptions({ minBuyIn: "10000000", maxPlayers: 2 });
+        setContext(buildState(options));
+        const { result } = renderHook(() => useSitAndGoPayouts());
+
+        expect(result.current.prizePool).toBe("20000000");
+        expect(result.current.places).toEqual([
+            { place: 1, percentBasisPoints: 10000, payout: "20000000" }
+        ]);
+    });
+
+    it("3 players: 70/30 split", () => {
+        const options = buildOptions({ minBuyIn: "10000000", maxPlayers: 3 });
+        setContext(buildState(options));
+        const { result } = renderHook(() => useSitAndGoPayouts());
+
+        expect(result.current.prizePool).toBe("30000000");
+        expect(result.current.places.map(p => p.payout)).toEqual(["21000000", "9000000"]);
+    });
+
+    it("6 players: 65/35 split", () => {
+        const options = buildOptions({ minBuyIn: "10000000", maxPlayers: 6 });
+        setContext(buildState(options));
+        const { result } = renderHook(() => useSitAndGoPayouts());
+
+        expect(result.current.prizePool).toBe("60000000");
+        expect(result.current.places.map(p => p.payout)).toEqual(["39000000", "21000000"]);
+    });
+
+    it("9 players: 50/30/20 split", () => {
+        const options = buildOptions({ minBuyIn: "10000000", maxPlayers: 9 });
+        setContext(buildState(options));
+        const { result } = renderHook(() => useSitAndGoPayouts());
+
+        expect(result.current.prizePool).toBe("90000000");
+        expect(result.current.places.map(p => p.payout)).toEqual([
+            "45000000",
+            "27000000",
+            "18000000"
+        ]);
+        expect(result.current.places.map(p => p.percentBasisPoints)).toEqual([5000, 3000, 2000]);
+    });
+
+    it("returns empty places when maxPlayers is outside the supported curve range", () => {
+        const options = buildOptions({ minBuyIn: "10000000", maxPlayers: 12 });
+        setContext(buildState(options));
+        const { result } = renderHook(() => useSitAndGoPayouts());
+
+        expect(result.current.isSitAndGo).toBe(true);
+        expect(result.current.places).toEqual([]);
+        expect(result.current.prizePool).toBeNull();
+    });
+});

--- a/src/hooks/game/useSitAndGoPayouts.ts
+++ b/src/hooks/game/useSitAndGoPayouts.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { GameFormat } from "@block52/poker-vm-sdk";
 import { useGameStateContext } from "../../context/GameStateContext";
+import { hasContent, hasValue } from "../../utils/guards";
 
 export interface SitAndGoPayoutPlace {
     place: number;
@@ -39,12 +40,12 @@ export const useSitAndGoPayouts = (): SitAndGoPayoutsReturn => {
         const options = gameState?.gameOptions;
         const minBuyIn = options?.minBuyIn;
         const maxPlayers = options?.maxPlayers;
-        if (!minBuyIn || !maxPlayers) {
+        if (!hasContent(minBuyIn) || !hasValue(maxPlayers)) {
             return { isSitAndGo: true, prizePool: null, places: [] };
         }
 
         const curve = PAYOUT_CURVES[maxPlayers];
-        if (!curve) {
+        if (!hasValue(curve)) {
             return { isSitAndGo: true, prizePool: null, places: [] };
         }
 

--- a/src/hooks/game/useSitAndGoPayouts.ts
+++ b/src/hooks/game/useSitAndGoPayouts.ts
@@ -1,0 +1,66 @@
+import { useMemo } from "react";
+import { GameFormat } from "@block52/poker-vm-sdk";
+import { useGameStateContext } from "../../context/GameStateContext";
+
+export interface SitAndGoPayoutPlace {
+    place: number;
+    percentBasisPoints: number;
+    payout: string;
+}
+
+export interface SitAndGoPayoutsReturn {
+    isSitAndGo: boolean;
+    prizePool: string | null;
+    places: SitAndGoPayoutPlace[];
+}
+
+// Single-table SNG payout curves (basis points, sum to 10000).
+// Indexed by maxPlayers; covers the common single-table seat counts.
+const PAYOUT_CURVES: Record<number, number[]> = {
+    2: [10000],
+    3: [7000, 3000],
+    4: [7000, 3000],
+    5: [6500, 3500],
+    6: [6500, 3500],
+    7: [5000, 3000, 2000],
+    8: [5000, 3000, 2000],
+    9: [5000, 3000, 2000],
+    10: [5000, 3000, 2000]
+};
+
+const EMPTY: SitAndGoPayoutsReturn = { isSitAndGo: false, prizePool: null, places: [] };
+
+export const useSitAndGoPayouts = (): SitAndGoPayoutsReturn => {
+    const { gameState, gameFormat } = useGameStateContext();
+
+    return useMemo(() => {
+        if (gameFormat !== GameFormat.SIT_AND_GO) return EMPTY;
+
+        const options = gameState?.gameOptions;
+        const minBuyIn = options?.minBuyIn;
+        const maxPlayers = options?.maxPlayers;
+        if (!minBuyIn || !maxPlayers) {
+            return { isSitAndGo: true, prizePool: null, places: [] };
+        }
+
+        const curve = PAYOUT_CURVES[maxPlayers];
+        if (!curve) {
+            return { isSitAndGo: true, prizePool: null, places: [] };
+        }
+
+        const buyIn = BigInt(minBuyIn);
+        const prizePool = buyIn * BigInt(maxPlayers);
+
+        const places: SitAndGoPayoutPlace[] = curve.map((bp, index) => ({
+            place: index + 1,
+            percentBasisPoints: bp,
+            payout: ((prizePool * BigInt(bp)) / 10000n).toString()
+        }));
+
+        return {
+            isSitAndGo: true,
+            prizePool: prizePool.toString(),
+            places
+        };
+    }, [gameFormat, gameState?.gameOptions]);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,10 +306,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@block52/poker-vm-sdk@1.1.17":
-  version "1.1.17"
-  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.1.17.tgz#f5088ad551c05555dccd2e30e5125d1b8066c60c"
-  integrity sha512-rRK4oiU3ObwcE+KkBk4lNlD870ty1/zDY8X/NpFj5z0iQOdsA722nABzsZ+DvWxvpS4M1Sr9HhY8FQg+sGbelA==
+"@block52/poker-vm-sdk@1.1.18":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.1.18.tgz#c4b4415623b3bcd4e3fe9ab9f6bf8d2757e23cdc"
+  integrity sha512-kfYp6lc/Q49w54nzFUUVYXWyz2PDshHzJ1oiSMbVLohZyw1Xf5mYudQ9U4tHkOnJ6TSJ0HiaIx2z2DSF6diyVA==
   dependencies:
     "@bufbuild/protobuf" "^2.10.0"
     "@cosmjs/crypto" "^0.32.4"


### PR DESCRIPTION
## Summary
- Groundwork commit: bumps `@block52/poker-vm-sdk` 1.1.17 → 1.1.18 and switches `Table.tsx` to read the new first-class `gameOptions.levelStartTime` (replacing the `otherOptions` lookup).
- Sets up the feature branch for #350 — the SNG payout positions panel in the lower-right of the table.
- Full implementation plan posted on the issue: https://github.com/block52/ui/issues/350#issuecomment-4426297532

Closes #350

## Test plan
- [ ] `yarn lint` passes
- [ ] `yarn build` passes (verifies SDK 1.1.18 types resolve)
- [ ] Open a SNG table — confirm blind-level countdown still renders correctly with `gameOptions.levelStartTime` (no regression from the `otherOptions` removal)
- [ ] Cash table — confirm no countdown shown (hasTimer stays false)
- [ ] *(follow-up commits)* `useSitAndGoPayouts` hook unit tests cover 2/3/6/9-player payout math
- [ ] *(follow-up commits)* `SngPayoutPanel` renders only for SNG format, positioned bottom-right, doesn't overlap existing watermark/badge stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)