### PR TITLE
fix(ui): stop surfacing duplicate-blind-tx errors as alert popup

### DIFF
--- a/src/components/common/actionHandlers.ts
+++ b/src/components/common/actionHandlers.ts
@@ -33,8 +33,6 @@ interface ActionHandlerOptions {
     successLog?: string;
     /** Log message prefix for attempt (optional) */
     attemptLog?: string;
-    /** Show alert on error (optional) */
-    alertOnError?: boolean;
 }
 
 /**
@@ -115,11 +113,6 @@ function createTableIdAmountHandler(
             return result?.hash || null;
         } catch (error: any) {
             console.error(`Failed to ${actionName}:`, error);
-
-            if (options.alertOnError) {
-                alert(`Failed to ${actionName}: ${error.message}`);
-            }
-
             return null;
         }
     };
@@ -205,8 +198,7 @@ const handleBet = createAmountFirstHandler("bet", betHand);
  */
 const handlePostSmallBlind = createTableIdAmountHandler("post small blind", postSmallBlind, {
     attemptLog: "🎰 Attempting to post small blind:",
-    successLog: "✅ Small blind posted successfully",
-    alertOnError: true
+    successLog: "✅ Small blind posted successfully"
 });
 
 /**


### PR DESCRIPTION
Closes block52/poker-vm#2142

## Summary
- `handlePostSmallBlind` was the only action handler with `alertOnError: true`, firing a native browser `alert()` on any failure.
- The error users saw (`{"code":-32603,"message":"Internal error","data":"tx already exists in cache"}`) is the benign duplicate-submission rejection — the first blind-post tx is already in the mempool, so the second one is rejected. The first tx still goes through, so this is noise, not a real failure.
- Per maintainer guidance on the issue: "just a warning, will not display it."

## Change
Removed `alertOnError: true` from `handlePostSmallBlind` and deleted the option entirely from `ActionHandlerOptions` + `createTableIdAmountHandler` since no other handler used it. The small-blind handler now logs to console like every other action.

```diff
-    successLog: "✅ Small blind posted successfully",
-    alertOnError: true
+    successLog: "✅ Small blind posted successfully"
```

## Why this instead of #2156
The closed PR #2156 (poker-vm) removed an unrelated `console.warn` from the deprecated seed-shuffling path. That warning isn't visible to users and isn't what the screenshot in the issue shows — the actual user-facing popup is a native browser `alert()` from the UI, triggered when the small-blind tx fails. Fixed in the UI, where it actually originates.

## Test plan
- [x] `npx eslint src/components/common/actionHandlers.ts` — 0 errors (warnings are pre-existing unused-`options` from `successLog`/`attemptLog`)
- [x] `npx jest src/components/playPage/Table/components/PlayerActionButtons.test.tsx` — 8/8 pass
- [ ] Manual: post small blind, observe no popup if a duplicate submission happens (console.error still logs for debugging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)