### PR TITLE
feat: Telegram QR login at /tg

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,12 @@ VITE_UI_TEXT_SECONDARY=#9ca3af                # Gray-400 for secondary text
 
 # Site password protection (optional) - if not set, no password is required
 VITE_SITE_PASSWORD=
+
+# Telegram integration (block52/ui#374)
+# Register a Telegram app at https://my.telegram.org → API development tools.
+# These end up in the FE bundle (it's a browser MTProto client) — same as Telegram Web.
+# Register a SEPARATE app for the FE; do not reuse the broker's credentials.
+VITE_TG_API_ID=                                  # int from my.telegram.org
+VITE_TG_API_HASH=                                # hex string from my.telegram.org
+# Where the Go broker (block52/poker-vm:bot/tg-broker) is reachable from the browser.
+VITE_TG_BROKER_URL=http://localhost:8089

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "swr": "^2.3.7",
     "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss": "^3.4.14",
+    "telegram": "^2.26.22",
     "unstorage": "^1.17.0",
     "util": "^0.12.5",
     "uuid": "^13.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import AdminDashboard from "./pages/admin/AdminDashboard";
 import NodeStatusPage from "./pages/NodeStatusPage";
 import NodesPage from "./pages/NodesPage";
 import TechNotesPage from "./pages/tech-notes/TechNotesPage";
+import LinkTelegramPage from "./pages/LinkTelegramPage";
 import { TestSdk } from "./test-sdk";
 import { GameStateProvider } from "./context/GameStateContext";
 import { GameSettingsProvider } from "./context/GameSettingsContext";
@@ -38,6 +39,7 @@ import { ProfileAvatarModal } from "./components/profile";
 import { PaymentApiProvider } from "./context/PaymentApiContext";
 import { CosmosApiProvider } from "./context/CosmosApiContext";
 import { IndexerApiProvider } from "./context/IndexerApiContext";
+import { BrokerApiProvider } from "./context/BrokerApiContext";
 
 const queryClient = new QueryClient();
 
@@ -124,6 +126,7 @@ function AppContent() {
                 <Route path="/nodes" element={<NodesPage />} />
                 <Route path="/node/:name" element={<NodeStatusPage />} />
                 <Route path="/tech-notes" element={<TechNotesPage />} />
+                <Route path="/tg" element={<LinkTelegramPage />} />
                 <Route path="/" element={<Dashboard />} />
             </Routes>
             <ToastContainer
@@ -160,7 +163,9 @@ function App() {
                             <PaymentApiProvider>
                                 <CosmosApiProvider>
                                     <IndexerApiProvider>
-                                        <AppContent />
+                                        <BrokerApiProvider>
+                                            <AppContent />
+                                        </BrokerApiProvider>
                                     </IndexerApiProvider>
                                 </CosmosApiProvider>
                             </PaymentApiProvider>

--- a/src/apis/Api.ts
+++ b/src/apis/Api.ts
@@ -31,6 +31,11 @@ export class CosmosApi extends HTTPClient {
     public getNftAvatar = (cosmosAddress: string) => this.get(`/pokerchain/poker/nft_avatar/${cosmosAddress}`);
 }
 
+export class BrokerApi extends HTTPClient {
+    public postBinding = (data: { walletAddress: string; tgUserId: number; tgUsername: string }) =>
+        this.post("/bindings", data);
+}
+
 export class IndexerApi extends HTTPClient {
     public getCardStats = () => this.get("/api/v1/stats/cards");
     public getSyncStatus = () => this.get("/api/v1/status");

--- a/src/context/BrokerApiContext.tsx
+++ b/src/context/BrokerApiContext.tsx
@@ -1,0 +1,20 @@
+import React, { useContext, useMemo } from "react";
+import { BrokerApi } from "../apis/Api";
+
+const BrokerApiContext = React.createContext<BrokerApi | null>(null);
+
+export const BrokerApiProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const api = useMemo(
+        () => new BrokerApi({ baseUrl: import.meta.env.VITE_TG_BROKER_URL || "http://localhost:8089", secure: false }),
+        []
+    );
+    return <BrokerApiContext.Provider value={api}>{children}</BrokerApiContext.Provider>;
+};
+
+export const useBrokerApi = (): BrokerApi => {
+    const context = useContext(BrokerApiContext);
+    if (!context) {
+        throw new Error("useBrokerApi must be used within a BrokerApiProvider");
+    }
+    return context;
+};

--- a/src/pages/LinkTelegramPage.tsx
+++ b/src/pages/LinkTelegramPage.tsx
@@ -46,10 +46,14 @@ export const LinkTelegramPage: React.FC = () => {
 
         try {
             // Lazy-load gramjs — keeps the main bundle slim.
-            const [{ TelegramClient }, { StringSession }] = await Promise.all([
+            // gramjs is CommonJS; Vite's dep optimizer exposes the whole module
+            // as `default`, so named exports must be destructured off that.
+            const [telegramMod, sessionsMod] = await Promise.all([
                 import("telegram"),
                 import("telegram/sessions")
             ]);
+            const { TelegramClient } = telegramMod.default;
+            const { StringSession } = sessionsMod.default;
 
             const sessionKey = SESSION_KEY_PREFIX + cosmosAddress;
             const savedSession = window.localStorage.getItem(sessionKey) || "";

--- a/src/pages/LinkTelegramPage.tsx
+++ b/src/pages/LinkTelegramPage.tsx
@@ -1,0 +1,226 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import useCosmosWallet from "../hooks/wallet/useCosmosWallet";
+import { useBrokerApi } from "../context/BrokerApiContext";
+
+type Status =
+    | { kind: "idle" }
+    | { kind: "starting" }
+    | { kind: "awaiting-scan"; tgLoginUrl: string }
+    | { kind: "needs-password" }
+    | { kind: "linking" }
+    | { kind: "linked"; tgUsername: string; tgUserId: number }
+    | { kind: "error"; message: string };
+
+const SESSION_KEY_PREFIX = "telegram_session:";
+
+export const LinkTelegramPage: React.FC = () => {
+    const { address: cosmosAddress } = useCosmosWallet();
+    const broker = useBrokerApi();
+
+    const [status, setStatus] = useState<Status>({ kind: "idle" });
+    const [password, setPassword] = useState("");
+
+    // Hold the gramjs client across renders so password submission can resume the flow.
+    const clientRef = useRef<unknown>(null);
+    const passwordResolverRef = useRef<((pw: string) => void) | null>(null);
+
+    const apiId = Number(import.meta.env.VITE_TG_API_ID);
+    const apiHash = String(import.meta.env.VITE_TG_API_HASH || "");
+    const credsConfigured = Number.isFinite(apiId) && apiId > 0 && apiHash !== "";
+
+    const startQrLogin = useCallback(async () => {
+        if (!cosmosAddress) {
+            setStatus({ kind: "error", message: "Connect your Cosmos wallet first." });
+            return;
+        }
+        if (!credsConfigured) {
+            setStatus({
+                kind: "error",
+                message: "VITE_TG_API_ID and VITE_TG_API_HASH are not configured."
+            });
+            return;
+        }
+
+        setStatus({ kind: "starting" });
+
+        try {
+            // Lazy-load gramjs — keeps the main bundle slim.
+            const [{ TelegramClient }, { StringSession }] = await Promise.all([
+                import("telegram"),
+                import("telegram/sessions")
+            ]);
+
+            const sessionKey = SESSION_KEY_PREFIX + cosmosAddress;
+            const savedSession = window.localStorage.getItem(sessionKey) || "";
+            const session = new StringSession(savedSession);
+
+            const client = new TelegramClient(session, apiId, apiHash, { connectionRetries: 5 });
+            clientRef.current = client;
+
+            await client.connect();
+
+            const user = await client.signInUserWithQrCode(
+                { apiId, apiHash },
+                {
+                    qrCode: async code => {
+                        // Telegram QR login URLs require base64url. gramjs's Buffer polyfill
+                        // doesn't always implement "base64url", so derive it from "base64".
+                        const tokenBase64 = code.token.toString("base64");
+                        const tokenBase64Url = tokenBase64
+                            .replace(/\+/g, "-")
+                            .replace(/\//g, "_")
+                            .replace(/=+$/, "");
+                        const url = `tg://login?token=${tokenBase64Url}`;
+                        setStatus({ kind: "awaiting-scan", tgLoginUrl: url });
+                    },
+                    password: async () => {
+                        setStatus({ kind: "needs-password" });
+                        return await new Promise<string>(resolve => {
+                            passwordResolverRef.current = resolve;
+                        });
+                    },
+                    onError: async (err: Error) => {
+                        console.error("Telegram QR login error:", err);
+                        setStatus({ kind: "error", message: err.message });
+                        return true;
+                    }
+                }
+            );
+
+            window.localStorage.setItem(sessionKey, session.save());
+
+            const tgUserId = Number(user.id);
+            const tgUsername =
+                "username" in user && typeof user.username === "string" ? user.username : "";
+
+            setStatus({ kind: "linking" });
+
+            await broker.postBinding({
+                walletAddress: cosmosAddress,
+                tgUserId,
+                tgUsername
+            });
+
+            setStatus({ kind: "linked", tgUsername: tgUsername || `id:${tgUserId}`, tgUserId });
+        } catch (err) {
+            console.error("Telegram link failed:", err);
+            const message = err instanceof Error ? err.message : "Unknown error";
+            setStatus({ kind: "error", message });
+        }
+    }, [apiHash, apiId, broker, cosmosAddress, credsConfigured]);
+
+    const submitPassword = useCallback(() => {
+        const resolve = passwordResolverRef.current;
+        if (resolve) {
+            passwordResolverRef.current = null;
+            resolve(password);
+            setPassword("");
+            setStatus({ kind: "starting" });
+        }
+    }, [password]);
+
+    // If the user navigates away mid-flow, drop the in-flight resolver so a
+    // future visit starts cleanly.
+    useEffect(() => {
+        return () => {
+            passwordResolverRef.current = null;
+        };
+    }, []);
+
+    return (
+        <div className="min-h-screen bg-[#2c3245] text-gray-100 px-6 py-10">
+            <div className="max-w-xl mx-auto">
+                <h1 className="text-2xl font-semibold mb-2">Link Telegram</h1>
+                <p className="text-sm text-gray-400 mb-6">
+                    Connect your Telegram account to this Cosmos wallet. Scan the QR code with
+                    Telegram on your phone (Settings → Devices → Link Desktop Device).
+                </p>
+
+                {!cosmosAddress && (
+                    <div className="bg-amber-900/30 border border-amber-700 rounded p-4 text-sm">
+                        No Cosmos wallet detected. Import a seed phrase first.
+                    </div>
+                )}
+
+                {cosmosAddress && (
+                    <div className="bg-gray-800/40 rounded p-4 text-xs text-gray-300 mb-6">
+                        Wallet: <span className="font-mono">{cosmosAddress}</span>
+                    </div>
+                )}
+
+                {status.kind === "idle" && cosmosAddress && (
+                    <button
+                        onClick={startQrLogin}
+                        disabled={!credsConfigured}
+                        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 disabled:cursor-not-allowed rounded text-white"
+                    >
+                        Start QR login
+                    </button>
+                )}
+
+                {!credsConfigured && (
+                    <p className="text-xs text-amber-400 mt-2">
+                        VITE_TG_API_ID / VITE_TG_API_HASH not set — see .env.example.
+                    </p>
+                )}
+
+                {status.kind === "starting" && <p className="text-sm text-gray-300">Loading…</p>}
+
+                {status.kind === "awaiting-scan" && (
+                    <div className="mt-4">
+                        <div className="bg-white p-4 rounded-lg inline-block">
+                            <QRCodeSVG value={status.tgLoginUrl} size={240} level="H" />
+                        </div>
+                        <p className="text-sm text-gray-400 mt-3">
+                            Open Telegram → Settings → Devices → Link Desktop Device, then point your camera here.
+                        </p>
+                    </div>
+                )}
+
+                {status.kind === "needs-password" && (
+                    <div className="mt-4 space-y-3">
+                        <label className="block text-sm">Two-factor password</label>
+                        <input
+                            type="password"
+                            value={password}
+                            onChange={e => setPassword(e.target.value)}
+                            className="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-white"
+                            autoFocus
+                        />
+                        <button
+                            onClick={submitPassword}
+                            disabled={password.length === 0}
+                            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:bg-gray-600 rounded text-white"
+                        >
+                            Submit
+                        </button>
+                    </div>
+                )}
+
+                {status.kind === "linking" && (
+                    <p className="text-sm text-gray-300 mt-4">
+                        Logged in to Telegram. Registering binding with the broker…
+                    </p>
+                )}
+
+                {status.kind === "linked" && (
+                    <div className="bg-emerald-900/30 border border-emerald-700 rounded p-4 text-sm mt-4">
+                        Linked Telegram as <strong>@{status.tgUsername}</strong> (id {status.tgUserId}).
+                    </div>
+                )}
+
+                {status.kind === "error" && (
+                    <div className="bg-red-900/30 border border-red-700 rounded p-4 text-sm mt-4">
+                        {status.message}
+                        <button onClick={() => setStatus({ kind: "idle" })} className="ml-3 underline">
+                            Try again
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default LinkTelegramPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,6 +459,11 @@
   resolved "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz"
   integrity sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w==
 
+"@cryptography/aes@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@cryptography/aes/-/aes-0.1.1.tgz#0096726a6a2a2cfc2e8bddf3997e98e49f1a224d"
+  integrity sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==
+
 "@csstools/color-helpers@^5.1.0":
   version "5.1.0"
   resolved "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz"
@@ -2651,6 +2656,13 @@ asn1.js@^4.10.1:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
+async-mutex@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.2.tgz#1485eda5bda1b0ec7c8df1ac2e815757ad1831df"
+  integrity sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==
+  dependencies:
+    tslib "^2.3.1"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
@@ -2782,6 +2794,11 @@ bech32@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz"
   integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
+
+big-integer@^1.6.48:
+  version "1.6.52"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
+  integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
 
 big.js@6.2.2:
   version "6.2.2"
@@ -2982,7 +2999,7 @@ buffer@6.0.3, buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-bufferutil@^4.0.8:
+bufferutil@^4.0.1, bufferutil@^4.0.3, bufferutil@^4.0.8:
   version "4.1.0"
   resolved "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz"
   integrity sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==
@@ -3404,6 +3421,14 @@ csstype@^3.2.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
+d@1, d@^1.0.1, d@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.2.tgz#2aefd554b81981e7dccf72d6842ae725cb17e5de"
+  integrity sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==
+  dependencies:
+    es5-ext "^0.10.64"
+    type "^2.7.2"
+
 data-urls@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz"
@@ -3430,6 +3455,13 @@ debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, de
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@^4.4.3, debug@~4.4.1:
   version "4.4.3"
@@ -3597,6 +3629,36 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
+dom-serializer@^1.0.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
+  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
+  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
+  dependencies:
+    domelementtype "^2.2.0"
+
+domutils@^2.5.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+
 dot-prop@^4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz"
@@ -3718,6 +3780,11 @@ engine.io-parser@~5.2.1:
   resolved "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz"
   integrity sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==
 
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
 entities@^6.0.0:
   version "6.0.1"
   resolved "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz"
@@ -3762,10 +3829,37 @@ es-set-tostringtag@^2.1.0:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
+es5-ext@^0.10.35, es5-ext@^0.10.62, es5-ext@^0.10.63, es5-ext@^0.10.64, es5-ext@~0.10.14:
+  version "0.10.64"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.64.tgz#12e4ffb48f1ba2ea777f1fcdd1918ef73ea21714"
+  integrity sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==
+  dependencies:
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.3"
+    esniff "^2.0.1"
+    next-tick "^1.1.0"
+
 es6-error@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
+
+es6-iterator@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.4.tgz#f4e7d28013770b4208ecbf3e0bf14d3bcb557b8c"
+  integrity sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==
+  dependencies:
+    d "^1.0.2"
+    ext "^1.7.0"
 
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
@@ -3859,6 +3953,16 @@ eslint@^10.1.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
+esniff@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/esniff/-/esniff-2.0.1.tgz#a4d4b43a5c71c7ec51c51098c1d8a29081f9b308"
+  integrity sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==
+  dependencies:
+    d "^1.0.1"
+    es5-ext "^0.10.62"
+    event-emitter "^0.3.5"
+    type "^2.7.2"
+
 espree@^11.2.0:
   version "11.2.0"
   resolved "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz"
@@ -3926,6 +4030,14 @@ ethers@^6.15.0:
     aes-js "4.0.0-beta.5"
     tslib "2.7.0"
     ws "8.17.1"
+
+event-emitter@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  integrity sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 eventemitter2@^6.4.9:
   version "6.4.9"
@@ -3999,6 +4111,13 @@ expect@30.3.0, expect@^30.0.0:
     jest-message-util "30.3.0"
     jest-mock "30.3.0"
     jest-util "30.3.0"
+
+ext@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
+  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
+  dependencies:
+    type "^2.7.2"
 
 extension-port-stream@^3.0.0:
   version "3.0.0"
@@ -4500,6 +4619,16 @@ html-escaper@^2.0.0:
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
+
 http-cache-semantics@^4.0.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz"
@@ -4618,6 +4747,11 @@ internal-ip@^6.2.0:
     ipaddr.js "^1.9.1"
     is-ip "^3.1.0"
     p-event "^4.2.0"
+
+ip-address@^10.1.1:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 ip-regex@^4.0.0:
   version "4.3.0"
@@ -4789,6 +4923,11 @@ is-typed-array@^1.1.14, is-typed-array@^1.1.3:
   integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
   dependencies:
     which-typed-array "^1.1.16"
+
+is-typedarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -5643,6 +5782,11 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
@@ -5721,6 +5865,11 @@ motion-utils@^12.36.0:
   resolved "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz"
   integrity sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
@@ -5765,6 +5914,11 @@ neo-async@^2.6.2:
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+next-tick@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
+
 node-fetch-native@^1.6.7:
   version "1.6.7"
   resolved "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz"
@@ -5786,6 +5940,13 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
+
+node-localstorage@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/node-localstorage/-/node-localstorage-2.2.1.tgz#869723550a4883e426cb391d2df0b563a51c7c1c"
+  integrity sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==
+  dependencies:
+    write-file-atomic "^1.1.4"
 
 node-mock-http@^1.0.4:
   version "1.0.4"
@@ -5988,6 +6149,11 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
+pako@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
+
 parse-asn1@^5.0.0, parse-asn1@^5.1.9:
   version "5.1.9"
   resolved "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz"
@@ -6015,6 +6181,11 @@ parse5@^7.0.0, parse5@^7.2.1:
   integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
   dependencies:
     entities "^6.0.0"
+
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -6517,6 +6688,11 @@ readonly-date@^1.0.0:
   resolved "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz"
   integrity sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ==
 
+real-cancellable-promise@^1.1.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/real-cancellable-promise/-/real-cancellable-promise-1.2.3.tgz#6df13b7db40cbff9969975d6194c11e2356c4a13"
+  integrity sha512-hBI5Gy/55VEeeMtImMgEirD7eq5UmqJf1J8dFZtbJZA/3rB0pYFZ7PayMGueb6v4UtUtpKpP+05L0VwyE1hI9Q==
+
 real-require@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz"
@@ -6833,6 +7009,16 @@ slash@^3.0.0:
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slide@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+  integrity sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==
+
+smart-buffer@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
+  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
+
 socket.io-client@^4.5.1:
   version "4.8.3"
   resolved "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz"
@@ -6850,6 +7036,14 @@ socket.io-parser@~4.2.4:
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.4.1"
+
+socks@^2.6.2:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.9.tgz#aa5f130ca0f88a43fa44faf4869c50d22aa27752"
+  integrity sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==
+  dependencies:
+    ip-address "^10.1.1"
+    smart-buffer "^4.2.0"
 
 sonic-boom@^2.2.1:
   version "2.8.0"
@@ -6902,6 +7096,11 @@ stack-utils@^2.0.6:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+store2@^2.13.0:
+  version "2.14.4"
+  resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.4.tgz#81b313abaddade4dcd7570c5cc0e3264a8f7a242"
+  integrity sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==
 
 stream-browserify@^3.0.0:
   version "3.0.0"
@@ -7142,6 +7341,29 @@ tailwindcss@^3.4.14:
     resolve "^1.22.8"
     sucrase "^3.35.0"
 
+telegram@^2.26.22:
+  version "2.26.22"
+  resolved "https://registry.yarnpkg.com/telegram/-/telegram-2.26.22.tgz#16beb73e52403b5d5bcc4602226e39dc24217333"
+  integrity sha512-EIj7Yrjiu0Yosa3FZ/7EyPg9s6UiTi/zDQrFmR/2Mg7pIUU+XjAit1n1u9OU9h2oRnRM5M+67/fxzQluZpaJJg==
+  dependencies:
+    "@cryptography/aes" "^0.1.1"
+    async-mutex "^0.3.0"
+    big-integer "^1.6.48"
+    buffer "^6.0.3"
+    htmlparser2 "^6.1.0"
+    mime "^3.0.0"
+    node-localstorage "^2.2.1"
+    pako "^2.0.3"
+    path-browserify "^1.0.1"
+    real-cancellable-promise "^1.1.1"
+    socks "^2.6.2"
+    store2 "^2.13.0"
+    ts-custom-error "^3.2.0"
+    websocket "^1.0.34"
+  optionalDependencies:
+    bufferutil "^4.0.3"
+    utf-8-validate "^5.0.5"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz"
@@ -7249,6 +7471,11 @@ ts-api-utils@^2.4.0:
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz"
   integrity sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==
 
+ts-custom-error@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/ts-custom-error/-/ts-custom-error-3.3.1.tgz#8bd3c8fc6b8dc8e1cb329267c45200f1e17a65d1"
+  integrity sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==
+
 ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
@@ -7279,7 +7506,7 @@ tslib@2.7.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
-tslib@^2.4.0, tslib@^2.6.0:
+tslib@^2.3.1, tslib@^2.4.0, tslib@^2.6.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -7311,6 +7538,11 @@ type-fest@^4.41.0:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz"
   integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
+type@^2.7.2:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.7.3.tgz#436981652129285cc3ba94f392886c2637ea0486"
+  integrity sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==
+
 typed-array-buffer@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz"
@@ -7319,6 +7551,13 @@ typed-array-buffer@^1.0.3:
     call-bound "^1.0.3"
     es-errors "^1.3.0"
     is-typed-array "^1.1.14"
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
 
 typescript-eslint@^8.57.2:
   version "8.57.2"
@@ -7478,7 +7717,7 @@ use-sync-external-store@^1.6.0:
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
-utf-8-validate@^5.0.2:
+utf-8-validate@^5.0.2, utf-8-validate@^5.0.5:
   version "5.0.10"
   resolved "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz"
   integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
@@ -7599,6 +7838,18 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
+websocket@^1.0.34:
+  version "1.0.35"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.35.tgz#374197207d7d4cc4c36cbf8a1bb886ee52a07885"
+  integrity sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==
+  dependencies:
+    bufferutil "^4.0.1"
+    debug "^2.2.0"
+    es5-ext "^0.10.63"
+    typedarray-to-buffer "^3.1.5"
+    utf-8-validate "^5.0.2"
+    yaeti "^0.0.6"
+
 whatwg-encoding@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz"
@@ -7717,6 +7968,15 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
+write-file-atomic@^1.1.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+  integrity sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
+
 write-file-atomic@^2.0.0:
   version "2.4.3"
   resolved "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz"
@@ -7791,6 +8051,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+  integrity sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Phase 4-ish of [poker-vm#1492](https://github.com/block52/poker-vm/issues/1492). Closes #374.

Once this ships, [poker-vm#2125](https://github.com/block52/poker-vm/issues/2125) (Phase 2b — seat invite/kick) is unblocked.

## Summary
- New \`/tg\` route → \`LinkTelegramPage\`. Renders a QR code; user scans with their phone Telegram → fully-authorized MTProto session in the browser. Same flow as web.telegram.org.
- New \`BrokerApi\` class + \`BrokerApiContext\` / \`useBrokerApi\` hook, following the existing IndexerApi/PaymentApi pattern. Exposes \`postBinding({ walletAddress, tgUserId, tgUsername })\`.
- Session persisted as a gramjs \`StringSession\` blob in \`localStorage\` keyed by Cosmos address (\`telegram_session:<b52...>\`). Survives reload.
- **gramjs is dynamic-imported on mount of \`/tg\`** — splits into a separate ~800 KB chunk, so the main bundle is unchanged for everyone who never visits the page.

## Env vars (new)
\`\`\`
VITE_TG_API_ID=...          # int, from https://my.telegram.org
VITE_TG_API_HASH=...        # hex string, from https://my.telegram.org
VITE_TG_BROKER_URL=http://localhost:8089
\`\`\`
Register a **separate** TG app for the FE — don't reuse the broker's credentials.

## Placement
The route is reachable directly at \`/tg\`. No header/menu link yet — agreed in the design discussion to iterate on placement once the flow is working end-to-end.

## What this PR does NOT do
- 2FA retry loop (gramjs may call the password callback more than once; current code resolves it once and the user has to hit \"Try again\" to reload the flow). Phase 4 polish.
- Unlink button. Phase 4 polish.
- Chat panel in the table view. Separate, later.

## Verification — what I actually checked (be skeptical of the rest)
- ✅ \`yarn build\` (\`tsc -b && vite build\`) succeeds. Bundle split shows \`sessions-*.js\` (gramjs) and \`crypto-browserify-*.js\` as separate chunks — main bundle unchanged.
- ✅ \`yarn lint:fix\` — 0 new errors from this PR. One pre-existing react-refresh warning on the new context file, same kind as every other ApiContext file.
- ✅ \`yarn dev\` boots; \`GET /tg\` returns 200; Vite serves the transformed page (32 KB, contains the expected symbols).
- ✅ Vite's optimized gramjs chunk (1.3 MB) loads on direct request; the underlying CJS \`exports.TelegramClient\` is present.
- ⚠️  **Vite's dep optimizer wraps gramjs (CommonJS) as a default-only export** — \`import { TelegramClient } from \"telegram\"\` would resolve to \`undefined\` at runtime, even though TS believes it's fine. The second commit on this PR fixes it by destructuring off \`.default\`. **Caught from inspecting the optimized chunk, not from a real browser session.**
- ❌ **Not yet verified end-to-end in a browser.** gramjs in the browser needs Buffer/process shims. Vite's rolldown variant *appears* to inline these (the chunk has 300+ \`Buffer.\` references and zero \`require(\"node:…\")\`), but I have not clicked through the QR flow against a real Telegram account. **Reviewer: this is the highest-risk part of the PR.**

## Test plan
- [ ] \`cp .env.example .env\`, fill TG creds, start the Go broker (block52/poker-vm:bot/tg-broker on \`:8089\`)
- [ ] \`yarn dev\` → visit \`http://localhost:5173/tg\`
- [ ] Import a Cosmos seed (so \`useCosmosWallet\` returns an address)
- [ ] Click \"Start QR login\" → QR renders
- [ ] **Check browser console** for any Buffer/process polyfill errors — this is the unverified bit
- [ ] Scan with phone Telegram → page reaches \"Linked\" state, broker shows a new \`bindings\` row
- [ ] Reload \`/tg\` → session is restored from localStorage (no re-prompt)
- [ ] 2FA account: same flow, password input appears before \"Linked\"

If the browser-console step fails with polyfill errors, the fix is usually \`vite-plugin-node-polyfills\` in \`vite.config.ts\`. Happy to land that as a follow-up commit on this PR once we know which polyfills are actually missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)