### PR TITLE
feat: winning hand card animation with muting

### DIFF
--- a/src/components/playPage/Players/OppositePlayer.tsx
+++ b/src/components/playPage/Players/OppositePlayer.tsx
@@ -15,6 +15,7 @@ import * as React from "react";
 import { useParams } from "react-router-dom";
 import Badge from "../common/Badge";
 import { useWinnerInfo } from "../../../hooks/game/useWinnerInfo";
+import { useWinnerCards } from "../../../hooks/game/useWinnerCards";
 import { WinnerInfo } from "../../../types";
 import { usePlayerData } from "../../../hooks/player/usePlayerData";
 import { useShowingCardsByAddress } from "../../../hooks/player/useShowingCardsByAddress";
@@ -42,6 +43,7 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
     const { id } = useParams<{ id: string }>();
     const { playerData, stackValue, isFolded, isAllIn, isSeated, isSittingOut, isBusted, holeCards, round } = usePlayerData(index);
     const { winnerInfo } = useWinnerInfo();
+    const winnerCards = useWinnerCards();
     const { isActive: isTurnTimerActive } = usePlayerTimer(id, index);
     const { equities, shouldShow: shouldShowEquity } = useAllInEquity();
     const { getAvatarForAddress } = useProfileAvatar();
@@ -140,8 +142,8 @@ const OppositePlayer: React.FC<OppositePlayerProps> = React.memo(({ left, top, i
                         isShowingCards && showingCards ? (
                             // Show the actual cards if player is showing
                             <>
-                                <img src={getCardImageUrl(showingCards[0])} alt="Player Card 1" width={60} height={80} className="mb-[11px]" />
-                                <img src={getCardImageUrl(showingCards[1])} alt="Player Card 2" width={60} height={80} className="mb-[11px]" />
+                                <img src={getCardImageUrl(showingCards[0])} alt="Player Card 1" width={60} height={80} className={`mb-[11px]${isWinner && winnerCards.size > 0 && winnerCards.has(showingCards[0]) ? " animate-win-card" : ""}${isWinner && winnerCards.size > 0 && !winnerCards.has(showingCards[0]) ? " opacity-40" : ""}`} />
+                                <img src={getCardImageUrl(showingCards[1])} alt="Player Card 2" width={60} height={80} className={`mb-[11px]${isWinner && winnerCards.size > 0 && winnerCards.has(showingCards[1]) ? " animate-win-card" : ""}${isWinner && winnerCards.size > 0 && !winnerCards.has(showingCards[1]) ? " opacity-40" : ""}`} />
                             </>
                         ) : (
                             // Show card backs for opponents (they shouldn't see actual cards)

--- a/src/components/playPage/Players/Player.tsx
+++ b/src/components/playPage/Players/Player.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { memo, useMemo, useCallback, useState, useEffect } from "react";
 import Badge from "../common/Badge";
 import { useWinnerInfo } from "../../../hooks/game/useWinnerInfo";
+import { useWinnerCards } from "../../../hooks/game/useWinnerCards";
 import { usePlayerData } from "../../../hooks/player/usePlayerData";
 import { usePlayerTimer } from "../../../hooks/player/usePlayerTimer";
 import { useParams } from "react-router-dom";
@@ -23,6 +24,7 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
         const { id } = useParams<{ id: string }>();
         const { playerData, stackValue, isFolded, isAllIn, isSeated, isSittingOut, isBusted, holeCards, round } = usePlayerData(index);
         const { winnerInfo } = useWinnerInfo();
+        const winnerCards = useWinnerCards();
         const { extendTime, canExtend, isCurrentUserTurn, isActive: isTurnTimerActive } = usePlayerTimer(id, index);
 
         const { dealerSeat } = useDealerPosition();
@@ -112,25 +114,31 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
                 return <div className="w-[120px] h-[80px]"></div>;
             }
 
+            const hasWinningCards = winnerCards.size > 0;
+            const liftCard0 = isWinner && hasWinningCards && winnerCards.has(holeCards[0]);
+            const liftCard1 = isWinner && hasWinningCards && winnerCards.has(holeCards[1]);
+            const muteCard0 = isWinner && hasWinningCards && !winnerCards.has(holeCards[0]);
+            const muteCard1 = isWinner && hasWinningCards && !winnerCards.has(holeCards[1]);
+
             return (
                 <>
                     <img
                         src={getCardImageUrl(holeCards[0])}
                         width={60}
                         height={80}
-                        className="mb-[11px]"
+                        className={`mb-[11px]${liftCard0 ? " animate-win-card" : ""}${muteCard0 ? " opacity-40" : ""}`}
                         onError={_e => console.error(`❌ Player ${index} card1 failed to load:`, getCardImageUrl(holeCards[0]))}
                     />
                     <img
                         src={getCardImageUrl(holeCards[1])}
                         width={60}
                         height={80}
-                        className="mb-[11px]"
+                        className={`mb-[11px]${liftCard1 ? " animate-win-card" : ""}${muteCard1 ? " opacity-40" : ""}`}
                         onError={_e => console.error(`❌ Player ${index} card2 failed to load:`, getCardImageUrl(holeCards[1]))}
                     />
                 </>
             );
-        }, [holeCards, index]);
+        }, [holeCards, index, isWinner, winnerCards]);
 
         // 6) container style for positioning
         const containerStyle = useMemo(

--- a/src/components/playPage/Table.css
+++ b/src/components/playPage/Table.css
@@ -58,8 +58,22 @@
 }
 
 .animate-fall {
-    animation: fall 1.0s ease-out both;
+    animation: fall 1.0s ease-out backwards;
 }
+
+/* Winning card highlight — lifts card upward and brightens it */
+@keyframes card-lift {
+    0%   { transform: translateY(0)     scale(1);    filter: brightness(1); }
+    100% { transform: translateY(-14px) scale(1.05); filter: brightness(1.25) drop-shadow(0 0 8px rgba(255, 215, 0, 0.85)); }
+}
+
+.animate-win-card {
+    animation: card-lift 350ms ease-out forwards;
+    position: relative;
+    z-index: 20;
+}
+
+
 
 /* Animation classes */
 .shimmer-animation {

--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -102,6 +102,7 @@ import { leaveTable } from "../../hooks/playerActions/leaveTable";
 
 // 5. Winner Info
 import { useWinnerInfo } from "../../hooks/game/useWinnerInfo"; // Provides winner information for animations
+import { useWinnerCards } from "../../hooks/game/useWinnerCards"; // Winning card codes for card-lift animation
 import { useGameResults } from "../../hooks/game/useGameResults"; // Game results display
 
 // other
@@ -687,6 +688,7 @@ const Table = React.memo(() => {
 
     // invoke hook for seat loop
     const { winnerInfo } = useWinnerInfo();
+    const winnerCards = useWinnerCards();
 
     // Zoom is now handled by the table layout configuration
     // const calculateZoom = useCallback(() => { ... }, []);
@@ -1341,6 +1343,7 @@ const Table = React.memo(() => {
                                 isSitAndGoWaitingForPlayers={isSitAndGoWaitingForPlayers}
                                 cardBackStyle={cardBackStyle}
                                 tableTheme={tableStyle}
+                                winnerCards={winnerCards}
                             />
 
                             {/* Chips — map screen position to rotated seat number */}

--- a/src/components/playPage/Table/components/TableBoard.tsx
+++ b/src/components/playPage/Table/components/TableBoard.tsx
@@ -30,6 +30,9 @@ export interface TableBoardProps {
     // Styling
     cardBackStyle: CardBackStyle;
     tableTheme?: TableTheme;
+
+    // Winning hand cards — cards in this set get the lift animation
+    winnerCards?: Set<string>;
 }
 
 export const TableBoard: React.FC<TableBoardProps> = ({
@@ -38,7 +41,8 @@ export const TableBoard: React.FC<TableBoardProps> = ({
     communityCards,
     isSitAndGoWaitingForPlayers,
     cardBackStyle,
-    tableTheme = "modern"
+    tableTheme = "modern",
+    winnerCards
 }) => {
     // Memoize community cards rendering
     const communityCardsElements = useMemo(() => {
@@ -55,13 +59,21 @@ export const TableBoard: React.FC<TableBoardProps> = ({
             }
         }
 
+        const hasWinningCards = (winnerCards?.size ?? 0) > 0;
+
         return Array.from({ length: 5 }).map((_, idx) => {
             const card = communityCards[idx];
             const isVisible = idx < contiguousCount && card && card !== "??" && card !== "XX";
+            const isWinCard = isVisible && hasWinningCards && (winnerCards!.has(card));
+            const shouldMute = isVisible && hasWinningCards && !winnerCards!.has(card);
 
             if (isVisible) {
                 return (
-                    <div key={`${idx}-${card}`} className="card animate-fall" style={{ animationDelay: `${idx * 150}ms` }}>
+                    <div
+                        key={`${idx}-${card}`}
+                        className={`card animate-fall${isWinCard ? " animate-win-card" : ""}${shouldMute ? " opacity-40" : ""}`}
+                        style={{ animationDelay: `${idx * 150}ms` }}
+                    >
                         <OppositePlayerCards frontSrc={getCardImageUrl(card)} backSrc={getCardBackUrl(cardBackStyle)} flipped />
                     </div>
                 );
@@ -75,7 +87,7 @@ export const TableBoard: React.FC<TableBoardProps> = ({
                 );
             }
         });
-    }, [communityCards, cardBackStyle]);
+    }, [communityCards, cardBackStyle, winnerCards]);
 
     return (
         <>

--- a/src/hooks/game/useWinnerCards.ts
+++ b/src/hooks/game/useWinnerCards.ts
@@ -1,0 +1,16 @@
+import { useMemo } from "react";
+import { useWinnerInfo } from "./useWinnerInfo";
+
+/**
+ * Returns a Set of card codes (e.g. "AS", "KH") that form the winning hand(s).
+ * Used to apply the card-lift animation to the specific cards that won.
+ * Returns an empty Set when there is no winner or the backend hasn't sent cards yet.
+ */
+export const useWinnerCards = (): Set<string> => {
+    const { winnerInfo } = useWinnerInfo();
+
+    return useMemo(() => {
+        const cards = winnerInfo?.flatMap(w => w.cards ?? []) ?? [];
+        return new Set(cards);
+    }, [winnerInfo]);
+};


### PR DESCRIPTION
- Add `useWinnerCards` hook to build a Set of winning card codes from WinnerDTO.cards
- Apply `animate-win-card` CSS lift animation to each card that forms the winning hand
- Mute non-winning cards to opacity-40 (community cards, hero and opponent hole cards)
- Fix animate-fall fill-mode: both → backwards so CSS opacity classes are not overridden
- Per-card granularity: only the exact 5 cards of the best hand are lifted; the rest fade

<img width="1280" height="807" alt="telegram-cloud-photo-size-5-6102934518445576379-y" src="https://github.com/user-attachments/assets/82bc778a-577a-4399-b075-88750d74f420" />
