### PR TITLE
issue-385

### DIFF
--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -1191,7 +1191,7 @@ const Table = React.memo(() => {
                 onClick={() => setTableStyle(s => (s === "modern" ? "classic" : s === "classic" ? "nouns" : "modern"))}
                 style={{
                     position: "fixed",
-                    bottom: 12,
+                    bottom: isMobileLandscape ? 60 : 12,
                     left: 12,
                     zIndex: 999999,
                     padding: "6px 12px",


### PR DESCRIPTION
Increase the bottom offset for the table style toggle in the Table component to 60px when isMobileLandscape is true, leaving other viewports at 12px. This prevents the fixed button from overlapping mobile landscape UI elements.
<img width="1349" height="926" alt="Screenshot 2026-05-21 at 11 22 06 am" src="https://github.com/user-attachments/assets/e40cd373-3ad1-46d0-9ae1-8de3ee3d74b9" />
<img width="932" height="429" alt="Screenshot 2026-05-21 at 11 22 01 am" src="https://github.com/user-attachments/assets/b936ff90-515a-4da7-ac57-3d4279b72e90" />
