### PR TITLE
feat(ui): client-side Sit Out Next Big Blind checkbox (#114)

### DIFF
--- a/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
@@ -183,7 +183,7 @@ describe("PlayerActionButtons", () => {
         expect(screen.getByText("To join the table, click on an available seat.")).toBeInTheDocument();
     });
 
-    it("renders sit-out checkbox when SIT_OUT action available", () => {
+    it("renders both sit-out checkboxes when SIT_OUT action available", () => {
         render(
             <PlayerActionButtons
                 {...baseProps}
@@ -192,7 +192,8 @@ describe("PlayerActionButtons", () => {
                 handNumber={2}
             />
         );
-        expect(screen.getByRole("checkbox")).toBeInTheDocument();
+        expect(screen.getAllByRole("checkbox")).toHaveLength(2);
         expect(screen.getByText("Sit Out Next Hand")).toBeInTheDocument();
+        expect(screen.getByText("Sit Out Next Big Blind")).toBeInTheDocument();
     });
 });

--- a/src/components/playPage/Table/components/PlayerActionButtons.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.tsx
@@ -10,7 +10,7 @@ import React, { useState, useEffect, useRef } from "react";
 
 import { LegalActionDTO, NonPlayerActionType } from "@block52/poker-vm-sdk";
 import { handleSitOut, handleSitIn } from "../../../common/actionHandlers";
-import { SIT_IN_METHOD_POST_NOW } from "../../../../hooks/playerActions";
+import { SIT_IN_METHOD_POST_NOW, useAutoSitOutNextBB } from "../../../../hooks/playerActions";
 import type { NetworkEndpoints } from "../../../../context/NetworkContext";
 import { getPlayerActionDisplay } from "../../../../utils/playerActionDisplayUtils";
 import { toast } from "react-toastify";
@@ -19,6 +19,8 @@ import { useTableTopUp } from "../../../../hooks/game/useTableTopUp";
 import { useGameStateContext } from "../../../../context/GameStateContext";
 import { useGameSettings } from "../../../../context/GameSettingsContext";
 import { isNullish } from "../../../../utils/guards";
+import { findUserSeat } from "../../../../utils/playerSeatUtils";
+import { getCosmosAddressSync } from "../../../../utils/cosmosAccountUtils";
 
 // Wait for the chain to confirm sit-in via actionCount before re-enabling the
 // button. Mirrors the dirty-state pattern landed in block52/ui#365 for the
@@ -70,6 +72,11 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
     // Optimistic local state for immediate visual feedback
     const [optimisticChecked, setOptimisticChecked] = useState<boolean | null>(null);
 
+    // Browser-only intent for "Sit Out Next Big Blind" (#114). No chain state:
+    // the hook below fires a standard SIT_OUT(next-hand) when bigBlindPosition
+    // rotates onto our seat, then this flag is cleared so the box unchecks.
+    const [sitOutNextBbQueued, setSitOutNextBbQueued] = useState<boolean>(false);
+
     // Dirty state for the Sit-In button. Was previously useOptimistic which
     // auto-reverts when the underlying transition completes — that's
     // exactly the gap we want to close: SDK SYNC return (~50ms) reverted
@@ -96,6 +103,16 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
         setOptimisticChecked(!isChecked);
         handleSitOut(tableId, currentNetwork);
     };
+
+    useAutoSitOutNextBB(
+        tableId,
+        currentNetwork,
+        findUserSeat(gameState, getCosmosAddressSync()),
+        gameState?.bigBlindPosition,
+        sitOutNextBbQueued,
+        () => setSitOutNextBbQueued(false), // clear box after fire
+        () => setSitOutNextBbQueued(false)  // also clear on error so user can retry
+    );
 
     const display = getPlayerActionDisplay({
         playerStatus,
@@ -292,7 +309,7 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
                 <>
                     {buyChipsElement}
                     <div className={`fixed z-30 ${positionClass}`}>
-                        <div className={`backdrop-blur-sm rounded-lg shadow-lg border border-white/20 bg-black/60 ${isCompact ? "p-2" : "p-3"}`}>
+                        <div className={`backdrop-blur-sm rounded-lg shadow-lg border border-white/20 bg-black/60 ${isCompact ? "p-2" : "p-3"} flex flex-col gap-1`}>
                             <label className="flex items-center cursor-pointer">
                                 <input
                                     type="checkbox"
@@ -302,6 +319,17 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
                                 />
                                 <span className={`ml-2 ${isChecked ? "text-amber-300" : "text-white"} ${isCompact ? "text-xs" : "text-sm"}`}>
                                     Sit Out Next Hand
+                                </span>
+                            </label>
+                            <label className="flex items-center cursor-pointer">
+                                <input
+                                    type="checkbox"
+                                    checked={sitOutNextBbQueued}
+                                    onChange={() => setSitOutNextBbQueued(prev => !prev)}
+                                    className="form-checkbox h-4 w-4 text-amber-500 border-gray-500 rounded focus:ring-0"
+                                />
+                                <span className={`ml-2 ${sitOutNextBbQueued ? "text-amber-300" : "text-white"} ${isCompact ? "text-xs" : "text-sm"}`}>
+                                    Sit Out Next Big Blind
                                 </span>
                             </label>
                         </div>

--- a/src/hooks/playerActions/index.ts
+++ b/src/hooks/playerActions/index.ts
@@ -22,6 +22,7 @@ import { useAutoPostBlinds } from "./useAutoPostBlinds";
 import { useAutoNewHand } from "./useAutoNewHand";
 import { useAutoFold } from "./useAutoFold";
 import { useAutoMuck } from "./useAutoMuck";
+import { useAutoSitOutNextBB } from "./useAutoSitOutNextBB";
 
 export {
     betHand,
@@ -49,7 +50,8 @@ export {
     useAutoPostBlinds,
     useAutoNewHand,
     useAutoFold,
-    useAutoMuck
+    useAutoMuck,
+    useAutoSitOutNextBB
 };
 
 export type { OptimisticActionType, SitInMethod, SitOutMethod };

--- a/src/hooks/playerActions/useAutoSitOutNextBB.test.ts
+++ b/src/hooks/playerActions/useAutoSitOutNextBB.test.ts
@@ -1,0 +1,122 @@
+import { renderHook } from "@testing-library/react";
+import type { NetworkEndpoints } from "../../context/NetworkContext";
+import { useAutoSitOutNextBB } from "./useAutoSitOutNextBB";
+import { sitOut, SIT_OUT_METHOD_NEXT_HAND } from "./sitOut";
+
+jest.mock("./sitOut", () => {
+    const actual = jest.requireActual("./sitOut");
+    return {
+        ...actual,
+        sitOut: jest.fn().mockResolvedValue({ hash: "0xtx", gameId: "table-1", action: "sit-out" })
+    };
+});
+
+const mockedSitOut = sitOut as jest.MockedFunction<typeof sitOut>;
+const fakeNetwork = { name: "testnet", rpc: "http://x", rest: "http://y" } as unknown as NetworkEndpoints;
+
+describe("useAutoSitOutNextBB", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("does not fire when disabled even if BB matches seat", () => {
+        renderHook(() =>
+            useAutoSitOutNextBB("table-1", fakeNetwork, 3, 3, false)
+        );
+        expect(mockedSitOut).not.toHaveBeenCalled();
+    });
+
+    it("does not fire when BB is not on the user's seat", () => {
+        renderHook(() =>
+            useAutoSitOutNextBB("table-1", fakeNetwork, 3, 5, true)
+        );
+        expect(mockedSitOut).not.toHaveBeenCalled();
+    });
+
+    it("fires SIT_OUT(next-hand) once when enabled and BB lands on user's seat", async () => {
+        const onComplete = jest.fn();
+        renderHook(() =>
+            useAutoSitOutNextBB("table-1", fakeNetwork, 3, 3, true, onComplete)
+        );
+
+        // give the promise a microtask to resolve
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mockedSitOut).toHaveBeenCalledTimes(1);
+        expect(mockedSitOut).toHaveBeenCalledWith("table-1", fakeNetwork, SIT_OUT_METHOD_NEXT_HAND);
+        expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-fire while BB stays on the seat across re-renders", async () => {
+        const { rerender } = renderHook(
+            ({ bb }: { bb: number }) =>
+                useAutoSitOutNextBB("table-1", fakeNetwork, 3, bb, true),
+            { initialProps: { bb: 3 } }
+        );
+        await Promise.resolve();
+        expect(mockedSitOut).toHaveBeenCalledTimes(1);
+
+        rerender({ bb: 3 });
+        rerender({ bb: 3 });
+        await Promise.resolve();
+        expect(mockedSitOut).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-arms and fires again when BB moves off then back onto the seat", async () => {
+        const { rerender } = renderHook(
+            ({ bb }: { bb: number }) =>
+                useAutoSitOutNextBB("table-1", fakeNetwork, 3, bb, true),
+            { initialProps: { bb: 3 } }
+        );
+        await Promise.resolve();
+        expect(mockedSitOut).toHaveBeenCalledTimes(1);
+
+        // BB moves away (new hand) → arm reset
+        rerender({ bb: 4 });
+        await Promise.resolve();
+        // BB orbits all the way back
+        rerender({ bb: 3 });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mockedSitOut).toHaveBeenCalledTimes(2);
+    });
+
+    it("does nothing when tableId is undefined", async () => {
+        renderHook(() =>
+            useAutoSitOutNextBB(undefined, fakeNetwork, 3, 3, true)
+        );
+        await Promise.resolve();
+        expect(mockedSitOut).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when userSeat is undefined", async () => {
+        renderHook(() =>
+            useAutoSitOutNextBB("table-1", fakeNetwork, undefined, 3, true)
+        );
+        await Promise.resolve();
+        expect(mockedSitOut).not.toHaveBeenCalled();
+    });
+
+    it("invokes onError and still allows retry after BB moves off and back", async () => {
+        const onError = jest.fn();
+        mockedSitOut.mockRejectedValueOnce(new Error("chain busy"));
+
+        const { rerender } = renderHook(
+            ({ bb }: { bb: number }) =>
+                useAutoSitOutNextBB("table-1", fakeNetwork, 3, bb, true, undefined, onError),
+            { initialProps: { bb: 3 } }
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(mockedSitOut).toHaveBeenCalledTimes(1);
+
+        rerender({ bb: 4 });
+        rerender({ bb: 3 });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(mockedSitOut).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/hooks/playerActions/useAutoSitOutNextBB.ts
+++ b/src/hooks/playerActions/useAutoSitOutNextBB.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useCallback } from "react";
+import type { NetworkEndpoints } from "../../context/NetworkContext";
+import { sitOut, SIT_OUT_METHOD_NEXT_HAND } from "./sitOut";
+
+/**
+ * Client-side "Sit Out Next Big Blind".
+ *
+ * The chain does not yet implement `SIT_OUT method=next-bb` (poker-vm#1895),
+ * so this hook holds the intent in the browser and fires a standard
+ * `SIT_OUT method=next-hand` the moment the big blind rotates onto the
+ * player's seat. The player plays out the BB hand, then sits out from the
+ * following hand.
+ *
+ * Mirrors `useAutoFold`: the parent owns the enable flag and clears it via
+ * `onComplete` once the action fires, so the checkbox visibly unchecks.
+ *
+ * Single-shot per BB landing: `hasTriggeredRef` arms again only when the
+ * BB moves off the player's seat (new hand).
+ */
+export function useAutoSitOutNextBB(
+    tableId: string | undefined,
+    network: NetworkEndpoints,
+    userSeat: number | undefined,
+    bigBlindPosition: number | undefined,
+    enabled: boolean,
+    onComplete?: () => void,
+    onError?: (error: Error) => void
+): void {
+    const hasTriggeredRef = useRef<boolean>(false);
+    const isProcessingRef = useRef<boolean>(false);
+
+    const triggerSitOut = useCallback(async () => {
+        if (!tableId || isProcessingRef.current) return;
+
+        isProcessingRef.current = true;
+        try {
+            await sitOut(tableId, network, SIT_OUT_METHOD_NEXT_HAND);
+            onComplete?.();
+        } catch (error) {
+            console.error("Auto sit-out-next-BB failed:", error);
+            onError?.(error instanceof Error ? error : new Error(String(error)));
+        } finally {
+            isProcessingRef.current = false;
+        }
+    }, [tableId, network, onComplete, onError]);
+
+    useEffect(() => {
+        const seatIsBB =
+            typeof userSeat === "number" &&
+            userSeat > 0 &&
+            typeof bigBlindPosition === "number" &&
+            bigBlindPosition === userSeat;
+
+        const shouldFire =
+            enabled &&
+            seatIsBB &&
+            !hasTriggeredRef.current &&
+            !isProcessingRef.current;
+
+        if (shouldFire) {
+            hasTriggeredRef.current = true;
+            triggerSitOut();
+            return;
+        }
+
+        if (!seatIsBB) {
+            hasTriggeredRef.current = false;
+        }
+    }, [enabled, userSeat, bigBlindPosition, triggerSitOut]);
+}

--- a/src/hooks/playerActions/useAutoSitOutNextBB.ts
+++ b/src/hooks/playerActions/useAutoSitOutNextBB.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
+import { isSeatBigBlind } from "../../utils/playerSeatUtils";
 import { sitOut, SIT_OUT_METHOD_NEXT_HAND } from "./sitOut";
 
 /**
@@ -45,11 +46,7 @@ export function useAutoSitOutNextBB(
     }, [tableId, network, onComplete, onError]);
 
     useEffect(() => {
-        const seatIsBB =
-            typeof userSeat === "number" &&
-            userSeat > 0 &&
-            typeof bigBlindPosition === "number" &&
-            bigBlindPosition === userSeat;
+        const seatIsBB = isSeatBigBlind(userSeat, bigBlindPosition);
 
         const shouldFire =
             enabled &&

--- a/src/hooks/playerActions/useAutoSitOutNextBB.ts
+++ b/src/hooks/playerActions/useAutoSitOutNextBB.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from "react";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
+import { hasContent } from "../../utils/guards";
 import { isSeatBigBlind } from "../../utils/playerSeatUtils";
 import { sitOut, SIT_OUT_METHOD_NEXT_HAND } from "./sitOut";
 
@@ -31,7 +32,7 @@ export function useAutoSitOutNextBB(
     const isProcessingRef = useRef<boolean>(false);
 
     const triggerSitOut = useCallback(async () => {
-        if (!tableId || isProcessingRef.current) return;
+        if (!hasContent(tableId) || isProcessingRef.current) return;
 
         isProcessingRef.current = true;
         try {

--- a/src/utils/playerSeatUtils.test.ts
+++ b/src/utils/playerSeatUtils.test.ts
@@ -1,0 +1,33 @@
+import { findUserSeat } from "./playerSeatUtils";
+
+describe("findUserSeat", () => {
+    const gameState = {
+        players: [
+            { address: "b52aaa", seat: 1 },
+            { address: "b52BBB", seat: 5 },
+            { address: "b52ccc", seat: 9 }
+        ]
+    };
+
+    it("returns the seat of the matching player (case-insensitive)", () => {
+        expect(findUserSeat(gameState, "b52aaa")).toBe(1);
+        expect(findUserSeat(gameState, "B52BBB")).toBe(5);
+        expect(findUserSeat(gameState, "b52bbb")).toBe(5);
+    });
+
+    it("returns undefined when the address is not seated", () => {
+        expect(findUserSeat(gameState, "b52ddd")).toBeUndefined();
+    });
+
+    it("returns undefined when the address is blank/null/undefined", () => {
+        expect(findUserSeat(gameState, "")).toBeUndefined();
+        expect(findUserSeat(gameState, null)).toBeUndefined();
+        expect(findUserSeat(gameState, undefined)).toBeUndefined();
+    });
+
+    it("returns undefined when gameState or players is missing", () => {
+        expect(findUserSeat(null, "b52aaa")).toBeUndefined();
+        expect(findUserSeat(undefined, "b52aaa")).toBeUndefined();
+        expect(findUserSeat({}, "b52aaa")).toBeUndefined();
+    });
+});

--- a/src/utils/playerSeatUtils.test.ts
+++ b/src/utils/playerSeatUtils.test.ts
@@ -1,4 +1,4 @@
-import { findUserSeat } from "./playerSeatUtils";
+import { findUserSeat, isSeatBigBlind } from "./playerSeatUtils";
 
 describe("findUserSeat", () => {
     const gameState = {
@@ -29,5 +29,35 @@ describe("findUserSeat", () => {
         expect(findUserSeat(null, "b52aaa")).toBeUndefined();
         expect(findUserSeat(undefined, "b52aaa")).toBeUndefined();
         expect(findUserSeat({}, "b52aaa")).toBeUndefined();
+    });
+});
+
+describe("isSeatBigBlind", () => {
+    it("returns true when seat matches bigBlindPosition", () => {
+        expect(isSeatBigBlind(3, 3)).toBe(true);
+        expect(isSeatBigBlind(1, 1)).toBe(true);
+        expect(isSeatBigBlind(9, 9)).toBe(true);
+    });
+
+    it("returns false when seat does not match bigBlindPosition", () => {
+        expect(isSeatBigBlind(3, 4)).toBe(false);
+        expect(isSeatBigBlind(5, 1)).toBe(false);
+    });
+
+    it("returns false when seat is undefined", () => {
+        expect(isSeatBigBlind(undefined, 3)).toBe(false);
+    });
+
+    it("returns false when bigBlindPosition is undefined", () => {
+        expect(isSeatBigBlind(3, undefined)).toBe(false);
+    });
+
+    it("returns false when both are undefined", () => {
+        expect(isSeatBigBlind(undefined, undefined)).toBe(false);
+    });
+
+    it("treats seat 0 as not-seated (false even if bigBlindPosition is 0)", () => {
+        expect(isSeatBigBlind(0, 0)).toBe(false);
+        expect(isSeatBigBlind(0, 3)).toBe(false);
     });
 });

--- a/src/utils/playerSeatUtils.ts
+++ b/src/utils/playerSeatUtils.ts
@@ -1,0 +1,25 @@
+import type { PlayerDTO } from "@block52/poker-vm-sdk";
+import { hasContent } from "./guards";
+
+interface GameStateLike {
+    players?: ReadonlyArray<Pick<PlayerDTO, "address" | "seat">>;
+}
+
+/**
+ * Find the user's seat number in a game state by matching the cosmos address
+ * (case-insensitive). Returns `undefined` when the user isn't seated or when
+ * either input is missing, so callers can pass the result straight into hooks
+ * that already accept `number | undefined`.
+ *
+ * Centralizes the lookup so we don't repeat the localStorage + lowercase
+ * + find pattern from `usePlayerSeatInfo` in every component that needs it.
+ */
+export function findUserSeat(
+    gameState: GameStateLike | null | undefined,
+    userAddress: string | null | undefined
+): number | undefined {
+    if (!hasContent(userAddress) || !gameState?.players) return undefined;
+    const wanted = userAddress.toLowerCase();
+    const player = gameState.players.find(p => p.address?.toLowerCase() === wanted);
+    return player?.seat;
+}

--- a/src/utils/playerSeatUtils.ts
+++ b/src/utils/playerSeatUtils.ts
@@ -1,6 +1,27 @@
 import type { PlayerDTO } from "@block52/poker-vm-sdk";
 import { hasContent } from "./guards";
 
+/**
+ * Returns true when the given seat is the big-blind position for the current
+ * hand. Both inputs may be undefined (player not seated yet, or game state
+ * not loaded), in which case the result is false rather than throwing — the
+ * call sites are auto-action guards where "we don't know yet" should mean
+ * "don't fire."
+ *
+ * Seat 0 is treated as not-seated. Chain seats are 1-indexed.
+ */
+export function isSeatBigBlind(
+    seat: number | undefined,
+    bigBlindPosition: number | undefined
+): boolean {
+    return (
+        typeof seat === "number" &&
+        seat > 0 &&
+        typeof bigBlindPosition === "number" &&
+        bigBlindPosition === seat
+    );
+}
+
 interface GameStateLike {
     players?: ReadonlyArray<Pick<PlayerDTO, "address" | "seat">>;
 }

--- a/src/utils/playerSeatUtils.ts
+++ b/src/utils/playerSeatUtils.ts
@@ -1,5 +1,5 @@
 import type { PlayerDTO } from "@block52/poker-vm-sdk";
-import { hasContent } from "./guards";
+import { hasValue, hasContent, hasElements } from "./guards";
 
 /**
  * Returns true when the given seat is the big-blind position for the current
@@ -14,16 +14,11 @@ export function isSeatBigBlind(
     seat: number | undefined,
     bigBlindPosition: number | undefined
 ): boolean {
-    return (
-        typeof seat === "number" &&
-        seat > 0 &&
-        typeof bigBlindPosition === "number" &&
-        bigBlindPosition === seat
-    );
+    return hasValue(seat) && seat > 0 && hasValue(bigBlindPosition) && bigBlindPosition === seat;
 }
 
 interface GameStateLike {
-    players?: ReadonlyArray<Pick<PlayerDTO, "address" | "seat">>;
+    players?: Array<Pick<PlayerDTO, "address" | "seat">>;
 }
 
 /**
@@ -39,8 +34,8 @@ export function findUserSeat(
     gameState: GameStateLike | null | undefined,
     userAddress: string | null | undefined
 ): number | undefined {
-    if (!hasContent(userAddress) || !gameState?.players) return undefined;
+    const players = gameState?.players;
+    if (!hasContent(userAddress) || !hasElements(players)) return undefined;
     const wanted = userAddress.toLowerCase();
-    const player = gameState.players.find(p => p.address?.toLowerCase() === wanted);
-    return player?.seat;
+    return players.find(p => p.address?.toLowerCase() === wanted)?.seat;
 }


### PR DESCRIPTION
Closes #114.

## Summary
- Adds a second "Sit Out Next Big Blind" checkbox below the existing "Sit Out Next Hand" checkbox in `PlayerActionButtons`.
- Held in browser state only — no chain field, no localStorage, no PVM `next-bb` dependency ([poker-vm #1895](https://github.com/block52/poker-vm/issues/1895) stays optional/future).
- New `useAutoSitOutNextBB` hook watches `gameState.bigBlindPosition` against the user's seat each WS update and fires a standard `SIT_OUT method=next-hand` the moment BB lands. Single-shot per BB landing; re-arms when BB moves off the seat. Mirrors the auto-fold-on-timeout pattern from #49.
- Extracted `findUserSeat` to `utils/playerSeatUtils.ts` so the localStorage + lowercase + find pattern isn't repeated inline in components.

**Trade-off accepted:** the player still pays the current BB on the hand the action fires (player plays out the BB hand, sits out the next). The "skip the BB entirely" variant needs next-hand BB prediction (empty-seat skip + heads-up rotation) — out of scope for this ticket, captured in the issue body.

## Test plan
- [x] `useAutoSitOutNextBB` unit tests: fires once on BB-match, no fire when disabled / seat mismatch / missing inputs, re-arms after BB moves, surfaces errors via `onError`. (8 tests)
- [x] `findUserSeat` unit tests: case-insensitive match, missing inputs return undefined. (4 tests)
- [x] `PlayerActionButtons.test.tsx` updated to assert both checkboxes render. (8 tests, all green)
- [ ] Manual verification: at a table, check the box → wait for BB to rotate onto the seat → confirm one `SIT_OUT` tx fires and the box auto-unchecks.
- [ ] Manual: uncheck before BB lands → confirm no transaction is sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)