### PR TITLE
issue-351

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "=https://paymentservice.texashodl.net",
   "dependencies": {
-    "@block52/poker-vm-sdk": "1.2.0",
+    "@block52/poker-vm-sdk": "^1.2.0",
     "@metamask/sdk": "^0.34.0",
     "@reown/appkit": "1.6.7",
     "@reown/appkit-adapter-ethers": "1.6.7",

--- a/src/components/playPage/Table.css
+++ b/src/components/playPage/Table.css
@@ -58,7 +58,7 @@
 }
 
 .animate-fall {
-    animation: fall 0.5s ease-out forwards;
+    animation: fall 1.0s ease-out both;
 }
 
 /* Animation classes */

--- a/src/components/playPage/Table/components/TableBoard.tsx
+++ b/src/components/playPage/Table/components/TableBoard.tsx
@@ -42,16 +42,37 @@ export const TableBoard: React.FC<TableBoardProps> = ({
 }) => {
     // Memoize community cards rendering
     const communityCardsElements = useMemo(() => {
+        // Count how many contiguous real cards exist from position 0.
+        // Prevents out-of-order reveals when the backend sends intermediate states
+        // (e.g. turn revealed before flop during all-in runout).
+        let contiguousCount = 0;
+        for (let i = 0; i < 5; i++) {
+            const c = communityCards[i];
+            if (c && c !== "??" && c !== "XX") {
+                contiguousCount = i + 1;
+            } else {
+                break;
+            }
+        }
+
         return Array.from({ length: 5 }).map((_, idx) => {
-            if (idx < communityCards.length) {
-                const card = communityCards[idx];
+            const card = communityCards[idx];
+            const isVisible = idx < contiguousCount && card && card !== "??" && card !== "XX";
+
+            if (isVisible) {
                 return (
-                    <div key={idx} className="card animate-fall">
+                    <div key={`${idx}-${card}`} className="card animate-fall" style={{ animationDelay: `${idx * 150}ms` }}>
                         <OppositePlayerCards frontSrc={getCardImageUrl(card)} backSrc={getCardBackUrl(cardBackStyle)} flipped />
                     </div>
                 );
             } else {
-                return <div key={idx} className="w-[85px] h-[127px] aspect-square border-[0.5px] border-dashed border-white rounded-[5px] " style={{ borderColor: "rgba(255,255,255,0.35)" }} />;
+                return (
+                    <div
+                        key={idx}
+                        className="w-[85px] h-[127px] aspect-square border-[0.5px] border-dashed border-white rounded-[5px] "
+                        style={{ borderColor: "rgba(255,255,255,0.35)" }}
+                    />
+                );
             }
         });
     }, [communityCards, cardBackStyle]);
@@ -60,11 +81,7 @@ export const TableBoard: React.FC<TableBoardProps> = ({
         <>
             {/* Club Logo */}
             <div className={`table-logo ${tableTheme === "nouns" ? "table-logo-nouns" : ""}`}>
-                {tableTheme === "nouns" ? (
-                    <NounsGlasses width={300} className="nouns-glasses-logo" />
-                ) : (
-                    <img src={clubLogo} alt="Club Logo" />
-                )}
+                {tableTheme === "nouns" ? <NounsGlasses width={300} className="nouns-glasses-logo" /> : <img src={clubLogo} alt="Club Logo" />}
             </div>
 
             {/* Central Display Area */}

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,7 +306,7 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@block52/poker-vm-sdk@1.2.0":
+"@block52/poker-vm-sdk@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.2.0.tgz#5355ae99b34b663cf692a938f8a7c6a94fdafcee"
   integrity sha512-nvfJwgMPCDY9cNUV9BgkGbeEe6NZ/gPdXaThEZICCoCuSHoVx1Bssajedx6uoDLK/kfAWljt/nxlg5mrAsS+cQ==


### PR DESCRIPTION
Prevent out-of-order community card reveals by only showing contiguous real cards (handles backend intermediate states) and include card value in keys. Add staggered animation delays for a smoother fall effect and extend the fall animation timing. Also relax @block52/poker-vm-sdk version to a caret range and tidy up a small JSX conditional for the club logo.