### PR TITLE
feat: inline deposit flow in BuyInModal when balance is short

### DIFF
--- a/src/components/modals/BuyInModal.tsx
+++ b/src/components/modals/BuyInModal.tsx
@@ -12,6 +12,7 @@ import { useNetwork } from "../../context/NetworkContext";
 import { useGameStateContext } from "../../context/GameStateContext";
 import { getBlindsForDisplay } from "../../utils/gameFormatUtils";
 import { GameFormat } from "@block52/poker-vm-sdk";
+import DepositCore from "./DepositCore";
 import styles from "./BuyInModal.module.css";
 
 import type { BuyInModalProps } from "./types";
@@ -102,16 +103,19 @@ const BuyInModal: React.FC<BuyInModalProps> = React.memo(({ onClose, onJoin, tab
     const viewTableDisabled = exceedsBalance;
     const takeSeatDisabled = !canJoinRandomSeat || exceedsBalance;
 
+    // When balance is below the minimum buy-in, the modal swaps the
+    // buy-in form for the deposit flow inline. balance refreshes after
+    // a successful deposit (DepositCore calls refreshBalance), so this
+    // flips back automatically once the user has funded enough.
+    // block52/ui#378
+    const needsDeposit = balanceFormatted < minBuyInNumber;
+
     // Memoized event handlers
     const handleBuyInChange = useCallback((amount: string) => {
         setBuyInAmount(amount);
         setBuyInError("");
         localStorage.setItem("buy_in_amount", amount);
     }, []);
-
-    const handleDepositClick = useCallback(() => {
-        navigate("/");
-    }, [navigate]);
 
     const handleJoinClick = useCallback(() => {
         try {
@@ -305,6 +309,19 @@ const BuyInModal: React.FC<BuyInModalProps> = React.memo(({ onClose, onJoin, tab
                     )}
                 </div>
 
+                {needsDeposit ? (
+                    /* Inline deposit flow when balance is below minimum buy-in.
+                       DepositCore refreshes the wallet on success, which causes
+                       `needsDeposit` to flip false and the buy-in form to
+                       replace this block automatically. block52/ui#378 */
+                    <div className="mb-6">
+                        <div className={`mb-4 p-3 rounded-lg text-sm ${styles.depositLink}`}>
+                            You need at least ${minBuyInFormatted} to join this table. Deposit to continue.
+                        </div>
+                        <DepositCore showMethodSelector />
+                    </div>
+                ) : (
+                <>
                 {/* Stake Dropdown */}
                 <div className="mb-6">
                     <label className="block text-gray-300 mb-1 font-medium text-sm">Select Stake</label>
@@ -406,15 +423,16 @@ const BuyInModal: React.FC<BuyInModalProps> = React.memo(({ onClose, onJoin, tab
                         {isJoiningRandomSeat ? "Joining..." : "Take My Seat"}
                     </button>
                 </div>
+                </>
+                )}
 
-                {isDisabled && (
-                    <div className={`text-sm mb-4 ${styles.balanceError}`}>
-                        Your available balance does not reach the minimum buy-in amount for this game. Please{" "}
-                        <span className={`underline cursor-pointer ${styles.depositLink}`} onClick={handleDepositClick}>
-                            deposit
-                        </span>{" "}
-                        to continue.
-                    </div>
+                {needsDeposit && (
+                    <button
+                        onClick={onClose}
+                        className={`w-full mb-4 px-5 py-3 rounded-lg text-white font-medium transition-all duration-200 ${styles.cancelButton}`}
+                    >
+                        Cancel
+                    </button>
                 )}
 
                 <div className={`text-xs ${styles.noteText}`}>


### PR DESCRIPTION
Closes #378.

## Summary
When a player opens the buy-in modal with USDC balance < minBuyIn, the modal now shows the deposit flow (\`<DepositCore />\`) inline instead of a link that redirected to \`/\`. After a successful deposit, \`DepositCore\` refreshes the wallet balance; that flips the condition and the buy-in form returns automatically. Single modal, two-step flow.

## Why this shape (per discussion on #378)
- **No second modal.** Stays in the BuyInModal user already opened.
- **No auto-open on table arrival.** Trigger is unchanged — clicking a seat / SNG auto-join.
- **\"Insufficient\" = \`balance < minBuyIn\`.** If they have enough for the minimum, the buy-in form shows.
- **They aren't seated during the deposit.** Only land on a seat after they click Join in the buy-in mode.

## Changes
- \`BuyInModal.tsx\` — single block conditional on \`needsDeposit\`:
  - **Deposit mode:** info banner + \`<DepositCore showMethodSelector />\` + Cancel button.
  - **Buy-in mode:** existing stake select / amount input / wait-for-bb / action buttons (unchanged).
- Removed the old \`handleDepositClick\` (which navigated to \`/\`) and the dead balance-error link block underneath the buttons.

## What's deliberately the same
- Balances panel at the top of the modal renders in both modes — useful so users see the current state during the deposit and after it lands.
- \`useNavigate\` / \`navigate\` stays because \`handleRandomSeatJoin\` uses it for the post-join redirect.
- \`isDisabled\` stays because \`canJoinRandomSeat\` reads it; semantically equivalent to \`needsDeposit\` now, but renaming for renaming's sake isn't worth the churn.

## Verification
- \`yarn build\` — clean.
- \`yarn lint\` — 0 new errors. The three pre-existing warnings on this file (\`smallBlind\` unused, two \`_error\` unused) are unrelated and predate this change.
- Couldn't smoke in the dev server — port 5173 had another project's vite on it locally and I didn't want to kill yours. Build evidence is sufficient that the JSX is well-formed; the only failure mode static checks can't reach is whether \`DepositCore\` looks visually right inside the slightly narrower BuyInModal container. Worth eyeballing.

## Test plan
- [ ] Open a table you can't afford → click an empty seat → buy-in modal opens directly into the deposit flow (no separate modal pop)
- [ ] Complete a USDC deposit → balance refreshes → modal swaps to the buy-in form automatically
- [ ] Click Join → seated as normal
- [ ] Cancel during deposit mode → modal closes, no orphan state
- [ ] Open the table when you already have enough → buy-in form shows immediately, no deposit step

🤖 Generated with [Claude Code](https://claude.com/claude-code)