### PR TITLE
fix(footer): hold action spinner until chain confirms via actionCount (#364)

### DIFF
--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { NonPlayerActionType, PlayerActionType, PlayerStatus, TexasHoldemRound } from "@block52/poker-vm-sdk";
+import { isNullish } from "../../utils/guards";
 import { parseMicroToBigInt, microBigIntToUsdc, usdcToMicroBigInt } from "../../constants/currency";
 import { isTournamentFormat } from "../../utils/gameFormatUtils";
 import {
@@ -349,9 +350,9 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
     // Canonical clear: chain has advanced past the actionCount at which
     // we submitted, i.e. our action was committed.
     useEffect(() => {
-        if (pendingActionCount === null) return;
+        if (isNullish(pendingActionCount)) return;
         const current = gameState?.actionCount;
-        if (current !== undefined && current > pendingActionCount) {
+        if (!isNullish(current) && current > pendingActionCount) {
             setLoadingAction(null);
             setPendingActionCount(null);
         }
@@ -362,7 +363,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
     // never advanced). After DIRTY_STATE_TIMEOUT_MS, re-enable the button
     // so the user can try again.
     useEffect(() => {
-        if (pendingActionCount === null) return;
+        if (isNullish(pendingActionCount)) return;
         const t = setTimeout(() => {
             console.warn(
                 `[action] no confirmation within ${DIRTY_STATE_TIMEOUT_MS}ms ` +

--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -60,6 +60,21 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
     // Loading state for actions
     const [loadingAction, setLoadingAction] = useState<string | null>(null);
 
+    // "Dirty" tracker for the gap between SDK SYNC return (~50ms) and the
+    // WS push delivering the committed state (~5s). We capture the chain's
+    // actionCount at submit time and keep loadingAction set until the chain
+    // says "I processed your action" by advancing past that number. Without
+    // this, the button stops spinning ~50ms after click but the panel sits
+    // with stale legalActions for the rest of the block budget, letting the
+    // player re-click the same action. See block52/ui#364.
+    const [pendingActionCount, setPendingActionCount] = useState<number | null>(null);
+
+    // How long to wait for the chain to confirm before re-enabling the
+    // button anyway. Generous enough to survive a slow WS / 5s commit
+    // window, tight enough that a genuinely stuck state recovers within
+    // the player's per-turn timeout budget.
+    const DIRTY_STATE_TIMEOUT_MS = 8000;
+
     // Action sounds
     const { playActionSound } = useActionSounds();
 
@@ -294,11 +309,24 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         }
     }, [hasRaiseAction, hasBetAction, minRaise, minBet]);
 
-    // Helper function to wrap action handlers with loading state
+    // Helper function to wrap action handlers with loading state.
+    // The spinner stays on until ONE of:
+    //   - chain advances actionCount past the value captured at submit
+    //     (see the watcher useEffect below — canonical confirmation)
+    //   - DIRTY_STATE_TIMEOUT_MS elapses (escape hatch useEffect below)
+    //   - actionFn() throws (CheckTx rejected — clear immediately so the
+    //     user can retry)
+    // We intentionally do NOT clear in a `finally` after a successful
+    // SDK return: with SYNC broadcast that fires ~50ms after click,
+    // which used to be ~5s under BLOCK broadcast — leaving the button
+    // re-enabled while the panel still showed stale legalActions.
+    // block52/ui#364.
     const handleActionWithTransaction = useCallback(
         async (actionName: string, actionFn: () => Promise<string | null>, skipActionSound = false) => {
+            const submittedAt = gameState?.actionCount ?? 0;
             try {
                 setLoadingAction(actionName);
+                setPendingActionCount(submittedAt);
                 if (!skipActionSound && playerActionSounds) {
                     playActionSound(actionName);
                 }
@@ -306,15 +334,45 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
                 if (txHash && onTransactionSubmitted) {
                     onTransactionSubmitted(txHash);
                 }
+                // Success path: let the watcher useEffect clear when the
+                // chain confirms via actionCount, or the timeout fires.
             } catch (error) {
                 console.error(`Error executing ${actionName}:`, error);
-                throw error;
-            } finally {
                 setLoadingAction(null);
+                setPendingActionCount(null);
+                throw error;
             }
         },
-        [onTransactionSubmitted, playActionSound, playerActionSounds]
+        [gameState?.actionCount, onTransactionSubmitted, playActionSound, playerActionSounds]
     );
+
+    // Canonical clear: chain has advanced past the actionCount at which
+    // we submitted, i.e. our action was committed.
+    useEffect(() => {
+        if (pendingActionCount === null) return;
+        const current = gameState?.actionCount;
+        if (current !== undefined && current > pendingActionCount) {
+            setLoadingAction(null);
+            setPendingActionCount(null);
+        }
+    }, [gameState?.actionCount, pendingActionCount]);
+
+    // Escape hatch: WS push never arrived (chain stalled, WS disconnect,
+    // or — rare — CheckTx passed but DeliverTx rejected so actionCount
+    // never advanced). After DIRTY_STATE_TIMEOUT_MS, re-enable the button
+    // so the user can try again.
+    useEffect(() => {
+        if (pendingActionCount === null) return;
+        const t = setTimeout(() => {
+            console.warn(
+                `[action] no confirmation within ${DIRTY_STATE_TIMEOUT_MS}ms ` +
+                    `for actionCount=${pendingActionCount}; clearing dirty state.`,
+            );
+            setLoadingAction(null);
+            setPendingActionCount(null);
+        }, DIRTY_STATE_TIMEOUT_MS);
+        return () => clearTimeout(t);
+    }, [pendingActionCount]);
 
     // Handler for dealing cards with entropy
     const handleDealWithEntropy = useCallback(


### PR DESCRIPTION
Closes #364. Implements **option (a)** from that issue.

## What this fixes

After [#360](https://github.com/block52/ui/pull/360) switched action submission to SDK `performActionSync`, the spinner stopped ~50ms after click (when CheckTx accepted) but the WS push delivering the committed state didn't arrive for another ~5s. In that gap:

- Button became re-enabled
- Panel still showed stale `legalActions`
- Player could re-click the same action or pick a different one, generating a duplicate submit that would then fail at DeliverTx as stale

## How

A "dirty" state in `PokerActionPanel` that keeps the spinner on past the SDK return. The success path no longer clears in `finally` — that was the broken behaviour. Instead, three signals clear it:

| Signal | When it fires | Source |
|---|---|---|
| **Canonical: actionCount advanced** | Chain processed our action | `gameState.actionCount` from `GameStateContext` (delivered via WS push at block commit) |
| **Escape hatch: 8s timeout** | WS / chain stalled, OR CheckTx accepted but DeliverTx rejected so actionCount never advanced | `setTimeout` in a `useEffect` |
| **Error: actionFn() throws** | CheckTx rejected (invalid sig, illegal action) | catch block |

The 8s timeout is generous enough to survive the current 5s commit window, tight enough to recover within the per-turn budget if something's wedged.

## Diff shape

`src/components/Footer/PokerActionPanel.tsx`: +62 / -4 lines. One new state (`pendingActionCount`), two new `useEffect`s, modifications to `handleActionWithTransaction`. No external API change — the callback's signature is unchanged.

## Test plan

- [x] `yarn build` clean
- [x] `PlayerActionButtons` test suite still green (8/8)
- [ ] Manual: click `check` → spinner stays for ~5s until panel disappears as it becomes the next player's turn. No re-enabled intermediary state.
- [ ] Manual: send an invalid action (e.g. fold when not your turn — if it slips past local validation). Spinner clears immediately on the SDK throw; error toast fires.
- [ ] Manual: cut WS connection mid-action. Spinner clears after 8s with a `[action] no confirmation within 8000ms...` console warning. Button re-enables.
- [ ] Manual: spam the same action button while spinner is up — second click should be no-op because the button is disabled.

## Out of scope

- Auto-actions (auto-deal, auto-fold, etc.) — they have their own `onActionStarted` / `onActionError` callbacks. If the same gap shows up there, separate issue.
- DeliverTx-reject UX — covered by the 8s escape hatch today (button just re-enables). A loud "your action was rejected" toast would be nicer; tracked elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)