### PR TITLE
Issue-397

### DIFF
--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -483,7 +483,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         >
             <div
                 className={`flex flex-col w-full justify-center rounded-lg relative z-10 ${
-                    isMobileLandscape ? "mx-1 space-y-0.5 max-w-full" : "lg:w-[850px] mx-4 lg:mx-0 space-y-2 lg:space-y-3 max-w-full"
+                    isMobileLandscape ? "mx-1 space-y-0.5 max-w-full" : "lg:w-[570px] mx-4 lg:mx-0 space-y-2 lg:space-y-3 max-w-full"
                 }`}
             >
                 {/* Deal Button Group */}


### PR DESCRIPTION
Update the tailwind width for the PokerActionPanel wrapper on non-mobile-landscape screens from lg:w-[850px] to lg:w-[570px] in src/components/Footer/PokerActionPanel.tsx. This tightens the panel's layout on large viewports to improve responsiveness and visual balance.
<img width="903" height="219" alt="Screenshot 2026-05-22 at 11 28 33 am" src="https://github.com/user-attachments/assets/c927f254-ea3f-4b69-9a66-a882963b51c0" />
<img width="2377" height="767" alt="Screenshot 2026-05-22 at 11 28 25 am" src="https://github.com/user-attachments/assets/793522dc-42aa-4255-af61-e9b4fa0c443a" />
