### PR TITLE
feat(sng): wire real chain fetch for SNG claim-signature (#2119)

### DIFF
--- a/src/hooks/game/useFetchSngClaimSignature.test.tsx
+++ b/src/hooks/game/useFetchSngClaimSignature.test.tsx
@@ -1,0 +1,141 @@
+import { renderHook } from "@testing-library/react";
+import { useFetchSngClaimSignature } from "./useFetchSngClaimSignature";
+
+jest.mock("../../context/NetworkContext", () => ({
+    useNetwork: () => ({
+        currentNetwork: {
+            name: "test",
+            rpc: "http://localhost:26657",
+            rest: "https://node1.example.com",
+            grpc: "localhost:9090",
+            ws: "ws://localhost:26657/websocket",
+        },
+    }),
+}));
+
+jest.mock("../../utils/cosmos/urls", () => ({
+    getCosmosUrls: (net: { rest: string }) => ({
+        rpcEndpoint: "http://localhost:26657",
+        restEndpoint: net.rest,
+    }),
+}));
+
+// Helper to fake a Response — TS doesn't have a public constructor
+// shape for Response in node, so this is the cleanest path.
+const fakeResponse = (overrides: Partial<Response>) => overrides as unknown as Response;
+
+describe("useFetchSngClaimSignature", () => {
+    const fetchMock = jest.fn();
+    const originalFetch = global.fetch;
+
+    beforeAll(() => {
+        global.fetch = fetchMock as unknown as typeof global.fetch;
+    });
+    afterAll(() => {
+        global.fetch = originalFetch;
+    });
+    beforeEach(() => {
+        fetchMock.mockReset();
+    });
+
+    const renderFetch = () => {
+        const { result } = renderHook(() => useFetchSngClaimSignature());
+        return result.current.fetchSignature;
+    };
+
+    it("hits the canonical chain endpoint with url-encoded params", async () => {
+        fetchMock.mockResolvedValueOnce(fakeResponse({
+            ok: true,
+            statusText: "OK",
+            json: async () => ({
+                recipient: "0xabc",
+                game_id: "0xdef",
+                place: 1,
+                payout: "1000000",
+                timestamp: "1747300000",
+                format: "0xff",
+                signature: "0xsig",
+            }),
+        }));
+
+        const fn = renderFetch();
+        await fn("0xdef", "b521xxx");
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][0]).toBe(
+            "https://node1.example.com/block52/pokerchain/poker/v1/sng_claim_signature/0xdef/b521xxx",
+        );
+    });
+
+    it("translates the chain's snake_case response into the typed SngClaimPayload (timestamp as number)", async () => {
+        fetchMock.mockResolvedValueOnce(fakeResponse({
+            ok: true,
+            statusText: "OK",
+            json: async () => ({
+                recipient: "0xabc",
+                game_id: "0xdef",
+                place: 2,
+                payout: "400000",
+                timestamp: "1747300000",
+                format: "0xff",
+                signature: "0xsig",
+            }),
+        }));
+
+        const fn = renderFetch();
+        const payload = await fn("0xdef", "b521xxx");
+        expect(payload).toEqual({
+            recipient: "0xabc",
+            gameId: "0xdef",
+            place: 2,
+            payout: "400000",
+            timestamp: 1747300000,
+            format: "0xff",
+            signature: "0xsig",
+        });
+    });
+
+    it("surfaces the chain's structured error message on a 4xx", async () => {
+        fetchMock.mockResolvedValueOnce(fakeResponse({
+            ok: false,
+            statusText: "Bad Request",
+            json: async () => ({
+                code: 3,
+                message: "unpaid finish at place 4 — no NFT to claim",
+            }),
+        }));
+
+        const fn = renderFetch();
+        await expect(fn("0xdef", "b521xxx")).rejects.toThrow(
+            /unpaid finish at place 4/,
+        );
+    });
+
+    it("throws when the chain returns ok but with no signature (defensive)", async () => {
+        fetchMock.mockResolvedValueOnce(fakeResponse({
+            ok: true,
+            statusText: "OK",
+            json: async () => ({}),
+        }));
+
+        const fn = renderFetch();
+        await expect(fn("0xdef", "b521xxx")).rejects.toThrow(
+            /empty SNG claim signature payload/,
+        );
+    });
+
+    it("falls back to statusText when the error body isn't JSON", async () => {
+        fetchMock.mockResolvedValueOnce(fakeResponse({
+            ok: false,
+            statusText: "Service Unavailable",
+            json: async () => {
+                throw new Error("not json");
+            },
+        }));
+
+        const fn = renderFetch();
+        await expect(fn("0xdef", "b521xxx")).rejects.toThrow(
+            /Service Unavailable/,
+        );
+    });
+});

--- a/src/hooks/game/useFetchSngClaimSignature.ts
+++ b/src/hooks/game/useFetchSngClaimSignature.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useNetwork } from "../../context/NetworkContext";
+import { getCosmosUrls } from "../../utils/cosmos/urls";
 
 /**
  * Validator-signed payload returned by the chain for a SitAndGo win
@@ -18,39 +19,63 @@ export interface SngClaimPayload {
 }
 
 /**
+ * Shape returned by the chain's REST gateway. snake_case + payload
+ * fields as strings/numbers. Translated to {@link SngClaimPayload}
+ * (0x-typed branded strings) before handing off to the contract.
+ */
+interface ChainResponse {
+    recipient: string;
+    game_id: string;
+    place: number;
+    payout: string;
+    timestamp: string;  // gateway encodes uint64 as a JSON string
+    format: string;
+    signature: string;
+}
+
+/**
  * Fetches a validator-signed claim payload for the current user's
  * SNG win. Powers the "Claim NFT" button on {@link SitAndGoResultModal}.
  *
- * **Backend endpoint not yet live.** This hook is shipped alongside
- * the UI for [block52/poker-vm#2119] piece 3; the chain-side query
- * endpoint (piece 2) is the next deliverable from that issue.
- * Once piece 2 lands, this hook hits
- *   GET /poker/v1/sng_claim_signature?gameId=…&address=…
- * and returns the parsed payload. Until then the hook throws a
- * structured error that the modal renders as "Feature coming soon".
+ * Hits the chain query landed in
+ *   GET /block52/pokerchain/poker/v1/sng_claim_signature/{game_id}/{cosmos_address}
+ *
+ * (See block52/pokerchain#202.) The chain returns 4xx-ish errors as
+ * JSON `{ code, message }`; we surface message as the thrown Error
+ * so the modal's existing error-line treatment shows something
+ * useful instead of a raw `fetch failed`.
  */
 export const useFetchSngClaimSignature = () => {
     const { currentNetwork } = useNetwork();
 
     const fetchSignature = useCallback(
         async (gameId: string, address: string): Promise<SngClaimPayload> => {
-            // TODO(block52/poker-vm#2119, piece 2): swap this stub for
-            // a real GET against
-            //   `${currentNetwork.rest}/block52/pokerchain/poker/v1/sng_claim_signature`
-            // with query params { gameId, address }. The chain handler
-            // verifies the user finished paid + signs with the
-            // validator_eth_private_key, returning the payload above.
-            //
-            // For now we surface a clear "not yet available" error so
-            // the UI shows a sensible message instead of dispatching
-            // a zero-address tx.
-            void currentNetwork;
-            void gameId;
-            void address;
-            throw new Error(
-                "SNG win-NFT claim endpoint not yet deployed on the chain " +
-                "(tracked in block52/poker-vm#2119 piece 2). Check back once it ships.",
-            );
+            const { restEndpoint } = getCosmosUrls(currentNetwork);
+            const url = `${restEndpoint}/block52/pokerchain/poker/v1/sng_claim_signature/${encodeURIComponent(gameId)}/${encodeURIComponent(address)}`;
+
+            const response = await fetch(url);
+            const raw = await response.json().catch(() => ({}));
+
+            if (!response.ok) {
+                // Cosmos REST gateway error shape: { code, message, details }
+                const msg = typeof raw?.message === "string" ? raw.message : response.statusText;
+                throw new Error(`Failed to fetch SNG claim signature: ${msg}`);
+            }
+
+            const data = raw as ChainResponse;
+            if (!data.signature || !data.recipient) {
+                throw new Error("Chain returned an empty SNG claim signature payload");
+            }
+
+            return {
+                recipient: data.recipient as `0x${string}`,
+                gameId: data.game_id as `0x${string}`,
+                place: data.place,
+                payout: data.payout,
+                timestamp: Number(data.timestamp),
+                format: data.format as `0x${string}`,
+                signature: data.signature as `0x${string}`,
+            };
         },
         [currentNetwork],
     );


### PR DESCRIPTION
Final UI wiring for the SNG-win-NFT feature.

The chain endpoint shipped in [block52/pokerchain#202](https://github.com/block52/pokerchain/pull/202) and was deployed today. This PR swaps the "not yet live" stub in `useFetchSngClaimSignature` for the real GET against it. The Claim NFT button in [#373](https://github.com/block52/ui/pull/373) already calls this hook, so post-merge the only thing standing between us and a working flow is the contract deployment.

## What changed

`src/hooks/game/useFetchSngClaimSignature.ts` — replaced the placeholder `throw` with a `fetch()` against:

```
GET ${restEndpoint}/block52/pokerchain/poker/v1/sng_claim_signature/{gameId}/{cosmosAddress}
```

Translates the chain's snake_case JSON into the typed `SngClaimPayload` the UI already expects:

- `recipient` / `gameId` / `format` → `0x`-prefixed branded strings
- `timestamp` → cast from chain's JSON-uint64 string to number
- `payout` → left as decimal string (UI consumes via `BigInt()`)

Error handling:

| Chain returns | Hook does |
|---|---|
| `200 OK` with full payload | Returns typed `SngClaimPayload` |
| `200 OK` with missing signature/recipient | Throws `"Chain returned an empty SNG claim signature payload"` (defensive) |
| `4xx` with `{ code, message }` body | Throws the `message` (modal renders in error slot) |
| `4xx` with non-JSON body | Falls back to `response.statusText` |

## Tests

`src/hooks/game/useFetchSngClaimSignature.test.tsx` — 5 new cases:

| # | Case |
|---|---|
| 1 | Canonical URL is hit with url-encoded path params |
| 2 | Response translation: snake_case → typed `SngClaimPayload` + timestamp string→number |
| 3 | Structured 4xx error message surfaces to the thrown `Error` |
| 4 | 2xx with empty payload throws the defensive guard |
| 5 | Non-JSON 4xx body falls back to `statusText` |

Mocks `global.fetch` directly (jsdom doesn't ship it). All 5 pass; full suite 770/770 green.

## What remains for end-to-end

This is the **last UI PR for #2119**. After merge:

1. **Deploy `SngWinNFT.sol`** to Ethereum Mainnet (uses your deployer key — out of CI scope).
2. **One-line PR** to set `SNG_WIN_NFT_ADDRESS` in `src/config/constants.ts` to the deployed address.
3. **Manual smoke**: SNG → finish in paid place → click Claim NFT → confirm in MetaMask → NFT in wallet.

## Diff shape

```
src/hooks/game/useFetchSngClaimSignature.ts       | +49 / -24
src/hooks/game/useFetchSngClaimSignature.test.tsx | new file, 141 lines
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)