### PR TITLE
chore: bump @block52/poker-vm-sdk to 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "=https://paymentservice.texashodl.net",
   "dependencies": {
-    "@block52/poker-vm-sdk": "1.2.2",
+    "@block52/poker-vm-sdk": "1.2.4",
     "@metamask/sdk": "^0.34.0",
     "@reown/appkit": "1.6.7",
     "@reown/appkit-adapter-ethers": "1.6.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,10 +306,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@block52/poker-vm-sdk@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.2.2.tgz#581a1949a728519b9c9697f2f46b018f3e4147ce"
-  integrity sha512-BlY3SCSfGj9oH7FiF+AS/k44B/h/68cgUI/tj03T2yhGfpWpwYkyy1MKkZSXnL5+EXrSaKjE1Kj9X6tes8RsPw==
+"@block52/poker-vm-sdk@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.2.4.tgz#1488b50c7460cbcbca72a83f3ab20bec76253737"
+  integrity sha512-IL3Ckfa/g5dPwlty5BvlSicFYuc5RxkybC0PZSSqTFVDTgMpoPHPlmPU6WhOEHf6/I9WDBG0bX5rkXbo9ggLBw==
   dependencies:
     "@bufbuild/protobuf" "^2.10.0"
     "@cosmjs/crypto" "^0.32.4"


### PR DESCRIPTION
Bumps the SDK from `1.2.2` to `1.2.4`, which registers `MsgForceCloseGame` and fixes the `Unregistered type url: /pokerchain.poker.v1.MsgForceCloseGame` error when signing a force-close from the UI.

- `package.json`: `1.2.2` → `1.2.4`
- `yarn.lock`: resolves `@block52/poker-vm-sdk@1.2.4`

See block52/poker-vm#2185 (SDK fix) and block52/poker-vm#2173 (force-close feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)