### PR TITLE
fix(sit-in): hold spinner until chain confirms via actionCount

### DIFF
--- a/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
@@ -23,6 +23,14 @@ jest.mock("../../../common/actionHandlers", () => ({
     handleSitOut: (...args: unknown[]) => mockHandleSitOut(...args),
 }));
 
+// Mock GameStateContext — the sit-in dirty state added in block52/ui#367
+// reads actionCount from this context. These tests don't exercise that
+// pathway (they assert render structure + click handlers), so a static
+// stub is sufficient.
+jest.mock("../../../../context/GameStateContext", () => ({
+    useGameStateContext: () => ({ gameState: { actionCount: 0 } }),
+}));
+
 // Mock getPlayerActionDisplay — import the real module so we can spy on it
 jest.mock("../../../../utils/playerActionDisplayUtils", () => {
     const actual = jest.requireActual("../../../../utils/playerActionDisplayUtils");

--- a/src/components/playPage/Table/components/PlayerActionButtons.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.tsx
@@ -6,7 +6,7 @@
  * Responsive design for mobile, tablet, and desktop viewports.
  */
 
-import React, { useState, useEffect, useRef, useOptimistic, startTransition } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
 import { LegalActionDTO, NonPlayerActionType } from "@block52/poker-vm-sdk";
 import { handleSitOut, handleSitIn } from "../../../common/actionHandlers";
@@ -16,6 +16,13 @@ import { getPlayerActionDisplay } from "../../../../utils/playerActionDisplayUti
 import { toast } from "react-toastify";
 import BuyChipsButton from "../../../BuyChipsButton";
 import { useTableTopUp } from "../../../../hooks/game/useTableTopUp";
+import { useGameStateContext } from "../../../../context/GameStateContext";
+import { isNullish } from "../../../../utils/guards";
+
+// Wait for the chain to confirm sit-in via actionCount before re-enabling the
+// button. Mirrors the dirty-state pattern landed in block52/ui#365 for the
+// main action panel. See block52/ui#364 for the rationale.
+const DIRTY_STATE_TIMEOUT_MS = 8000;
 
 export interface PlayerActionButtonsProps {
     isMobile: boolean;
@@ -61,7 +68,19 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
 
     // Optimistic local state for immediate visual feedback
     const [optimisticChecked, setOptimisticChecked] = useState<boolean | null>(null);
-    const [optimisticSitIn, setOptimisticSitIn] = useOptimistic<boolean>(false);
+
+    // Dirty state for the Sit-In button. Was previously useOptimistic which
+    // auto-reverts when the underlying transition completes — that's
+    // exactly the gap we want to close: SDK SYNC return (~50ms) reverted
+    // the button before the chain committed the sit-in (~5s later), so
+    // the user could re-click. Now we hold the dirty state until either
+    //   • chain advances actionCount past the value we captured at click
+    //     (canonical "chain processed it" signal)
+    //   • DIRTY_STATE_TIMEOUT_MS elapses (escape hatch)
+    //   • handleSitIn throws (CheckTx rejected — clear immediately)
+    const { gameState } = useGameStateContext();
+    const [sittingIn, setSittingIn] = useState(false);
+    const [pendingActionCount, setPendingActionCount] = useState<number | null>(null);
 
     // Sync optimistic state with server state when it arrives
     const serverChecked = pendingSitOut === "next-hand";
@@ -116,12 +135,46 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
     const handleSitInClick = async () => {
         if (!tableId) return toast.error("Table ID is missing. Cannot sit in.");
 
-        startTransition(async () => {
-            console.log("🎯 Label clicked! TableId:", tableId, "Network:", currentNetwork);
-            setOptimisticSitIn(true);
+        const submittedAt = gameState?.actionCount ?? 0;
+        setSittingIn(true);
+        setPendingActionCount(submittedAt);
+        try {
             await handleSitIn(tableId, currentNetwork, SIT_IN_METHOD_POST_NOW);
-        });
+            // Success path: let the watcher useEffect clear when the chain
+            // confirms via actionCount, or the timeout fires.
+        } catch (err) {
+            console.error("Sit-in failed:", err);
+            setSittingIn(false);
+            setPendingActionCount(null);
+        }
     };
+
+    // Canonical clear: chain has advanced past the actionCount at which we
+    // submitted, i.e. the sit-in was committed.
+    useEffect(() => {
+        if (isNullish(pendingActionCount)) return;
+        const current = gameState?.actionCount;
+        if (!isNullish(current) && current > pendingActionCount) {
+            setSittingIn(false);
+            setPendingActionCount(null);
+        }
+    }, [gameState?.actionCount, pendingActionCount]);
+
+    // Escape hatch: WS / chain stall, or CheckTx accepted but DeliverTx
+    // rejected so actionCount never advanced. Re-enable the button so the
+    // user can retry.
+    useEffect(() => {
+        if (isNullish(pendingActionCount)) return;
+        const t = setTimeout(() => {
+            console.warn(
+                `[sit-in] no confirmation within ${DIRTY_STATE_TIMEOUT_MS}ms ` +
+                    `for actionCount=${pendingActionCount}; clearing dirty state.`,
+            );
+            setSittingIn(false);
+            setPendingActionCount(null);
+        }, DIRTY_STATE_TIMEOUT_MS);
+        return () => clearTimeout(t);
+    }, [pendingActionCount]);
     // Buy Chips button rendered independently (bottom-right, opposite to action buttons)
     const buyChipsElement =
         canTopUp && tableId ? (
@@ -184,14 +237,14 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
                     <div className={`fixed z-30 ${positionClass}`}>
                         <button
                             onClick={handleSitInClick}
-                            disabled={optimisticSitIn}
+                            disabled={sittingIn}
                             className={`flex items-center gap-2 rounded-lg shadow-lg border-2 font-bold tracking-wide uppercase transition-all duration-150 ${
-                                optimisticSitIn
+                                sittingIn
                                     ? "bg-green-700 border-green-600 text-green-200 cursor-wait"
                                     : "bg-green-600 border-green-400 text-white hover:bg-green-500 hover:border-green-300 hover:scale-105 active:scale-95 animate-pulse"
                             } ${isCompact ? "px-3 py-2 text-xs" : "px-5 py-3 text-sm"}`}
                         >
-                            {optimisticSitIn ? (
+                            {sittingIn ? (
                                 <>
                                     <div className="w-3 h-3 border-2 border-green-200 border-t-transparent rounded-full animate-spin" />
                                     Sitting in...


### PR DESCRIPTION
Follow-up to [#365](https://github.com/block52/ui/pull/365). Applies the same dirty-state pattern to the **Sit In Next Hand** button in `PlayerActionButtons.tsx`, which had the same regression shape but a different cause.

## Why the existing implementation gapped

`PlayerActionButtons.tsx` used React's `useOptimistic` + `startTransition` for the sit-in button:

```ts
const [optimisticSitIn, setOptimisticSitIn] = useOptimistic<boolean>(false);

const handleSitInClick = async () => {
    startTransition(async () => {
        setOptimisticSitIn(true);
        await handleSitIn(tableId, currentNetwork, SIT_IN_METHOD_POST_NOW);
    });
};
```

`useOptimistic` auto-reverts the optimistic value when the underlying transition completes. Pre-SYNC, `handleSitIn` returned in ~5s (BLOCK broadcast waited for inclusion) — the spinner stayed until the chain had committed. Post-SYNC, it returns in ~50ms — the transition completes, the spinner reverts, the button shows "Sit In Next Hand" again while the player's sit-in is still mid-flight on the chain. Same gap as #364 caught on the main action panel.

## What this changes

Replace `useOptimistic` with the `useState` + `actionCount` pattern landed in #365:

- Subscribe to `GameStateContext` from this component for `actionCount`.
- Capture `gameState.actionCount` at click time as `pendingActionCount`.
- Keep the spinner on until ONE of:

| Signal | When | Source |
|---|---|---|
| Canonical: actionCount advanced | Chain committed our sit-in | watcher `useEffect` |
| Escape hatch: 8s timeout | WS / chain stall, or CheckTx-passed-DeliverTx-rejected | timer `useEffect` |
| Error path | `handleSitIn` throws | catch block |

Drop the now-unused `useOptimistic` and `startTransition` imports from React. Use `isNullish` from `src/utils/guards.ts` for the same idiom as #365.

## Tests

Test file added a static mock for `useGameStateContext`. The existing 8 tests assert render structure + click handlers; they don't exercise the actionCount path, so a stub `{ gameState: { actionCount: 0 } }` is sufficient. Without the mock the renders throw because the provider isn't in the test tree.

All 747 tests pass; `yarn build` clean.

## Test plan

- [x] `yarn build` clean
- [x] `yarn test` — 747/747 green
- [ ] Manual: sit out → wait for next hand → click "Sit In Next Hand". Spinner stays for ~5s until the chain commits and the button disappears (because the player's status changed). No "Sit In Next Hand" re-appearing mid-flight.
- [ ] Manual: cut WS during sit-in. Spinner clears after 8s with the `[sit-in] no confirmation within 8000ms...` console warning. Button re-enables.

## Refs

- [#365](https://github.com/block52/ui/pull/365) — the matching pattern on the main action panel.
- [#364](https://github.com/block52/ui/issues/364) — original bug report.
- [poker-vm#2104](https://github.com/block52/poker-vm/issues/2104) — SDK `performActionSync` underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)