### PR TITLE
feat(sng): one-shot result modal with Leave Table CTA (#371)

### DIFF
--- a/src/components/modals/SitAndGoResultModal.test.tsx
+++ b/src/components/modals/SitAndGoResultModal.test.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SitAndGoResultModal } from "./SitAndGoResultModal";
+
+// Mock the data hook — the modal's trigger logic depends entirely on
+// what getPlayerResult returns. By varying the mock per test we can
+// drive all four states (not-finished, paid, unpaid, winner) without
+// standing up a real GameStateContext.
+const mockGetPlayerResult = jest.fn();
+const mockIsSitAndGo = jest.fn();
+jest.mock("../../hooks/game/useSitAndGoPlayerResults", () => ({
+    useSitAndGoPlayerResults: () => ({
+        getPlayerResult: mockGetPlayerResult,
+        isSitAndGo: mockIsSitAndGo(),
+        getSeatResult: jest.fn(),
+        allResults: [],
+        hasResults: false,
+    }),
+}));
+
+// USDC formatter — fixed for this test suite. We don't care about
+// exact formatting precision; we just need the payout to be a string
+// that doesn't collide with "$0.00" when present.
+jest.mock("../../utils/numberUtils", () => ({
+    formatUSDCToSimpleDollars: (raw: string) => raw,
+}));
+
+const TABLE_ID = "0xabc";
+const USER_ADDRESS = "b521user";
+
+const setStoredAddress = (addr: string | null) => {
+    if (addr === null) localStorage.removeItem("user_cosmos_address");
+    else localStorage.setItem("user_cosmos_address", addr);
+};
+
+beforeEach(() => {
+    localStorage.clear();
+    mockGetPlayerResult.mockReset();
+    mockIsSitAndGo.mockReset();
+    mockIsSitAndGo.mockReturnValue(true);
+    setStoredAddress(USER_ADDRESS);
+});
+
+describe("SitAndGoResultModal", () => {
+    it("renders nothing when user has no tournament result yet", () => {
+        mockGetPlayerResult.mockReturnValue(null);
+        render(<SitAndGoResultModal tableId={TABLE_ID} onLeave={jest.fn()} />);
+
+        expect(screen.queryByTestId("sng-result-modal")).toBeNull();
+    });
+
+    it("renders nothing when not a Sit & Go", () => {
+        mockIsSitAndGo.mockReturnValue(false);
+        mockGetPlayerResult.mockReturnValue({ place: 1, payout: "1000000", isWinner: true });
+        render(<SitAndGoResultModal tableId={TABLE_ID} onLeave={jest.fn()} />);
+
+        expect(screen.queryByTestId("sng-result-modal")).toBeNull();
+    });
+
+    it("renders winner copy + payout for the tournament winner", () => {
+        mockGetPlayerResult.mockReturnValue({ place: 1, payout: "1000000", isWinner: true });
+        render(<SitAndGoResultModal tableId={TABLE_ID} onLeave={jest.fn()} />);
+
+        expect(screen.getByTestId("sng-result-modal")).toBeInTheDocument();
+        expect(screen.getByTestId("sng-result-heading")).toHaveTextContent(/won the tournament/i);
+        expect(screen.getByTestId("sng-result-payout")).toHaveTextContent("$1000000");
+    });
+
+    it("renders paid finish (2nd) with payout, no 'thanks for playing'", () => {
+        mockGetPlayerResult.mockReturnValue({ place: 2, payout: "400000", isWinner: false });
+        render(<SitAndGoResultModal tableId={TABLE_ID} onLeave={jest.fn()} />);
+
+        expect(screen.getByTestId("sng-result-heading")).toHaveTextContent("You finished 2nd!");
+        expect(screen.getByTestId("sng-result-payout")).toHaveTextContent("$400000");
+        expect(screen.queryByText(/thanks for playing/i)).toBeNull();
+    });
+
+    it("renders unpaid finish (4th of 4 in paid-3) with 'thanks for playing', no payout line", () => {
+        mockGetPlayerResult.mockReturnValue({ place: 4, payout: "0", isWinner: false });
+        render(<SitAndGoResultModal tableId={TABLE_ID} onLeave={jest.fn()} />);
+
+        expect(screen.getByTestId("sng-result-heading")).toHaveTextContent("You busted out — finished 4th.");
+        expect(screen.getByText(/thanks for playing/i)).toBeInTheDocument();
+        expect(screen.queryByTestId("sng-result-payout")).toBeNull();
+    });
+
+    it("Leave Table button fires onLeave and persists dismissal", async () => {
+        const onLeave = jest.fn();
+        mockGetPlayerResult.mockReturnValue({ place: 2, payout: "400000", isWinner: false });
+        render(<SitAndGoResultModal tableId={TABLE_ID} onLeave={onLeave} />);
+
+        fireEvent.click(screen.getByTestId("sng-result-leave-btn"));
+
+        expect(onLeave).toHaveBeenCalledTimes(1);
+        // Persisted dismissal flag is now set so a remount won't re-pop the modal.
+        expect(localStorage.getItem(`viewed_sng_result_${TABLE_ID}_${USER_ADDRESS.toLowerCase()}`)).toBe("true");
+    });
+
+    it("does NOT re-render on a remount once dismissed (refresh-after-close)", () => {
+        mockGetPlayerResult.mockReturnValue({ place: 2, payout: "400000", isWinner: false });
+
+        // Simulate a previous session having dismissed the modal.
+        localStorage.setItem(
+            `viewed_sng_result_${TABLE_ID}_${USER_ADDRESS.toLowerCase()}`,
+            "true",
+        );
+
+        render(<SitAndGoResultModal tableId={TABLE_ID} onLeave={jest.fn()} />);
+
+        expect(screen.queryByTestId("sng-result-modal")).toBeNull();
+    });
+
+    it("does NOT render if no user address is stored (spectator)", () => {
+        setStoredAddress(null);
+        mockGetPlayerResult.mockReturnValue({ place: 2, payout: "400000", isWinner: false });
+        render(<SitAndGoResultModal tableId={TABLE_ID} onLeave={jest.fn()} />);
+
+        expect(screen.queryByTestId("sng-result-modal")).toBeNull();
+    });
+});

--- a/src/components/modals/SitAndGoResultModal.tsx
+++ b/src/components/modals/SitAndGoResultModal.tsx
@@ -1,0 +1,163 @@
+/**
+ * SitAndGoResultModal
+ *
+ * One-shot modal shown to the current user once they've finished a
+ * Sit-and-Go tournament. Surfaces the place + payout (or a "thanks
+ * for playing" message for unpaid finishes), with a "Leave Table"
+ * CTA that fires the chain leave so the table can be reaped.
+ *
+ * Triggering logic lives inside this component (rather than the
+ * parent), so the parent only needs to mount it for SNG tables and
+ * pass `tableId` + `onLeave`. The modal:
+ *   - reads the current user's result via useSitAndGoPlayerResults;
+ *   - returns null if there's no result yet (player still active);
+ *   - returns null if the user has already dismissed it this game
+ *     (localStorage flag keyed on `${tableId}:${userAddress}`).
+ *
+ * Refs block52/ui#371, originally tracked in block52/poker-vm#2106.
+ */
+import React, { useEffect, useMemo, useState } from "react";
+import { useSitAndGoPlayerResults } from "../../hooks/game/useSitAndGoPlayerResults";
+import { formatUSDCToSimpleDollars } from "../../utils/numberUtils";
+import { isNullish } from "../../utils/guards";
+
+const PLACE_SUFFIX = ["1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th"];
+const ordinal = (place: number): string => PLACE_SUFFIX[place - 1] ?? `${place}th`;
+
+// localStorage flag — once the user has dismissed the modal for this
+// (tableId, userAddress), a page refresh shouldn't re-pop it.
+const dismissKey = (tableId: string, userAddress: string) =>
+    `viewed_sng_result_${tableId}_${userAddress.toLowerCase()}`;
+
+interface SitAndGoResultModalProps {
+    tableId: string | undefined;
+    /**
+     * Invoked when the user clicks "Leave Table". Should fire the
+     * chain leave action so the finished table can be reaped (see
+     * acceptance criteria in block52/ui#371). The parent passes
+     * `handleLeaveTableConfirm` here.
+     */
+    onLeave: () => void | Promise<void>;
+}
+
+export const SitAndGoResultModal: React.FC<SitAndGoResultModalProps> = ({ tableId, onLeave }) => {
+    const { isSitAndGo, getPlayerResult } = useSitAndGoPlayerResults();
+
+    // Read the user address fresh on mount only. The active wallet
+    // never changes mid-session for a given table view.
+    const userAddress = useMemo(
+        () => localStorage.getItem("user_cosmos_address")?.toLowerCase() ?? null,
+        [],
+    );
+
+    const playerResult = useMemo(() => {
+        if (!isSitAndGo || isNullish(userAddress)) return null;
+        return getPlayerResult(userAddress);
+    }, [isSitAndGo, getPlayerResult, userAddress]);
+
+    // Seed dismissed state from localStorage so a page refresh after
+    // the user explicitly closed the modal doesn't re-pop it.
+    const [dismissed, setDismissed] = useState<boolean>(() => {
+        if (isNullish(tableId) || isNullish(userAddress)) return false;
+        return localStorage.getItem(dismissKey(tableId, userAddress)) === "true";
+    });
+
+    // If the user lands on the page and the result is already present
+    // (e.g. tournament ended while they were away), the seeded state
+    // above already gates correctly. This effect only matters for the
+    // mid-session transition (result arrives via WS push while modal
+    // is mounted).
+    useEffect(() => {
+        if (isNullish(tableId) || isNullish(userAddress)) return;
+        setDismissed(localStorage.getItem(dismissKey(tableId, userAddress)) === "true");
+    }, [tableId, userAddress]);
+
+    if (isNullish(playerResult) || dismissed) return null;
+    if (isNullish(tableId) || isNullish(userAddress)) return null;
+
+    const { place, payout, isWinner } = playerResult;
+    const isPaid = payout !== "0";
+
+    const handleLeaveClick = async () => {
+        // Persist dismissal first so a slow chain leave doesn't leave
+        // the modal hanging if the user navigates away mid-tx.
+        localStorage.setItem(dismissKey(tableId, userAddress), "true");
+        setDismissed(true);
+        await onLeave();
+    };
+
+    // Copy: paid finishers get the celebratory variant (with payout
+    // line). Unpaid finishers get a softer message with no dollar
+    // amount. Winners get a small celebratory swap.
+    const heading = isWinner
+        ? "🏆 You won the tournament!"
+        : isPaid
+            ? `You finished ${ordinal(place)}!`
+            : `You busted out — finished ${ordinal(place)}.`;
+
+    const subtext = isPaid
+        ? null
+        : "Thanks for playing.";
+
+    return (
+        <div
+            className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 backdrop-blur-sm"
+            data-testid="sng-result-modal"
+        >
+            <div className="bg-gray-800/90 backdrop-blur-md p-8 rounded-xl w-96 shadow-2xl border border-blue-400/20 relative overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-br from-blue-600/10 to-purple-600/10 rounded-xl" />
+                <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-blue-500 via-purple-500 to-blue-500" />
+
+                <div className="relative z-10">
+                    <div className="flex items-center justify-center mb-4">
+                        <img src="/block52.png" alt="Block52 Logo" className="h-16 w-auto object-contain" />
+                    </div>
+
+                    <h2
+                        className="text-2xl font-bold text-white text-center mb-2 text-shadow"
+                        data-testid="sng-result-heading"
+                    >
+                        {heading}
+                    </h2>
+
+                    {subtext && (
+                        <p className="text-gray-300 text-center mb-6 text-sm">
+                            {subtext}
+                        </p>
+                    )}
+
+                    {isPaid && (
+                        <div className="bg-green-500/10 border border-green-500/30 rounded-lg p-4 mb-6 text-center">
+                            <div className="text-xs text-green-300 font-semibold mb-1">
+                                YOUR PAYOUT
+                            </div>
+                            <div
+                                className="text-3xl text-white font-bold"
+                                data-testid="sng-result-payout"
+                            >
+                                ${formatUSDCToSimpleDollars(payout)}
+                            </div>
+                        </div>
+                    )}
+
+                    <button
+                        onClick={handleLeaveClick}
+                        data-testid="sng-result-leave-btn"
+                        className="w-full py-3 px-4 rounded-lg border border-red-500/40 bg-red-500/10 text-red-400 text-sm font-semibold hover:bg-red-500/20 hover:border-red-500/60 transition-colors duration-200"
+                    >
+                        Leave Table
+                    </button>
+
+                    <div className="text-center mt-4">
+                        <div className="flex items-center justify-center gap-1">
+                            <div className="w-2 h-2 rounded-full bg-blue-400 animate-pulse" />
+                            <span className="text-xs text-gray-400">Powered by Block52</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default SitAndGoResultModal;

--- a/src/components/modals/index.ts
+++ b/src/components/modals/index.ts
@@ -12,6 +12,7 @@ export { default as WithdrawalModal } from "./WithdrawalModal";
 export { default as BuyInModal } from "./BuyInModal";
 export { default as LeaveTableModal } from "./LeaveTableModal";
 export { default as SitAndGoAutoJoinModal } from "./SitAndGoAutoJoinModal";
+export { default as SitAndGoResultModal } from "./SitAndGoResultModal";
 export { default as DealEntropyModal } from "./DealEntropyModal";
 
 // Type exports

--- a/src/components/playPage/Table/components/TableModals.tsx
+++ b/src/components/playPage/Table/components/TableModals.tsx
@@ -12,7 +12,7 @@
 import React from "react";
 import { isSitAndGoFormat } from "../../../../utils/gameFormatUtils";
 import GameStartCountdown from "../../common/GameStartCountdown";
-import { SitAndGoAutoJoinModal } from "../../../modals";
+import { SitAndGoAutoJoinModal, SitAndGoResultModal } from "../../../modals";
 import SitAndGoWaitingModal from "../../SitAndGoWaitingModal";
 import TransactionPopup from "../../common/TransactionPopup";
 import { LeaveTableModal } from "../../../modals";
@@ -81,6 +81,16 @@ export const TableModals: React.FC<TableModalsProps> = ({
 
             {/* Sit & Go Waiting Modal - Shows for Sit & Go games when user is playing but waiting for more players */}
             {isSitAndGoWaitingForPlayers && <SitAndGoWaitingModal onLeaveClick={handleLeaveTableClick} />}
+
+            {/* Sit & Go Result Modal - Self-gates on the user having a tournament
+                result in gameState.results[]. Skips the LeaveTableModal confirm
+                step and goes straight to the chain leave: the user has already
+                acknowledged the result by clicking "Leave Table", and the
+                table is finished — no balance-still-on-table concern.
+                block52/ui#371. */}
+            {gameFormat && isSitAndGoFormat(gameFormat) && (
+                <SitAndGoResultModal tableId={tableId} onLeave={handleLeaveTableConfirm} />
+            )}
 
             {/* Transaction Popup - Bottom Right */}
             <TransactionPopup txHash={recentTxHash} onClose={handleCloseTransactionPopup} />


### PR DESCRIPTION
Closes #371. Folds in [poker-vm#2106](https://github.com/block52/poker-vm/issues/2106) (closed as duplicate of #371 earlier today).

## What this adds

A new `SitAndGoResultModal` that fires **once** when the current user's tournament finish lands in `gameState.results[]`. Three copy variants:

| Result | Heading | Body |
|---|---|---|
| 1st place | "🏆 You won the tournament!" | Payout figure |
| Paid place (2nd, 3rd, …) | "You finished 2nd!" | Payout figure |
| Unpaid (e.g. 4th of 4) | "You busted out — finished 4th." | "Thanks for playing." (no payout line) |

Every variant has a single **Leave Table** button wired to `handleLeaveTableConfirm` — the chain leave action, so finished tables get reaped. We deliberately skip the `LeaveTableModal` "are you sure?" confirmation: the user has already seen their result and chosen to leave, and the table is finished — no balance-still-on-table to warn about.

## Trigger logic lives in the modal

Parent (`TableModals`) just mounts it for SNG-format tables and passes `tableId` + `onLeave`. The modal:

- Reads `useSitAndGoPlayerResults().getPlayerResult(userAddress)`.
- Returns `null` while the player is still active (no `results[]` entry yet).
- Returns `null` if not an SNG.
- Returns `null` if the user has dismissed it (localStorage one-shot keyed on `${tableId}:${userAddress}`).
- Persists the dismissal flag **before** firing `onLeave`, so a slow chain leave doesn't leave the modal hanging if the user navigates away mid-tx.

Style mirrors `SitAndGoWaitingModal` — same shell, same palette, same Block52 logo treatment.

## Depends on #370 (already merged)

[#370](https://github.com/block52/ui/pull/370) fixed a bug where `getPlayerResult` synthesized `{place: 1, payout: <chip amount>}` for every hand winner mid-tournament. Without #370 this modal would have popped up on every hand win during a Sit-and-Go. With #370 the trigger is reliable — fires only on real tournament results.

## Tests

`src/components/modals/SitAndGoResultModal.test.tsx` — 8 cases:

| # | Case |
|---|---|
| 1 | No tournament result → renders nothing |
| 2 | Not an SNG → renders nothing |
| 3 | Winner (1st) → heading + payout |
| 4 | Paid finish (2nd) → heading + payout, no "thanks" subtext |
| 5 | Unpaid finish (4th of 4) → "thanks for playing", no payout line |
| 6 | Leave button fires `onLeave` callback + persists dismissal to localStorage |
| 7 | Dismissed-on-mount (refresh after closing) → renders nothing |
| 8 | No user address stored (spectator) → renders nothing |

`yarn test`: 761/761 green. `yarn build` clean.

## Diff shape

```
src/components/modals/index.ts                         |   1 +
src/components/modals/SitAndGoResultModal.tsx          | 169 ++++++
src/components/modals/SitAndGoResultModal.test.tsx     | 124 ++++
src/components/playPage/Table/components/TableModals.tsx |  12 +-
```

`TableModals.tsx`: 11 lines added — mount the new modal, no new prop interface (reuses existing `tableId`, `gameFormat`, `handleLeaveTableConfirm` props the component already receives).

## Test plan

- [x] Unit tests cover all four content states + dismissal persistence.
- [x] `yarn build` clean, `yarn test` 761/761 green.
- [ ] Manual: play a 4-handed SNG to completion. Bust 3 players; confirm the busted players see the modal once with correct ordinal + payout. Confirm the winner sees the trophy variant. Confirm clicking "Leave Table" actually leaves and the table can be deleted.
- [ ] Manual: bust 4th of 4 in a paid-3 SNG; confirm the unpaid variant with no payout line.
- [ ] Manual: close the modal, refresh the page; confirm it doesn't re-pop.

## Refs

- [#371](https://github.com/block52/ui/issues/371) — feature ask.
- [#370](https://github.com/block52/ui/pull/370) — bug fix this depends on (merged).
- [#355](https://github.com/block52/ui/issues/355) — sibling bug, resolved by #370.
- [poker-vm#2106](https://github.com/block52/poker-vm/issues/2106) — original ask in the wrong repo, closed as duplicate of #371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)