### PR TITLE
fix(ui): keep Top-Up Chips button visible while seated (#401)

### DIFF
--- a/src/components/BuyChipsButton.tsx
+++ b/src/components/BuyChipsButton.tsx
@@ -15,10 +15,11 @@ interface BuyChipsButtonProps {
 /**
  * BuyChipsButton component
  *
- * Displays a button in the bottom-left corner of the table UI that allows
- * players to top up their chip stack when not in an active hand.
+ * Displays a Top-Up Chips button at the bottom-right of the table UI.
+ * Visible whenever the user is seated (#401); the disabled state reflects
+ * whether the chain currently accepts a top-up request.
  *
- * Location: Bottom-left corner of table screen (as per issue #774)
+ * Location: Bottom-right of table screen (as per issue #774).
  */
 const BuyChipsButton: React.FC<BuyChipsButtonProps> = ({
     tableId,
@@ -49,9 +50,9 @@ const BuyChipsButton: React.FC<BuyChipsButtonProps> = ({
                 className={`px-4 py-2 rounded-lg font-medium text-white shadow-md transition-all duration-200 ${
                     canTopUp ? styles.topUpEnabled : styles.topUpDisabled
                 }`}
-                title={canTopUp ? "Add chips to your stack" : "Cannot top up during an active hand"}
+                title={canTopUp ? "Add chips for the next hand" : "Top-up not available right now"}
             >
-                💰 BUY CHIPS
+                💰 TOP-UP CHIPS
             </button>
 
             {showModal && (

--- a/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
@@ -92,7 +92,7 @@ beforeEach(() => {
 });
 
 describe("PlayerActionButtons", () => {
-    it("renders nothing visible when display kind is none and no top-up available", () => {
+    it("renders only the Top-Up Chips wrapper when display kind is none and no top-up legal (#401)", () => {
         const { container } = render(
             <PlayerActionButtons
                 {...baseProps}
@@ -101,8 +101,11 @@ describe("PlayerActionButtons", () => {
                 legalActions={[]}
             />
         );
-        // BuyChipsButton is mocked to return null, so container should be empty
-        expect(container.firstChild).toBeNull();
+        // Per #401 AC-1 the Top-Up Chips button slot is always present while seated;
+        // its inner BuyChipsButton (mocked here) renders disabled when chain rejects.
+        // Confirm: a single wrapper div, no other action panels.
+        expect(container.children).toHaveLength(1);
+        expect(container.firstChild).toHaveClass("fixed", "z-30");
     });
 
     it("renders waiting for players message for solo player", () => {

--- a/src/components/playPage/Table/components/PlayerActionButtons.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.tsx
@@ -194,9 +194,11 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
         }, DIRTY_STATE_TIMEOUT_MS);
         return () => clearTimeout(t);
     }, [pendingActionCount]);
-    // Buy Chips button rendered independently (bottom-right, opposite to action buttons)
+    // Top-Up Chips button: always visible while the user is seated (#401).
+    // Disabled state is driven by `canTopUp` so the chain rejection (e.g. ACTIVE
+    // status with current PVM verify rules) shows greyed-out rather than hidden.
     const buyChipsElement =
-        canTopUp && tableId ? (
+        isCurrentUserSeated && tableId ? (
             <div className={`fixed z-30 ${buyChipsPositionClass}`}>
                 <BuyChipsButton
                     tableId={tableId}


### PR DESCRIPTION
## Summary
- Switch the bottom-right Top-Up Chips button visibility from `canTopUp` to `isCurrentUserSeated`, so the button stays present whenever the user has a seat (per #401 AC-1).
- Rebrand the label from **BUY CHIPS** → **TOP-UP CHIPS**, with title/tooltip copy updated to match.
- The disabled state now reflects whether the chain currently accepts a top-up (`canTopUp`) — players see a greyed-out affordance instead of the button vanishing mid-hand.

## Test plan
- [ ] Sit at a table, observe Top-Up Chips button persists across hand stages (pre-flop, flop, turn, river, between hands).
- [ ] Verify button is disabled (not hidden) when chain rejects top-up (e.g. ACTIVE status mid-hand under current PVM verify rules).
- [ ] Verify button is not rendered when the user is a spectator / not seated.
- [ ] Run `yarn test PlayerActionButtons` — updated test asserts wrapper div is present when `displayKind === none`.
- [ ] Confirm the modal still opens / behaves as before once enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)