### PR TITLE
fix(sng): inline leave-confirm in waiting modal, chip-aware stack display

### DIFF
--- a/src/components/playPage/SitAndGoWaitingModal.tsx
+++ b/src/components/playPage/SitAndGoWaitingModal.tsx
@@ -4,19 +4,52 @@
  * Displays a modal for players who have joined a Sit & Go tournament
  * and are waiting for more players to fill the table before the game starts.
  */
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useGameOptions } from "../../hooks/game/useGameOptions";
 import { useVacantSeatData } from "../../hooks/game/useVacantSeatData";
 import { getGameTypeMnemonic } from "../../utils/gameFormatUtils";
+import { formatSitAndGoStackString } from "../../utils/numberUtils";
 import styles from "./SitAndGoWaitingModal.module.css";
 
 interface SitAndGoWaitingModalProps {
-    onLeaveClick?: () => void;
+    onLeaveConfirm?: () => Promise<void>;
+    playerStack?: string;
 }
 
-const SitAndGoWaitingModal: React.FC<SitAndGoWaitingModalProps> = ({ onLeaveClick }) => {
+const SitAndGoWaitingModal: React.FC<SitAndGoWaitingModalProps> = ({ onLeaveConfirm, playerStack }) => {
     const { gameOptions } = useGameOptions();
     const { emptySeatIndexes } = useVacantSeatData();
+
+    const [isConfirming, setIsConfirming] = useState(false);
+    const [isLeaving, setIsLeaving] = useState(false);
+    const [leaveError, setLeaveError] = useState<string | null>(null);
+
+    const handleLeaveClick = useCallback(() => {
+        setLeaveError(null);
+        setIsConfirming(true);
+    }, []);
+
+    const handleCancel = useCallback(() => {
+        setIsConfirming(false);
+        setLeaveError(null);
+    }, []);
+
+    const handleConfirm = useCallback(async () => {
+        if (!onLeaveConfirm) return;
+        setIsLeaving(true);
+        setLeaveError(null);
+        try {
+            await onLeaveConfirm();
+        } catch (err) {
+            console.error("Error leaving SNG table:", err);
+            setLeaveError(err instanceof Error ? err.message : "Failed to leave table. Please try again.");
+            setIsLeaving(false);
+        }
+    }, [onLeaveConfirm]);
+
+    const chipsLabel = playerStack !== undefined ? formatSitAndGoStackString(playerStack) : null;
+    const buyInLabel = gameOptions?.startingStack ? formatSitAndGoStackString(gameOptions.startingStack) : null;
+    const canShowLeaveUi = onLeaveConfirm !== undefined && playerStack !== undefined;
 
     // Calculate players joined
     const playersJoined = useMemo(() => {
@@ -108,16 +141,56 @@ const SitAndGoWaitingModal: React.FC<SitAndGoWaitingModalProps> = ({ onLeaveClic
                         </div>
                     </div>
 
-                    
-                    {/* Leave Game Button */}
-                    {onLeaveClick && (
+
+                    {/* Leave Game — inline two-step confirmation (no separate modal) */}
+                    {canShowLeaveUi && !isConfirming && (
                         <div className="mb-4">
                             <button
-                                onClick={onLeaveClick}
+                                onClick={handleLeaveClick}
                                 className="w-full py-2 px-4 rounded-lg border border-red-500/40 bg-red-500/10 text-red-400 text-sm font-medium hover:bg-red-500/20 hover:border-red-500/60 transition-colors duration-200"
                             >
                                 Leave Game
                             </button>
+                        </div>
+                    )}
+
+                    {canShowLeaveUi && isConfirming && (
+                        <div className="mb-4 bg-gray-700/80 backdrop-blur-sm rounded-lg p-4 border border-red-500/40">
+                            <p className="text-white text-sm font-semibold mb-3 text-center">Leave this tournament?</p>
+
+                            <div className="space-y-1.5 mb-3">
+                                <div className="flex justify-between items-center text-sm">
+                                    <span className="text-gray-400">Your Chips:</span>
+                                    <span className="text-white font-bold">{chipsLabel}</span>
+                                </div>
+                                {buyInLabel && (
+                                    <div className="flex justify-between items-center text-xs">
+                                        <span className="text-gray-500">Buy-In:</span>
+                                        <span className="text-gray-300">{buyInLabel}</span>
+                                    </div>
+                                )}
+                            </div>
+
+                            {leaveError && (
+                                <p className="text-red-400 text-xs mb-3 text-center break-words">{leaveError}</p>
+                            )}
+
+                            <div className="flex flex-col space-y-2">
+                                <button
+                                    onClick={handleConfirm}
+                                    disabled={isLeaving}
+                                    className="w-full py-2 px-4 rounded-lg border border-red-500/60 bg-red-500/20 text-red-300 text-sm font-medium hover:bg-red-500/30 hover:border-red-500/80 transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
+                                >
+                                    {isLeaving ? "Leaving..." : "Confirm Leave"}
+                                </button>
+                                <button
+                                    onClick={handleCancel}
+                                    disabled={isLeaving}
+                                    className="w-full py-2 px-4 rounded-lg border border-gray-500/40 bg-gray-600/30 text-gray-300 text-sm font-medium hover:bg-gray-600/50 transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
+                                >
+                                    Cancel
+                                </button>
+                            </div>
                         </div>
                     )}
 

--- a/src/components/playPage/Table/components/TableModals.tsx
+++ b/src/components/playPage/Table/components/TableModals.tsx
@@ -58,7 +58,6 @@ export const TableModals: React.FC<TableModalsProps> = ({
     tableId,
     onAutoJoinSuccess,
     isSitAndGoWaitingForPlayers,
-    handleLeaveTableClick,
     recentTxHash,
     handleCloseTransactionPopup,
     isLeaveModalOpen,
@@ -80,7 +79,12 @@ export const TableModals: React.FC<TableModalsProps> = ({
             )}
 
             {/* Sit & Go Waiting Modal - Shows for Sit & Go games when user is playing but waiting for more players */}
-            {isSitAndGoWaitingForPlayers && <SitAndGoWaitingModal onLeaveClick={handleLeaveTableClick} />}
+            {isSitAndGoWaitingForPlayers && (
+                <SitAndGoWaitingModal
+                    onLeaveConfirm={handleLeaveTableConfirm}
+                    playerStack={currentPlayerStack}
+                />
+            )}
 
             {/* Sit & Go Result Modal - Self-gates on the user having a tournament
                 result in gameState.results[]. Skips the LeaveTableModal confirm

--- a/src/utils/numberUtils.ts
+++ b/src/utils/numberUtils.ts
@@ -158,6 +158,17 @@ export const formatForSitAndGo = (value: number): string => {
 };
 
 /**
+ * Format a Sit & Go chip-stack string (the on-the-wire DTO form — Commandment 9)
+ * for display, bridging string → number → "1,500"-style output in one place so
+ * call sites don't repeat bare `Number(...)` casts (Commandment 12).
+ * @param stack Stack value as a string in chip units (NOT USDC microunits)
+ * @returns Formatted string like "1,500" or "10,000"
+ */
+export const formatSitAndGoStackString = (stack: string): string => {
+    return formatForSitAndGo(Number(stack));
+};
+
+/**
  * Format stack values for Cash Games
  * Shows with dollar sign and 2 decimal places
  * @param value The stack value as a number


### PR DESCRIPTION
## Summary

Closes #270.

Clicking **Leave Game** on the SNG `Waiting for Players` modal opened the cash-game `LeaveTableModal`, which formatted the player's chip-unit stack (e.g. `1500`) through `formatUSDCToSimpleDollars` — yielding `$0.00` — and showed an irrelevant **⚠️ Active Hand Warning** before the tournament had started.

This PR builds an inline two-step confirmation **directly inside `SitAndGoWaitingModal.tsx`** (per the issue's proposed fix), so the cash-game `LeaveTableModal` stays untouched and never has to know about SNG chip units.

- `SitAndGoWaitingModal` props change from `onLeaveClick: () => void` to `onLeaveConfirm: () => Promise<void>` + `playerStack: string`. Local state (`isConfirming` / `isLeaving` / `leaveError`) drives an inline confirmation panel inside the same modal card — no separate overlay.
- Chip count and buy-in render via a new `formatSitAndGoStackString(stack: string)` util in `numberUtils.ts` that centralises the `formatForSitAndGo(Number(x))` pattern (Commandment 12 — NO Inline Casting). Other call sites (`Chip.tsx`, `Badge.tsx`, `SitAndGoAutoJoinModal.tsx`) intentionally untouched in this PR to keep scope tight; they can migrate in a follow-up.
- `TableModals.tsx` wires `onLeaveConfirm={handleLeaveTableConfirm}` + `playerStack={currentPlayerStack}` to the SNG-waiting branch. The cash-game `LeaveTableModal` rendering (action-bar leave button) is unchanged.
- No `Active Hand Warning` in the SNG flow; chain errors surface inline below the buttons.

## Test plan

- [ ] Create an SNG with `minPlayers: 2, maxPlayers: 4, startingStack: 1500`
- [ ] Join from one wallet so the table is at `1/4`
- [ ] On the waiting modal, click **Leave Game** — assert an inline confirmation panel replaces the leave button (no separate modal opens)
- [ ] Assert the panel shows `Your Chips: 1,500` and `Buy-In: 1,500` — **not** `\$0.00`
- [ ] Assert **no** "⚠️ Active Hand Warning" block is rendered
- [ ] Click **Cancel** → reverts to the original waiting UI with the Leave Game button
- [ ] Click **Leave Game** again → **Confirm Leave** → wallet signs, leave broadcasts, table unmounts
- [ ] Error path: stop the Cosmos node before confirming → assert a red error appears under the buttons and both buttons re-enable
- [ ] Cash-game regression: open a cash table → click the right-side action-bar leave button → assert the original `LeaveTableModal` still opens with `\$X.XX` formatting and (when applicable) the active-hand warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)