### PR TITLE
fix(ui): exclude TOP_UP from post-flop chip display + queue confirmation (#2141)

### DIFF
--- a/src/components/modals/TopUpModal.test.tsx
+++ b/src/components/modals/TopUpModal.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TexasHoldemRound } from "@block52/poker-vm-sdk";
+
+// Stub the shared Modal shell — its SVG/colorConfig stack relies on Vite's
+// import.meta.env which Jest can't load. The test only needs to inspect the
+// modal body content, so a plain pass-through is enough.
+jest.mock("../common", () => ({
+    Modal: ({ children, title }: { children: React.ReactNode; title?: string }) => (
+        <div data-testid="modal" data-title={title}>{children}</div>
+    ),
+    LoadingSpinner: () => <span data-testid="loading-spinner" />
+}));
+
+jest.mock("../../context/GameStateContext");
+
+// eslint-disable-next-line import/first
+import TopUpModal from "./TopUpModal";
+// eslint-disable-next-line import/first
+import { useGameStateContext } from "../../context/GameStateContext";
+
+const mockUseGameStateContext = useGameStateContext as jest.MockedFunction<typeof useGameStateContext>;
+
+// Stack/buy-in inputs are USDC micro-units (6 decimals).
+const TEN_USDC = "10000000";
+const FIFTY_USDC = "50000000";
+const ONE_HUNDRED_USDC = "100000000";
+
+const baseProps = {
+    tableId: "table-1",
+    currentStack: TEN_USDC,
+    minBuyIn: TEN_USDC,
+    maxBuyIn: ONE_HUNDRED_USDC,
+    walletBalance: FIFTY_USDC,
+    onClose: jest.fn()
+};
+
+const mockGameState = (round: TexasHoldemRound) => {
+    mockUseGameStateContext.mockReturnValue({
+        gameState: { round },
+        isLoading: false,
+        error: null,
+        gameFormat: "cash",
+        validationError: null,
+        subscribeToTable: jest.fn(),
+        unsubscribeFromTable: jest.fn()
+    } as unknown as ReturnType<typeof useGameStateContext>);
+};
+
+describe("TopUpModal — confirmation copy (issue #2141 AC-4)", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("shows the deferred-credit message after submit when the hand is in progress", async () => {
+        mockGameState(TexasHoldemRound.FLOP);
+        const onTopUp = jest.fn().mockResolvedValue(undefined);
+
+        render(<TopUpModal {...baseProps} onTopUp={onTopUp} />);
+
+        await userEvent.click(screen.getByRole("button", { name: /^BUY$/ }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Top-up confirmed. Chips will be added from the next hand.")
+            ).toBeInTheDocument();
+        });
+        expect(onTopUp).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows the immediate-credit message after submit at END (between hands)", async () => {
+        mockGameState(TexasHoldemRound.END);
+        const onTopUp = jest.fn().mockResolvedValue(undefined);
+
+        render(<TopUpModal {...baseProps} onTopUp={onTopUp} />);
+
+        await userEvent.click(screen.getByRole("button", { name: /^BUY$/ }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Top-up confirmed. Chips added to your stack.")
+            ).toBeInTheDocument();
+        });
+    });
+
+    it("shows the immediate-credit message at ANTE (pre-hand / blinds setup)", async () => {
+        mockGameState(TexasHoldemRound.ANTE);
+        const onTopUp = jest.fn().mockResolvedValue(undefined);
+
+        render(<TopUpModal {...baseProps} onTopUp={onTopUp} />);
+
+        await userEvent.click(screen.getByRole("button", { name: /^BUY$/ }));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("Top-up confirmed. Chips added to your stack.")
+            ).toBeInTheDocument();
+        });
+    });
+});

--- a/src/components/modals/TopUpModal.tsx
+++ b/src/components/modals/TopUpModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useMemo, useCallback } from "react";
+import { TexasHoldemRound } from "@block52/poker-vm-sdk";
 import { microToUsdc, usdcToMicroBigInt } from "../../constants/currency";
 import { calculateMinTopUp, calculateMaxTopUp } from "../../utils/topUpUtils";
+import { useGameStateContext } from "../../context/GameStateContext";
 import { Modal, LoadingSpinner } from "../common";
 import styles from "./TopUpModal.module.css";
 import type { TopUpModalProps } from "./types";
@@ -8,6 +10,16 @@ import type { TopUpModalProps } from "./types";
 const TopUpModal: React.FC<TopUpModalProps> = ({ currentStack, minBuyIn, maxBuyIn, walletBalance, onClose, onTopUp }) => {
     const [topUpError, setTopUpError] = useState("");
     const [isProcessing, setIsProcessing] = useState(false);
+    const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+    // block52/poker-vm#2141 / ui#279: while a hand is in progress (PREFLOP..SHOWDOWN)
+    // the PVM queues the top-up and only credits it at the next reInit. Surface that
+    // to the player so they don't expect chips to land mid-hand.
+    const { gameState } = useGameStateContext();
+    const handInProgress =
+        gameState?.round !== undefined &&
+        gameState.round !== TexasHoldemRound.ANTE &&
+        gameState.round !== TexasHoldemRound.END;
 
     const { currentStackFormatted, maxBuyInFormatted, walletBalanceFormatted, minTopUpFormatted, maxTopUpFormatted, minTopUpMicro, maxTopUpMicro } = useMemo(() => {
         const current = microToUsdc(currentStack);
@@ -78,13 +90,32 @@ const TopUpModal: React.FC<TopUpModalProps> = ({ currentStack, minBuyIn, maxBuyI
             }
 
             await onTopUp(topUpMicrounits.toString());
+            setSuccessMessage(
+                handInProgress
+                    ? "Top-up confirmed. Chips will be added from the next hand."
+                    : "Top-up confirmed. Chips added to your stack."
+            );
         } catch (error) {
             console.error("Error in top-up:", error);
             setTopUpError("Failed to top up. Please try again.");
         } finally {
             setIsProcessing(false);
         }
-    }, [topUpAmount, minTopUpMicro, maxTopUpMicro, minTopUpFormatted, maxTopUpFormatted, onTopUp]);
+    }, [topUpAmount, minTopUpMicro, maxTopUpMicro, minTopUpFormatted, maxTopUpFormatted, onTopUp, handInProgress]);
+
+    if (successMessage) {
+        return (
+            <Modal isOpen={true} onClose={onClose} title="Buy Chips" titleIcon="💰" patternId="hexagons-topup-success">
+                <p className="text-gray-200 mb-6">{successMessage}</p>
+                <button
+                    onClick={onClose}
+                    className={`w-full px-5 py-3 rounded-lg text-white font-medium hover:opacity-80 transition-opacity ${styles.buyButton}`}
+                >
+                    Close
+                </button>
+            </Modal>
+        );
+    }
 
     if (!canTopUp) {
         return (

--- a/src/hooks/player/usePlayerChipData.test.ts
+++ b/src/hooks/player/usePlayerChipData.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react";
-import { PlayerStatus, TexasHoldemRound } from "@block52/poker-vm-sdk";
+import { PlayerActionType, PlayerStatus, TexasHoldemRound } from "@block52/poker-vm-sdk";
 import { usePlayerChipData } from "./usePlayerChipData";
 import { useGameStateContext } from "../../context/GameStateContext";
 
@@ -216,7 +216,9 @@ describe("usePlayerChipData", () => {
                         {
                             playerId: "cosmos1allin",
                             round: TexasHoldemRound.FLOP,
-                            amount: "5000000"
+                            action: PlayerActionType.ALL_IN,
+                            amount: "5000000",
+                            index: 0
                         }
                     ]
                 },
@@ -250,7 +252,9 @@ describe("usePlayerChipData", () => {
                         {
                             playerId: "cosmos1folded",
                             round: TexasHoldemRound.TURN,
-                            amount: "1000000"
+                            action: PlayerActionType.BET,
+                            amount: "1000000",
+                            index: 0
                         }
                     ]
                 },
@@ -358,12 +362,16 @@ describe("usePlayerChipData", () => {
                         {
                             playerId: "cosmos1player",
                             round: TexasHoldemRound.PREFLOP,
-                            amount: "2000000" // Preflop bet
+                            action: PlayerActionType.CALL,
+                            amount: "2000000", // Preflop bet
+                            index: 0
                         },
                         {
                             playerId: "cosmos1player",
                             round: TexasHoldemRound.FLOP,
-                            amount: "3000000" // Flop bet (current round)
+                            action: PlayerActionType.BET,
+                            amount: "3000000", // Flop bet (current round)
+                            index: 1
                         }
                     ]
                 },
@@ -398,12 +406,16 @@ describe("usePlayerChipData", () => {
                         {
                             playerId: "cosmos1player",
                             round: TexasHoldemRound.RIVER,
-                            amount: "2000000" // First river bet
+                            action: PlayerActionType.BET,
+                            amount: "2000000", // First river bet
+                            index: 0
                         },
                         {
                             playerId: "cosmos1player",
                             round: TexasHoldemRound.RIVER,
-                            amount: "3000000" // Raise on river
+                            action: PlayerActionType.RAISE,
+                            amount: "3000000", // Raise on river
+                            index: 1
                         }
                     ]
                 },

--- a/src/utils/chipUtils.test.ts
+++ b/src/utils/chipUtils.test.ts
@@ -1,4 +1,4 @@
-import { ActionDTO, PlayerActionType, PlayerStatus, TexasHoldemRound } from "@block52/poker-vm-sdk";
+import { ActionDTO, NonPlayerActionType, PlayerActionType, PlayerStatus, TexasHoldemRound } from "@block52/poker-vm-sdk";
 import { shouldShowChips, getRelevantChipAmounts, calculateCurrentRoundBetting, hasPlayerBetInRound, CHIP_ACTIONS } from "./chipUtils";
 import { MAX_ACTION_GROUPS } from "../constants/chips";
 
@@ -208,35 +208,55 @@ describe("calculateCurrentRoundBetting", () => {
 
     it("sums amounts for the current round only", () => {
         const actions = [
-            { playerId: player, round: TexasHoldemRound.PREFLOP, amount: "100" },
-            { playerId: player, round: TexasHoldemRound.FLOP, amount: "200" },
-            { playerId: player, round: TexasHoldemRound.FLOP, amount: "300" },
+            makeAction({ playerId: player, round: TexasHoldemRound.PREFLOP, action: PlayerActionType.CALL, amount: "100", index: 0 }),
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "200", index: 1 }),
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.RAISE, amount: "300", index: 2 }),
         ];
         expect(calculateCurrentRoundBetting(player, TexasHoldemRound.FLOP, actions)).toBe("500");
     });
 
     it("filters by player address", () => {
         const actions = [
-            { playerId: "0xOther", round: TexasHoldemRound.FLOP, amount: "1000" },
-            { playerId: player, round: TexasHoldemRound.FLOP, amount: "200" },
+            makeAction({ playerId: "0xOther", round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "1000", index: 0 }),
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "200", index: 1 }),
         ];
         expect(calculateCurrentRoundBetting(player, TexasHoldemRound.FLOP, actions)).toBe("200");
     });
 
     it("excludes zero and empty amounts", () => {
         const actions = [
-            { playerId: player, round: TexasHoldemRound.FLOP, amount: "0" },
-            { playerId: player, round: TexasHoldemRound.FLOP, amount: "" },
-            { playerId: player, round: TexasHoldemRound.FLOP, amount: "500" },
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "0", index: 0 }),
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "", index: 1 }),
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "500", index: 2 }),
         ];
         expect(calculateCurrentRoundBetting(player, TexasHoldemRound.FLOP, actions)).toBe("500");
     });
 
     it("handles large BigInt amounts correctly", () => {
         const actions = [
-            { playerId: player, round: TexasHoldemRound.FLOP, amount: "999999999999999999" },
-            { playerId: player, round: TexasHoldemRound.FLOP, amount: "1" },
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "999999999999999999", index: 0 }),
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "1", index: 1 }),
         ];
         expect(calculateCurrentRoundBetting(player, TexasHoldemRound.FLOP, actions)).toBe("1000000000000000000");
+    });
+
+    // Regression: block52/poker-vm#2141 (originally block52/ui#279).
+    // A folded player's mid-hand TOP_UP must never count toward chips on the table
+    // for the current round, even though addNonPlayerAction tags it with currentRound.
+    it("excludes TOP_UP actions logged in the current round (issue #2141)", () => {
+        const actions = [
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "500", index: 0 }),
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: NonPlayerActionType.TOP_UP, amount: "300000", index: 1 }),
+        ];
+        expect(calculateCurrentRoundBetting(player, TexasHoldemRound.FLOP, actions)).toBe("500");
+    });
+
+    it("excludes non-bet actions (FOLD, CHECK) even with amount", () => {
+        const actions = [
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.FOLD, amount: "100", index: 0 }),
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.CHECK, amount: "200", index: 1 }),
+            makeAction({ playerId: player, round: TexasHoldemRound.FLOP, action: PlayerActionType.BET, amount: "400", index: 2 }),
+        ];
+        expect(calculateCurrentRoundBetting(player, TexasHoldemRound.FLOP, actions)).toBe("400");
     });
 });

--- a/src/utils/chipUtils.ts
+++ b/src/utils/chipUtils.ts
@@ -89,16 +89,21 @@ export const hasPlayerBetInRound = (
 };
 
 /**
- * Calculate how much a player has bet in the current round only.
+ * Sum of a player's actual bet-placing actions in the current round.
+ *
+ * Excludes non-bet actions (TOP_UP, JOIN, LEAVE, FOLD, CHECK, etc.) so that
+ * a mid-hand top-up by a folded player never renders as chips in front of
+ * them. See block52/poker-vm#2141 and block52/ui#279.
  */
 export const calculateCurrentRoundBetting = (
     playerAddress: string,
     currentRound: string,
-    previousActions: Array<{ playerId: string; round: string; amount?: string }>
+    previousActions: ActionDTO[]
 ): string => {
     const currentRoundActions = previousActions.filter(action =>
         action.playerId === playerAddress &&
         action.round === currentRound &&
+        CHIP_ACTIONS.includes(action.action) &&
         action.amount &&
         action.amount !== "0" &&
         action.amount !== ""


### PR DESCRIPTION
## Summary

Closes block52/poker-vm#2141. Paired with chain-side PR: https://github.com/block52/poker-vm/pull/2163.

Regression of #279. The PVM-side fix in poker-vm#1993 filtered TOP_UP from `getBets()`/`BetManager`, but the UI's post-flop chip display in `usePlayerChipData` re-derives bets from `previousActions` via `calculateCurrentRoundBetting()` — which summed by `playerId + round + amount` without filtering by action type. Since `pokerGameBase.addNonPlayerAction` tags every non-player action with `currentRound`, a TOP_UP fired during FLOP/TURN/RIVER landed in that round's bucket and was summed into chips on the table for the folded player.

## Changes

- `src/utils/chipUtils.ts` — `calculateCurrentRoundBetting` now filters by `CHIP_ACTIONS` (mirrors `getRelevantChipAmounts` and `hasPlayerBetInRound`) and takes `ActionDTO[]` from the SDK (no more ad-hoc loose shape — commandments #1 / #11).
- `src/components/modals/TopUpModal.tsx` — adds AC-4 confirmation panel after submit:
  - "Top-up confirmed. Chips will be added from the next hand." when `gameState.round` is in progress (∉ `{ANTE, END}`).
  - "Top-up confirmed. Chips added to your stack." otherwise.
  - Reads `gameState.round` via `useGameStateContext` (commandment #7 respected — checks loading state, not value fallback).

## Tests

- `chipUtils.test.ts` — regression test for #2141 + a FOLD/CHECK guard test. Existing tests updated to use the typed `ActionDTO` shape.
- `usePlayerChipData.test.ts` — fixtures gained an `action` field (they passed before only because the old loose signature didn't enforce it; tsc + jest both green now).
- `TopUpModal.test.tsx` — new file, 3 tests covering AC-4 copy across in-progress / `END` / `ANTE`.
- Full UI suite: **777 passed**. `tsc --noEmit`: clean.

## Test plan

- [ ] CI green.
- [ ] Manual against a running pokerchain + poker-vm with the companion PR merged: heads-up cash table, fold mid-hand, top up — verify no chips appear in front of the folded player, confirmation copy reads "added from the next hand", new hand starts with topped-up stack.
- [ ] Manual: top up at `END` (between hands) — chips visible on next deal, confirmation copy reads "added to your stack".

Refs: regression of #279 (per @bitcoinbrisbane's cross-ref on poker-vm#2141), builds on poker-vm#1993.