### PR TITLE
test(sng): update payout test to 4-entrant curve to unbreak CI

### DIFF
--- a/src/hooks/game/useSitAndGoPayouts.test.ts
+++ b/src/hooks/game/useSitAndGoPayouts.test.ts
@@ -77,13 +77,13 @@ describe("useSitAndGoPayouts", () => {
         ]);
     });
 
-    it("3 players: 70/30 split", () => {
-        const options = buildOptions({ minBuyIn: "10000000", maxPlayers: 3 });
+    it("4 players: 70/30 split", () => {
+        const options = buildOptions({ minBuyIn: "10000000", maxPlayers: 4 });
         setContext(buildState(options));
         const { result } = renderHook(() => useSitAndGoPayouts());
 
-        expect(result.current.prizePool).toBe("30000000");
-        expect(result.current.places.map(p => p.payout)).toEqual(["21000000", "9000000"]);
+        expect(result.current.prizePool).toBe("40000000");
+        expect(result.current.places.map(p => p.payout)).toEqual(["28000000", "12000000"]);
     });
 
     it("6 players: 65/35 split", () => {


### PR DESCRIPTION
## Summary

- f5a3a92 ("fix(sng): align entrant counts to {2, 4, 6, 9} across UI") replaced the 3-entrant payout curve with a 4-entrant one in `useSitAndGoPayouts` `PAYOUT_CURVES`, but the matching unit test in `useSitAndGoPayouts.test.ts` still asserted a 3-player split. The hook now returns `null` for `maxPlayers: 3`, so the test failed and CI on `main` has been red since that commit.
- Updates the case from `3 players: 70/30 split` to `4 players: 70/30 split` with `maxPlayers: 4`, prize pool `40000000`, and payouts `["28000000", "12000000"]`.

## Test plan

- [x] `yarn test --testPathPatterns=useSitAndGoPayouts` — 7/7 pass
- [x] `yarn test` — 772/772 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)