### PR TITLE
perf: switch action submission to SDK performActionSync (#359)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "=https://paymentservice.texashodl.net",
   "dependencies": {
-    "@block52/poker-vm-sdk": "1.1.18",
+    "@block52/poker-vm-sdk": "1.2.0",
     "@metamask/sdk": "^0.34.0",
     "@reown/appkit": "1.6.7",
     "@reown/appkit-adapter-ethers": "1.6.7",

--- a/src/hooks/game/useCosmosGameState.ts
+++ b/src/hooks/game/useCosmosGameState.ts
@@ -58,7 +58,14 @@ export const useCosmosGameState = (gameId: string, playerAddress?: string): UseC
     const performAction = useCallback(async (action: string, amountB52USDC: bigint = 0n): Promise<string> => {
         try {
             setError(null);
-            const txHash = await cosmosClient.performActionSync(gameId, action, amountB52USDC);
+            // NOTE: cosmosClient is a CosmosClient (read-only base class).
+            // performActionSync only exists on SigningCosmosClient, so we
+            // keep performAction here. The hook is in `src/hooks/game/`
+            // and appears to be unused by the main action flow (real
+            // submissions go through useOptimisticAction / playerActions/);
+            // this codepath would need a wider refactor to construct a
+            // SigningCosmosClient before it could use the sync variant.
+            const txHash = await cosmosClient.performAction(gameId, action, amountB52USDC);
 
             // Refetch game state after action
             setTimeout(() => {

--- a/src/hooks/game/useCosmosGameState.ts
+++ b/src/hooks/game/useCosmosGameState.ts
@@ -58,7 +58,7 @@ export const useCosmosGameState = (gameId: string, playerAddress?: string): UseC
     const performAction = useCallback(async (action: string, amountB52USDC: bigint = 0n): Promise<string> => {
         try {
             setError(null);
-            const txHash = await cosmosClient.performAction(gameId, action, amountB52USDC);
+            const txHash = await cosmosClient.performActionSync(gameId, action, amountB52USDC);
 
             // Refetch game state after action
             setTimeout(() => {

--- a/src/hooks/playerActions/betHand.ts
+++ b/src/hooks/playerActions/betHand.ts
@@ -15,7 +15,7 @@ export async function betHand(tableId: string, amount: bigint, network: NetworkE
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "bet",
         amount

--- a/src/hooks/playerActions/callHand.ts
+++ b/src/hooks/playerActions/callHand.ts
@@ -15,7 +15,7 @@ export async function callHand(tableId: string, amount: bigint, network: Network
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "call",
         amount

--- a/src/hooks/playerActions/checkHand.ts
+++ b/src/hooks/playerActions/checkHand.ts
@@ -14,7 +14,7 @@ export async function checkHand(tableId: string, network: NetworkEndpoints): Pro
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "check",
         0n

--- a/src/hooks/playerActions/dealCards.ts
+++ b/src/hooks/playerActions/dealCards.ts
@@ -14,7 +14,7 @@ export async function dealCards(tableId: string, network: NetworkEndpoints): Pro
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "deal",
         0n
@@ -45,7 +45,7 @@ export async function dealCardsWithEntropy(
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "deal",
         0n,

--- a/src/hooks/playerActions/foldHand.ts
+++ b/src/hooks/playerActions/foldHand.ts
@@ -14,7 +14,7 @@ export async function foldHand(tableId: string, network: NetworkEndpoints): Prom
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "fold",
         0n

--- a/src/hooks/playerActions/leaveTable.ts
+++ b/src/hooks/playerActions/leaveTable.ts
@@ -17,7 +17,7 @@ export async function leaveTable(tableId: string, value: string, network: Networ
 
 
     // Call SigningCosmosClient.performAction() with "leave" action
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "leave",
         BigInt(value)

--- a/src/hooks/playerActions/muckCards.ts
+++ b/src/hooks/playerActions/muckCards.ts
@@ -14,7 +14,7 @@ export async function muckCards(tableId: string, network: NetworkEndpoints): Pro
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "muck",
         0n

--- a/src/hooks/playerActions/postBigBlind.ts
+++ b/src/hooks/playerActions/postBigBlind.ts
@@ -15,7 +15,7 @@ export async function postBigBlind(tableId: string, amount: bigint, network: Net
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "post-big-blind",
         amount

--- a/src/hooks/playerActions/postSmallBlind.ts
+++ b/src/hooks/playerActions/postSmallBlind.ts
@@ -15,7 +15,7 @@ export async function postSmallBlind(tableId: string, amount: bigint, network: N
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "post-small-blind",
         amount

--- a/src/hooks/playerActions/raiseHand.ts
+++ b/src/hooks/playerActions/raiseHand.ts
@@ -15,7 +15,7 @@ export async function raiseHand(tableId: string, amount: bigint, network: Networ
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "raise",
         amount

--- a/src/hooks/playerActions/showCards.ts
+++ b/src/hooks/playerActions/showCards.ts
@@ -14,7 +14,7 @@ export async function showCards(tableId: string, network: NetworkEndpoints): Pro
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "show",
         0n

--- a/src/hooks/playerActions/sitIn.ts
+++ b/src/hooks/playerActions/sitIn.ts
@@ -33,7 +33,7 @@ export async function sitIn(
         data: `method=${method}`
     });
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "sit-in",
         0n,

--- a/src/hooks/playerActions/sitOut.ts
+++ b/src/hooks/playerActions/sitOut.ts
@@ -24,7 +24,7 @@ export async function sitOut(
 ): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "sit-out",
         0n,

--- a/src/hooks/playerActions/startNewHand.ts
+++ b/src/hooks/playerActions/startNewHand.ts
@@ -14,7 +14,7 @@ export async function startNewHand(tableId: string, network: NetworkEndpoints): 
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         "new-hand",
         0n

--- a/src/hooks/playerActions/useOptimisticAction.ts
+++ b/src/hooks/playerActions/useOptimisticAction.ts
@@ -45,7 +45,18 @@ interface UseOptimisticActionReturn {
 
 /**
  * Execute a poker action on the Cosmos blockchain.
- * Uses the SDK's performAction method directly.
+ *
+ * Uses the SDK's performActionSync method (CheckTx-only, returns in
+ * ~50-100ms) rather than performAction (waits for block inclusion,
+ * ~5s with current chain config). The authoritative state arrives
+ * via the WebSocket push once the block commits; the SDK throws here
+ * only on CheckTx rejection (invalid signature, insufficient gas,
+ * malformed message) — that's the immediate rollback signal.
+ *
+ * The "no WS confirmation within N seconds" timeout-based rollback
+ * is a separate enhancement tracked as a follow-up on block52/ui#359.
+ *
+ * Refs: block52/ui#359, block52/poker-vm#2104.
  */
 async function executeAction(
     tableId: string,
@@ -56,7 +67,7 @@ async function executeAction(
     const { signingClient, userAddress } = await getSigningClient(network);
 
 
-    const transactionHash = await signingClient.performAction(
+    const transactionHash = await signingClient.performActionSync(
         tableId,
         action,
         amount

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,10 +306,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@block52/poker-vm-sdk@1.1.18":
-  version "1.1.18"
-  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.1.18.tgz#c4b4415623b3bcd4e3fe9ab9f6bf8d2757e23cdc"
-  integrity sha512-kfYp6lc/Q49w54nzFUUVYXWyz2PDshHzJ1oiSMbVLohZyw1Xf5mYudQ9U4tHkOnJ6TSJ0HiaIx2z2DSF6diyVA==
+"@block52/poker-vm-sdk@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.2.0.tgz#5355ae99b34b663cf692a938f8a7c6a94fdafcee"
+  integrity sha512-nvfJwgMPCDY9cNUV9BgkGbeEe6NZ/gPdXaThEZICCoCuSHoVx1Bssajedx6uoDLK/kfAWljt/nxlg5mrAsS+cQ==
   dependencies:
     "@bufbuild/protobuf" "^2.10.0"
     "@cosmjs/crypto" "^0.32.4"


### PR DESCRIPTION
Closes #359.

> ⚠️ **DO NOT MERGE** until \`@block52/poker-vm-sdk@1.2.0\` is published to npm. Latest on npm is 1.1.18 at the time of this PR. The dep bump in \`package.json\` resolves once 1.2.0 lands; \`yarn.lock\` is intentionally not updated in this commit — the merger should run \`yarn install\` at merge time to refresh it. Filed as draft for now.

## What this changes

Replaces \`signingClient.performAction\` (BLOCK broadcast, waits ~5s for block inclusion) with \`signingClient.performActionSync\` (SYNC broadcast, returns ~50-100ms on CheckTx admission) in all player-facing action hooks. The authoritative state continues to arrive via the WS push once the chain commits the block — **no change to the reconciliation path**. The SDK throws on CheckTx rejection (invalid sig, insufficient gas, malformed message), which is the existing rollback signal.

The optimistic WS-broadcast infrastructure in \`useOptimisticAction\` already does the right thing:

1. \`sendAction()\` over WS → server broadcasts "pending" to subscribers ← unchanged
2. SDK chain submission ← **this PR: now SYNC instead of BLOCK**
3. WS push when block commits → "confirmed" state replaces optimistic ← unchanged

This PR is just step 2's mode swap.

## Hooks updated (16)

\`betHand\`, \`callHand\`, \`checkHand\`, \`dealCards\`, \`foldHand\`, \`leaveTable\`, \`muckCards\`, \`postBigBlind\`, \`postSmallBlind\`, \`raiseHand\`, \`showCards\`, \`sitIn\`, \`sitOut\`, \`startNewHand\`, \`useOptimisticAction\`, \`useCosmosGameState\`.

## Intentionally NOT updated

- \`src/pages/TestSigningPage.tsx\` — debug/test surface where BLOCK semantics (full DeliverTx result) is more useful for diagnostics.

## Follow-up (not in this PR)

The issue body of #359 specified a WS-timeout-based rollback: "if no WS confirmation arrives within ~3× \`timeout_commit\`, UI rolls back the optimistic state and shows an error toast." That's not implemented here — the rare CheckTx-succeeds-but-DeliverTx-never-confirms path. Current optimistic-state-stuck-pending UX continues to work but doesn't auto-revert in that edge case. Worth a follow-up issue once we have real production data on how often it actually happens.

## Test plan

Once SDK 1.2.0 is on npm:

- [ ] Pull this branch, run \`yarn install\`, commit \`yarn.lock\`.
- [ ] \`yarn build\` clean.
- [ ] \`yarn test\` clean.
- [ ] Deploy to staging, play a hand: click→render p50 should drop from ~5s to ~100ms.
- [ ] Acceptance: open WS dev panel, confirm the existing pending → confirmed transition still fires for every action.
- [ ] Manual edge case: send an action when not your turn. Confirm SDK throws and UI rolls back optimistic state (existing throw-on-error path).

## Refs

- [block52/poker-vm#2104](https://github.com/block52/poker-vm/issues/2104) — SDK feature this depends on.
- [block52/poker-vm#2111](https://github.com/block52/poker-vm/pull/2111) — PR that added \`performActionSync\` (merged, awaiting npm publish at \`sdk-v1.2.0\` release).
- [block52/pokerchain#193 §2](https://github.com/block52/pokerchain/issues/193) — chain-side perf umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)