### PR TITLE
feat(ui): user toggle to disable 6 o'clock auto-rotation (#392)

### DIFF
--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -763,7 +763,7 @@ const Table = React.memo(() => {
     } = useNextToActInfo(id);
 
     // Enable turn-to-act notifications (tab flashing + optional sound)
-    const { turnNotificationSound, playerActionSounds } = useGameSettings();
+    const { turnNotificationSound, playerActionSounds, seatAtBottom } = useGameSettings();
     useTurnNotification(isCurrentUserTurn, {
         enableSound: turnNotificationSound,
         soundVolume: 0.3,
@@ -959,14 +959,19 @@ const Table = React.memo(() => {
 
     // AUTO-ROTATION: Automatically rotate table when user joins
     // Auto-rotate table so current player is always at bottom (6 o'clock) (#13)
+    // Gated by the seatAtBottom user setting (#392) — when off, render absolute layout.
     // Formula in PlayerSeating: seatNumber = ((positionIndex - startIndex + tableSize) % tableSize) + 1
     // For position 0 (bottom) to show seat S: S = ((0 - startIndex + tableSize) % tableSize) + 1
     // Solving: startIndex = (tableSize - (S - 1)) % tableSize
     useEffect(() => {
+        if (!seatAtBottom) {
+            setStartIndex(0);
+            return;
+        }
         if (currentUserSeat > 0 && tableSize > 0) {
             setStartIndex((tableSize - (currentUserSeat - 1)) % tableSize);
         }
-    }, [currentUserSeat, tableSize]);
+    }, [currentUserSeat, tableSize, seatAtBottom]);
 
     // Winner animations
     const hasWinner = Array.isArray(winnerInfo) && winnerInfo.length > 0;

--- a/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
@@ -31,6 +31,17 @@ jest.mock("../../../../context/GameStateContext", () => ({
     useGameStateContext: () => ({ gameState: { actionCount: 0 } }),
 }));
 
+// Mock GameSettingsContext — the seat-at-bottom toggle added in
+// block52/ui#392 reads from this context. Static stub keeps these
+// render/click tests focused on the existing behaviour.
+const mockToggleSeatAtBottom = jest.fn();
+jest.mock("../../../../context/GameSettingsContext", () => ({
+    useGameSettings: () => ({
+        seatAtBottom: true,
+        toggleSeatAtBottom: mockToggleSeatAtBottom,
+    }),
+}));
+
 // Mock getPlayerActionDisplay — import the real module so we can spy on it
 jest.mock("../../../../utils/playerActionDisplayUtils", () => {
     const actual = jest.requireActual("../../../../utils/playerActionDisplayUtils");

--- a/src/components/playPage/Table/components/PlayerActionButtons.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.tsx
@@ -17,6 +17,7 @@ import { toast } from "react-toastify";
 import BuyChipsButton from "../../../BuyChipsButton";
 import { useTableTopUp } from "../../../../hooks/game/useTableTopUp";
 import { useGameStateContext } from "../../../../context/GameStateContext";
+import { useGameSettings } from "../../../../context/GameSettingsContext";
 import { isNullish } from "../../../../utils/guards";
 
 // Wait for the chain to confirm sit-in via actionCount before re-enabling the
@@ -79,6 +80,7 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
     //   • DIRTY_STATE_TIMEOUT_MS elapses (escape hatch)
     //   • handleSitIn throws (CheckTx rejected — clear immediately)
     const { gameState } = useGameStateContext();
+    const { seatAtBottom, toggleSeatAtBottom } = useGameSettings();
     const [sittingIn, setSittingIn] = useState(false);
     const [pendingActionCount, setPendingActionCount] = useState<number | null>(null);
 
@@ -234,7 +236,20 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
             return (
                 <>
                     {buyChipsElement}
-                    <div className={`fixed z-30 ${positionClass}`}>
+                    <div className={`fixed z-30 ${positionClass} flex flex-col gap-2`}>
+                        <div className={`backdrop-blur-sm rounded-lg shadow-lg border border-white/20 bg-black/60 ${isCompact ? "p-2" : "p-3"}`}>
+                            <label className="flex items-center cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={seatAtBottom}
+                                    onChange={toggleSeatAtBottom}
+                                    className="form-checkbox h-4 w-4 text-amber-500 border-gray-500 rounded focus:ring-0"
+                                />
+                                <span className={`ml-2 ${seatAtBottom ? "text-amber-300" : "text-white"} ${isCompact ? "text-xs" : "text-sm"}`}>
+                                    Seat me at 6 o'clock
+                                </span>
+                            </label>
+                        </div>
                         <button
                             onClick={handleSitInClick}
                             disabled={sittingIn}

--- a/src/context/GameSettingsContext.tsx
+++ b/src/context/GameSettingsContext.tsx
@@ -18,6 +18,7 @@ const LS_KEY_AUTO_FOLD = "setting_autofold";
 const LS_KEY_AUTO_MUCK = "setting_automuck";
 const LS_KEY_TURN_SOUND = "setting_turnsound";
 const LS_KEY_PLAYER_ACTION_SOUNDS = "setting_playeractionsounds";
+const LS_KEY_SEAT_AT_BOTTOM = "setting_seatatbottom";
 
 function readBoolSetting(key: string, fallback: boolean): boolean {
     const stored = localStorage.getItem(key);
@@ -33,6 +34,7 @@ export interface GameSettings {
     autoMuck: boolean;
     turnNotificationSound: boolean;
     playerActionSounds: boolean;
+    seatAtBottom: boolean;
 }
 
 export interface GameSettingsContextValue extends GameSettings {
@@ -43,6 +45,7 @@ export interface GameSettingsContextValue extends GameSettings {
     toggleAutoMuck: () => void;
     toggleTurnNotificationSound: () => void;
     togglePlayerActionSounds: () => void;
+    toggleSeatAtBottom: () => void;
 }
 
 const GameSettingsContext = createContext<GameSettingsContextValue>(null as any);
@@ -68,6 +71,9 @@ export const GameSettingsProvider: React.FC<{ children: React.ReactNode }> = ({ 
     );
     const [playerActionSounds, setPlayerActionSounds] = useState<boolean>(() =>
         readBoolSetting(LS_KEY_PLAYER_ACTION_SOUNDS, true)
+    );
+    const [seatAtBottom, setSeatAtBottom] = useState<boolean>(() =>
+        readBoolSetting(LS_KEY_SEAT_AT_BOTTOM, true)
     );
 
     const toggleAutoDeal = useCallback(() => {
@@ -126,6 +132,14 @@ export const GameSettingsProvider: React.FC<{ children: React.ReactNode }> = ({ 
         });
     }, []);
 
+    const toggleSeatAtBottom = useCallback(() => {
+        setSeatAtBottom(prev => {
+            const next = !prev;
+            localStorage.setItem(LS_KEY_SEAT_AT_BOTTOM, String(next));
+            return next;
+        });
+    }, []);
+
     return (
         <GameSettingsContext.Provider
             value={{
@@ -136,13 +150,15 @@ export const GameSettingsProvider: React.FC<{ children: React.ReactNode }> = ({ 
                 autoMuck,
                 turnNotificationSound,
                 playerActionSounds,
+                seatAtBottom,
                 toggleAutoDeal,
                 toggleAutoPostBlinds,
                 toggleAutoNewHand,
                 toggleAutoFold,
                 toggleAutoMuck,
                 toggleTurnNotificationSound,
-                togglePlayerActionSounds
+                togglePlayerActionSounds,
+                toggleSeatAtBottom
             }}
         >
             {children}


### PR DESCRIPTION
## Summary

- Adds a persisted **\"Seat me at 6 o'clock\"** checkbox above the green *Sit In Next Hand* button, in the same dark translucent style as the existing *Sit Out Next Hand* box.
- Defaults **ON** (preserves the auto-rotation behaviour from #13).
- When unchecked, the table renders the absolute seat layout (no rotation).
- Persisted in localStorage under \`setting_seatatbottom\`, matching the pattern in \`GameSettingsContext\`.

Closes #392. Builds on #13 (original 6 o'clock rotation), related to block52/poker-vm#333 (seat selection).

## Implementation

- \`src/context/GameSettingsContext.tsx\` — new \`seatAtBottom\` boolean + \`toggleSeatAtBottom\`, default \`true\`.
- \`src/components/playPage/Table.tsx\` — auto-rotation \`useEffect\` now resets \`startIndex\` to 0 when \`seatAtBottom\` is off; otherwise applies the existing \`(tableSize - (seat - 1)) % tableSize\` formula.
- \`src/components/playPage/Table/components/PlayerActionButtons.tsx\` — in the \`sit-in-options\` case, the wrapper became \`flex flex-col gap-2\` and a checkbox panel is rendered above the Sit In Next Hand button.

Pure UI transform — no SDK, game-state, or chain interactions.

## Test plan

- [ ] Fresh session: checkbox appears above *Sit In Next Hand*, checked by default.
- [ ] Sit in: user appears at bottom (6 o'clock), as today.
- [ ] Uncheck the box (before sitting in), then sit in: user appears at their absolute seat position; other players unchanged.
- [ ] Toggle while seated: layout updates immediately without reload.
- [ ] Reload after toggling: the setting is restored from localStorage.
- [ ] Mobile + landscape: checkbox panel sits above the button at the same anchored position (no overlap with chips/buy panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)