### PR TITLE
fix(ui): all-in button sets bet amount only (#395)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,10 @@ VITE_UI_TEXT_SECONDARY=#9ca3af                # Gray-400 for secondary text
 
 # Site password protection (optional) - if not set, no password is required
 VITE_SITE_PASSWORD=
+
+# All-In button behaviour (optional)
+# Default (unset or anything other than "true"): clicking All-In only sets the bet
+# slider/input to the player's max — the player must press Bet or Raise to commit.
+# Set to "true" to restore the legacy behaviour where clicking All-In immediately
+# submits the action.
+VITE_ALL_IN_INSTANT_EXECUTE=

--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -459,20 +459,9 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         setRaiseAmount(prev => Math.max(prev - step, minAmount));
     };
 
-    const handleAllInAction = async () => {
-        if (!tableId) return;
+    const handleAllInAction = () => {
         const maxAmount = hasBetAction ? maxBet : maxRaise;
-        const amountMicro = fromDisplay(maxAmount);
-
         setRaiseAmount(maxAmount);
-        if (playerActionSounds) {
-            playActionSound("all-in");
-        }
-        await handleActionWithTransaction(
-            hasRaiseAction ? "raise" : "bet",
-            async () => (hasRaiseAction ? await handleRaise(tableId, amountMicro, network) : await handleBet(amountMicro, tableId, network)),
-            true // skipActionSound — all-in sound already played above
-        );
     };
 
     return (

--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -459,9 +459,22 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         setRaiseAmount(prev => Math.max(prev - step, minAmount));
     };
 
-    const handleAllInAction = () => {
+    const handleAllInAction = async () => {
         const maxAmount = hasBetAction ? maxBet : maxRaise;
         setRaiseAmount(maxAmount);
+
+        if (import.meta.env.VITE_ALL_IN_INSTANT_EXECUTE !== "true") return;
+
+        if (!tableId) return;
+        const amountMicro = fromDisplay(maxAmount);
+        if (playerActionSounds) {
+            playActionSound("all-in");
+        }
+        await handleActionWithTransaction(
+            hasRaiseAction ? "raise" : "bet",
+            async () => (hasRaiseAction ? await handleRaise(tableId, amountMicro, network) : await handleBet(amountMicro, tableId, network)),
+            true
+        );
     };
 
     return (

--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { NonPlayerActionType, PlayerActionType, PlayerStatus, TexasHoldemRound } from "@block52/poker-vm-sdk";
-import { isNullish } from "../../utils/guards";
+import { hasContent, isNullish } from "../../utils/guards";
 import { parseMicroToBigInt, microBigIntToUsdc, usdcToMicroBigInt } from "../../constants/currency";
 import { isTournamentFormat } from "../../utils/gameFormatUtils";
 import {
@@ -465,7 +465,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
 
         if (import.meta.env.VITE_ALL_IN_INSTANT_EXECUTE !== "true") return;
 
-        if (!tableId) return;
+        if (!hasContent(tableId)) return;
         const amountMicro = fromDisplay(maxAmount);
         if (playerActionSounds) {
             playActionSound("all-in");


### PR DESCRIPTION
Closes #395

## Summary
- Reworks `handleAllInAction` in `PokerActionPanel.tsx` so the default behaviour mirrors the 1/4, 1/2, 3/4, and Pot preset buttons: clicking All-In only calls `setRaiseAmount(maxAmount)`. The bet slider and manual input both read from `raiseAmount`, so they update automatically — the player confirms via the existing Bet/Raise button.
- Adds a `VITE_ALL_IN_INSTANT_EXECUTE` feature toggle (default off). Setting it to `"true"` restores the legacy instant-execute behaviour for operators who prefer it.
- Documents the new env var in `.env.example`.

## Test plan
- [ ] **Default (toggle unset):** Click All-In → slider jumps to max, input shows max, no chips move to pot, no entry in hand history. Then click Bet/Raise → all-in commits correctly.
- [ ] **Toggle on (`VITE_ALL_IN_INSTANT_EXECUTE=true`):** Click All-In → action submits immediately, exactly as the previous behaviour.
- [ ] Confirm 1/4, 1/2, 3/4, Pot buttons still behave as before in both modes.
- [ ] Tournament table: same flow with chip-denominated stack.
- [ ] Mobile landscape layout: All-In button still renders and behaves the same.

## Notes
- In default mode the "all-in" shove sound no longer fires on click (the standard bet/raise sound fires on confirmation). In toggle-on mode the shove sound still plays as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)