### PR TITLE
fix(sng): don't render '1st Place' overlay for mid-tournament hand winners

### DIFF
--- a/src/hooks/game/useSitAndGoPlayerResults.test.tsx
+++ b/src/hooks/game/useSitAndGoPlayerResults.test.tsx
@@ -1,0 +1,133 @@
+import { renderHook } from "@testing-library/react";
+import { GameFormat, type ResultDTO, type WinnerDTO, type PlayerDTO, type TexasHoldemStateDTO } from "@block52/poker-vm-sdk";
+import { useSitAndGoPlayerResults } from "./useSitAndGoPlayerResults";
+
+// Mock the context provider so the hook reads our stubbed game state.
+const mockUseGameStateContext = jest.fn();
+jest.mock("../../context/GameStateContext", () => ({
+    useGameStateContext: () => mockUseGameStateContext(),
+}));
+
+// Minimal helpers to build the shapes the hook reads.
+const player = (seat: number, address: string): PlayerDTO =>
+    ({ seat, address } as PlayerDTO);
+
+const winner = (address: string, amount = "100"): WinnerDTO =>
+    ({ address, amount } as WinnerDTO);
+
+const result = (place: number, playerId: string, payout = "0"): ResultDTO =>
+    ({ place, playerId, payout } as ResultDTO);
+
+const setGameState = (overrides: Partial<TexasHoldemStateDTO>) => {
+    mockUseGameStateContext.mockReturnValue({
+        gameState: {
+            players: [],
+            winners: [],
+            results: [],
+            ...overrides,
+        } as TexasHoldemStateDTO,
+        gameFormat: GameFormat.SIT_AND_GO,
+    });
+};
+
+beforeEach(() => {
+    mockUseGameStateContext.mockReset();
+});
+
+describe("useSitAndGoPlayerResults", () => {
+    describe("getPlayerResult — REGRESSION: hand winner is not 1st place", () => {
+        // The bug: when a player wins a hand mid-tournament, the chain
+        // populates gameState.winners with their address (per-hand winner).
+        // gameState.results is only populated when the TOURNAMENT ends.
+        // The old fallback "winner in winners but not in results → place: 1"
+        // was wrong: hand winners get marked as tournament first-place
+        // overlays even when the tournament hasn't ended.
+        // Fix: getPlayerResult ONLY returns data from results[], never
+        // synthesizes a place from winners[].
+
+        it("returns null when player won the current hand but tournament has no results yet", () => {
+            setGameState({
+                players: [player(1, "alice"), player(2, "bob")],
+                winners: [winner("bob", "200")],
+                results: [],
+            });
+            const { result: hookResult } = renderHook(() => useSitAndGoPlayerResults());
+
+            expect(hookResult.current.getPlayerResult("bob")).toBeNull();
+        });
+
+        it("returns null for a hand winner not in tournament results, even when results is partially populated", () => {
+            // Edge case: results has some entries but the hand-winner ("bob")
+            // isn't among them. The buggy fallback used to return
+            // { place: 1 } here; correct behaviour is null.
+            setGameState({
+                players: [player(1, "alice"), player(2, "bob"), player(3, "carol")],
+                winners: [winner("bob", "200")],
+                results: [result(3, "carol"), result(2, "alice")],
+            });
+            const { result: hookResult } = renderHook(() => useSitAndGoPlayerResults());
+
+            expect(hookResult.current.getPlayerResult("bob")).toBeNull();
+        });
+    });
+
+    describe("getPlayerResult — happy paths", () => {
+        it("returns the result entry when the player is in tournament results", () => {
+            setGameState({
+                players: [player(1, "alice"), player(2, "bob")],
+                winners: [winner("alice", "400")],
+                results: [result(1, "alice", "400"), result(2, "bob", "0")],
+            });
+            const { result: hookResult } = renderHook(() => useSitAndGoPlayerResults());
+
+            expect(hookResult.current.getPlayerResult("alice")).toEqual({
+                place: 1,
+                payout: "400",
+                isWinner: true,
+            });
+            expect(hookResult.current.getPlayerResult("bob")).toEqual({
+                place: 2,
+                payout: "0",
+                isWinner: false,
+            });
+        });
+
+        it("returns null when the address has no result entry and no winner record", () => {
+            setGameState({
+                players: [player(1, "alice")],
+                winners: [],
+                results: [],
+            });
+            const { result: hookResult } = renderHook(() => useSitAndGoPlayerResults());
+
+            expect(hookResult.current.getPlayerResult("alice")).toBeNull();
+        });
+    });
+
+    describe("getSeatResult", () => {
+        it("returns the result for the address sitting at the seat", () => {
+            setGameState({
+                players: [player(1, "alice"), player(2, "bob")],
+                winners: [winner("alice", "400")],
+                results: [result(1, "alice", "400"), result(2, "bob", "0")],
+            });
+            const { result: hookResult } = renderHook(() => useSitAndGoPlayerResults());
+
+            expect(hookResult.current.getSeatResult(1)?.place).toBe(1);
+            expect(hookResult.current.getSeatResult(2)?.place).toBe(2);
+        });
+
+        it("returns null for a hand winner mid-tournament (no overlay leakage)", () => {
+            // Same scenario as the regression test above, but accessed via
+            // the seat-keyed API that Player.tsx / OppositePlayer.tsx use.
+            setGameState({
+                players: [player(1, "alice"), player(2, "bob")],
+                winners: [winner("bob", "200")],
+                results: [],
+            });
+            const { result: hookResult } = renderHook(() => useSitAndGoPlayerResults());
+
+            expect(hookResult.current.getSeatResult(2)).toBeNull();
+        });
+    });
+});

--- a/src/hooks/game/useSitAndGoPlayerResults.ts
+++ b/src/hooks/game/useSitAndGoPlayerResults.ts
@@ -45,7 +45,13 @@ export const useSitAndGoPlayerResults = (): SitAndGoPlayerResultsReturn => {
         return allResults.length > 0;
     }, [allResults]);
 
-    // Get result for a specific player address
+    // Get result for a specific player address.
+    //
+    // ONLY reads from gameState.results (tournament-final placements),
+    // never synthesizes a place from gameState.winners (per-hand winner).
+    // Conflating the two used to render "1st Place" overlays on hand
+    // winners mid-tournament — when winners[] was populated but the
+    // player wasn't yet in results[]. See test file's REGRESSION block.
     const getPlayerResult = useMemo(() => {
         return (playerAddress: string): PlayerResultData | null => {
             if (!playerAddress || !hasResults) return null;
@@ -55,22 +61,7 @@ export const useSitAndGoPlayerResults = (): SitAndGoPlayerResultsReturn => {
                 r => r.playerId?.toLowerCase() === playerAddress.toLowerCase()
             );
 
-            if (!result) {
-                // Check if player is the winner (not in results but won)
-                const winner = gameState?.winners?.find(
-                    w => w.address?.toLowerCase() === playerAddress.toLowerCase()
-                );
-
-                if (winner) {
-                    // Winner gets 1st place - return raw BigInt string
-                    return {
-                        place: 1,
-                        payout: winner.amount || "0",
-                        isWinner: true
-                    };
-                }
-                return null;
-            }
+            if (!result) return null;
 
             return {
                 place: result.place,
@@ -78,7 +69,7 @@ export const useSitAndGoPlayerResults = (): SitAndGoPlayerResultsReturn => {
                 isWinner: result.place === 1
             };
         };
-    }, [allResults, hasResults, gameState?.winners]);
+    }, [allResults, hasResults]);
 
     // Get result for a specific seat number
     const getSeatResult = useMemo(() => {


### PR DESCRIPTION
## Bug

In a Sit-and-Go, when a player wins a HAND (not the tournament), the "1st Place" overlay was rendering on their seat as if they'd won the whole tournament. Reported on table [`0x3f487f12...d066`](https://play.texashodl.net/table/0x3f487f12e81fca05638db02e411933c5feec2e2b31b01196c41cab11b525220e).

## Root cause

`src/hooks/game/useSitAndGoPlayerResults.ts:getPlayerResult` had a fallback:

```ts
if (!result) {
    // Check if player is the winner (not in results but won)
    const winner = gameState?.winners?.find(...)
    if (winner) {
        return { place: 1, payout: winner.amount, isWinner: true };
    }
    return null;
}
```

That's logically wrong:

- `gameState.winners` = **per-hand** winner (populated every showdown)
- `gameState.results` = **per-tournament** placements (populated as players bust out and at tournament end)

Being in `winners[]` means "won the current hand", **not** "won the tournament". The fallback conflated the two and synthesized `place: 1` for any hand winner who wasn't yet recorded in `results[]`.

The early `if (!hasResults) return null` guard masked the bug when `results` is fully empty (start of a tournament). The buggy fallback fires when `results` is **partially populated** — e.g. a 4-player SNG where one player has busted (so they're in `results` with `place: 4`), but the remaining three keep playing hands. Each hand winner among the remaining three got tagged "1st Place" until the tournament actually ended and `results` caught up.

## Fix

Drop the fallback. `getPlayerResult` returns `null` when the player isn't in `results[]`, regardless of `winners[]`. Tournament placement comes ONLY from the tournament-final field.

The hand-winner indicator is a separate concern — `useWinnerInfo` reads `winners[]` and feeds the Badge's `isWinner` prop (the "WINS" banner overlay). That path isn't touched.

## Tests

`src/hooks/game/useSitAndGoPlayerResults.test.tsx` (new file, 6 cases):

| Case | Behaviour |
|---|---|
| **REGRESSION**: `winners` populated, `results` empty | `getPlayerResult` returns `null` (already worked via `!hasResults` guard) |
| **REGRESSION**: `winners` has hand winner, `results` partially populated WITHOUT them | Returns `null` ← was returning `{place: 1}` on old code |
| Happy: player in `results` | Returns the result entry, `isWinner` true iff `place === 1` |
| Happy: empty everywhere | Returns `null` |
| `getSeatResult` happy path | Returns the result for the address at the seat |
| `getSeatResult` regression | Returns `null` for a hand winner mid-tournament (covers the seat-keyed API Player.tsx uses) |

Verified the second regression test fails on the old code and passes on the new code.

`yarn test`: **753/753 green**. `yarn build` clean.

## Test plan

- [x] Unit tests for the regression + happy paths
- [ ] Manual: bust one player out of a 4-handed SNG; play another hand; confirm the hand winner does NOT get a "1st Place" overlay
- [ ] Manual: at actual tournament end, confirm the winner DOES get "1st Place" (results populated for all players)

🤖 Generated with [Claude Code](https://claude.com/claude-code)