### PR TITLE
fix(ui): hide top-up chips button in SNG games

### DIFF
--- a/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { NonPlayerActionType, PlayerStatus } from "@block52/poker-vm-sdk";
+import { GameFormat, NonPlayerActionType, PlayerStatus } from "@block52/poker-vm-sdk";
 import { PlayerActionButtons, PlayerActionButtonsProps } from "./PlayerActionButtons";
 import { SIT_IN_METHOD_POST_NOW } from "../../../../hooks/playerActions";
 import type { NetworkEndpoints } from "../../../../context/NetworkContext";
@@ -27,8 +27,9 @@ jest.mock("../../../common/actionHandlers", () => ({
 // reads actionCount from this context. These tests don't exercise that
 // pathway (they assert render structure + click handlers), so a static
 // stub is sufficient.
+const mockGameStateContext = { gameState: { actionCount: 0 }, gameFormat: undefined as GameFormat | undefined };
 jest.mock("../../../../context/GameStateContext", () => ({
-    useGameStateContext: () => ({ gameState: { actionCount: 0 } }),
+    useGameStateContext: () => mockGameStateContext,
 }));
 
 // Mock GameSettingsContext — the seat-at-bottom toggle added in
@@ -184,6 +185,21 @@ describe("PlayerActionButtons", () => {
         );
         expect(screen.getByText("You are spectating this table")).toBeInTheDocument();
         expect(screen.getByText("To join the table, click on an available seat.")).toBeInTheDocument();
+    });
+
+    it("hides BuyChipsButton in SNG games even when TOP_UP is in legalActions", () => {
+        mockGameStateContext.gameFormat = GameFormat.SIT_AND_GO;
+        const { container } = render(
+            <PlayerActionButtons
+                {...baseProps}
+                legalActions={[action(NonPlayerActionType.TOP_UP)]}
+                totalSeatedPlayers={3}
+                handNumber={2}
+            />
+        );
+        // The wrapping div for BuyChipsButton should not be rendered in SNG
+        expect(container.querySelector(".fixed.z-30")).toBeNull();
+        mockGameStateContext.gameFormat = undefined;
     });
 
     it("renders both sit-out checkboxes when SIT_OUT action available", () => {

--- a/src/components/playPage/Table/components/PlayerActionButtons.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.tsx
@@ -8,7 +8,7 @@
 
 import React, { useState, useEffect, useRef } from "react";
 
-import { LegalActionDTO, NonPlayerActionType } from "@block52/poker-vm-sdk";
+import { GameFormat, LegalActionDTO, NonPlayerActionType } from "@block52/poker-vm-sdk";
 import { handleSitOut, handleSitIn } from "../../../common/actionHandlers";
 import { SIT_IN_METHOD_POST_NOW, useAutoSitOutNextBB } from "../../../../hooks/playerActions";
 import type { NetworkEndpoints } from "../../../../context/NetworkContext";
@@ -86,7 +86,7 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
     //     (canonical "chain processed it" signal)
     //   • DIRTY_STATE_TIMEOUT_MS elapses (escape hatch)
     //   • handleSitIn throws (CheckTx rejected — clear immediately)
-    const { gameState } = useGameStateContext();
+    const { gameState, gameFormat } = useGameStateContext();
     const { seatAtBottom, toggleSeatAtBottom } = useGameSettings();
     const [sittingIn, setSittingIn] = useState(false);
     const [pendingActionCount, setPendingActionCount] = useState<number | null>(null);
@@ -123,9 +123,10 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
         hasActivePlayers
     });
 
-    // Top-up: check if TOP_UP is in legal actions
+    // Top-up: check if TOP_UP is in legal actions (never available in SNG)
     const topUpAction = legalActions.find(a => a.action === NonPlayerActionType.TOP_UP);
-    const canTopUp = !!topUpAction && !!tableId;
+    const isSNG = gameFormat === GameFormat.SIT_AND_GO;
+    const canTopUp = !!topUpAction && !!tableId && !isSNG;
     const { topUp } = useTableTopUp(tableId || "", currentNetwork);
 
     const handleTopUp = async (amount: string) => {
@@ -194,11 +195,12 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
         }, DIRTY_STATE_TIMEOUT_MS);
         return () => clearTimeout(t);
     }, [pendingActionCount]);
-    // Top-Up Chips button: always visible while the user is seated (#401).
+    // Top-Up Chips button: always visible while the user is seated (#401),
+    // but completely hidden in SNG games where top-ups are not allowed (#2172).
     // Disabled state is driven by `canTopUp` so the chain rejection (e.g. ACTIVE
     // status with current PVM verify rules) shows greyed-out rather than hidden.
     const buyChipsElement =
-        isCurrentUserSeated && tableId ? (
+        isCurrentUserSeated && tableId && !isSNG ? (
             <div className={`fixed z-30 ${buyChipsPositionClass}`}>
                 <BuyChipsButton
                     tableId={tableId}


### PR DESCRIPTION
## Summary

- Hide the "Buy Chips" top-up button entirely for SNG (sit-and-go) games — players cannot rebuy or top up in SNGs
- Added `isSNG` check using `gameFormat` from `GameStateContext` to gate both `canTopUp` and `buyChipsElement`
- New test verifying the button wrapper is absent when format is `SIT_AND_GO`

Fixes block52/poker-vm#2172

## Test plan

- [x] New test: "hides BuyChipsButton in SNG games even when TOP_UP is in legalActions"
- [x] All 9 PlayerActionButtons tests pass
- [ ] Manual: verify button hidden on SNG table, visible on cash table

🤖 Generated with [Claude Code](https://claude.com/claude-code)