### PR TITLE
perf(ui): FE CPU #1 — kill redundant polling, memoize providers and hook returns

### DIFF
--- a/src/context/GameSettingsContext.tsx
+++ b/src/context/GameSettingsContext.tsx
@@ -8,7 +8,7 @@
  * value is present, preserving backwards compatibility.
  */
 
-import React, { createContext, useContext, useState, useCallback } from "react";
+import React, { createContext, useContext, useState, useCallback, useMemo } from "react";
 import { getAutoDealEnabled, getAutoPostBlindsEnabled, getAutoNewHandEnabled, getAutoFoldEnabled } from "../utils/urlParams";
 
 const LS_KEY_AUTO_DEAL = "setting_autodeal";
@@ -140,30 +140,46 @@ export const GameSettingsProvider: React.FC<{ children: React.ReactNode }> = ({ 
         });
     }, []);
 
-    return (
-        <GameSettingsContext.Provider
-            value={{
-                autoDeal,
-                autoPostBlinds,
-                autoNewHand,
-                autoFold,
-                autoMuck,
-                turnNotificationSound,
-                playerActionSounds,
-                seatAtBottom,
-                toggleAutoDeal,
-                toggleAutoPostBlinds,
-                toggleAutoNewHand,
-                toggleAutoFold,
-                toggleAutoMuck,
-                toggleTurnNotificationSound,
-                togglePlayerActionSounds,
-                toggleSeatAtBottom
-            }}
-        >
-            {children}
-        </GameSettingsContext.Provider>
+    const value = useMemo<GameSettingsContextValue>(
+        () => ({
+            autoDeal,
+            autoPostBlinds,
+            autoNewHand,
+            autoFold,
+            autoMuck,
+            turnNotificationSound,
+            playerActionSounds,
+            seatAtBottom,
+            toggleAutoDeal,
+            toggleAutoPostBlinds,
+            toggleAutoNewHand,
+            toggleAutoFold,
+            toggleAutoMuck,
+            toggleTurnNotificationSound,
+            togglePlayerActionSounds,
+            toggleSeatAtBottom
+        }),
+        [
+            autoDeal,
+            autoPostBlinds,
+            autoNewHand,
+            autoFold,
+            autoMuck,
+            turnNotificationSound,
+            playerActionSounds,
+            seatAtBottom,
+            toggleAutoDeal,
+            toggleAutoPostBlinds,
+            toggleAutoNewHand,
+            toggleAutoFold,
+            toggleAutoMuck,
+            toggleTurnNotificationSound,
+            togglePlayerActionSounds,
+            toggleSeatAtBottom
+        ]
     );
+
+    return <GameSettingsContext.Provider value={value}>{children}</GameSettingsContext.Provider>;
 };
 
 export const useGameSettings = (): GameSettingsContextValue => useContext(GameSettingsContext);

--- a/src/context/NetworkContext.tsx
+++ b/src/context/NetworkContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, ReactNode } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState, ReactNode } from "react";
 
 /**
  * NetworkEndpoints describes all endpoints for a given network.
@@ -169,11 +169,11 @@ export const NetworkProvider: React.FC<{ children: ReactNode }> = ({ children })
         localStorage.setItem(DISCOVERED_NETWORKS_KEY, JSON.stringify(discoveredNetworks));
     }, [discoveredNetworks]);
 
-    const setNetwork = (network: NetworkEndpoints) => {
+    const setNetwork = useCallback((network: NetworkEndpoints) => {
         setCurrentNetwork(network);
-    };
+    }, []);
 
-    const addDiscoveredNetwork = (network: NetworkEndpoints) => {
+    const addDiscoveredNetwork = useCallback((network: NetworkEndpoints) => {
         setDiscoveredNetworks(prev => {
             // Avoid duplicates by name
             if (prev.some(n => n.name === network.name)) {
@@ -185,26 +185,25 @@ export const NetworkProvider: React.FC<{ children: ReactNode }> = ({ children })
             }
             return [...prev, network];
         });
-    };
+    }, []);
 
-    const removeDiscoveredNetwork = (name: string) => {
+    const removeDiscoveredNetwork = useCallback((name: string) => {
         setDiscoveredNetworks(prev => prev.filter(n => n.name !== name));
-    };
+    }, []);
 
-    return (
-        <NetworkContext.Provider
-            value={{
-                currentNetwork,
-                setNetwork,
-                availableNetworks: NETWORK_PRESETS,
-                discoveredNetworks,
-                addDiscoveredNetwork,
-                removeDiscoveredNetwork
-            }}
-        >
-            {children}
-        </NetworkContext.Provider>
+    const value = useMemo<NetworkContextType>(
+        () => ({
+            currentNetwork,
+            setNetwork,
+            availableNetworks: NETWORK_PRESETS,
+            discoveredNetworks,
+            addDiscoveredNetwork,
+            removeDiscoveredNetwork
+        }),
+        [currentNetwork, setNetwork, discoveredNetworks, addDiscoveredNetwork, removeDiscoveredNetwork]
     );
+
+    return <NetworkContext.Provider value={value}>{children}</NetworkContext.Provider>;
 };
 
 export const useNetwork = (): NetworkContextType => {

--- a/src/context/PaymentApiContext.tsx
+++ b/src/context/PaymentApiContext.tsx
@@ -1,11 +1,14 @@
-import { createContext, FC, ReactNode, useContext } from "react";
+import { createContext, FC, ReactNode, useContext, useMemo } from "react";
 import { PaymentApi } from "../apis/Api";
 import { PROXY_URL } from "../config/constants";
 
 const PaymentApiContext = createContext<PaymentApi>(null as any);
 
 export const PaymentApiProvider: FC<{ children: ReactNode }> = ({ children }) => {
-    const api = new PaymentApi({ baseUrl: PROXY_URL!, secure: true, timeout: 5000 });
+    const api = useMemo(
+        () => new PaymentApi({ baseUrl: PROXY_URL!, secure: true, timeout: 5000 }),
+        []
+    );
 
     return <PaymentApiContext.Provider value={api}>{children}</PaymentApiContext.Provider>;
 };

--- a/src/hooks/game/useCosmosGameState.ts
+++ b/src/hooks/game/useCosmosGameState.ts
@@ -98,21 +98,13 @@ export const useCosmosGameState = (gameId: string, playerAddress?: string): UseC
         }
     }, [gameId, cosmosClient, fetchGameState]);
 
-    // Fetch data on mount and when dependencies change
-    useEffect(() => {
-        fetchGameState();
-    }, [fetchGameState]);
-
-    // Set up polling for real-time updates
+    // Fetch once on mount. Real-time updates come from GameStateContext via WebSocket;
+    // consumers needing live data should use useGameStateContext() instead of this hook.
     useEffect(() => {
         if (!gameId) return;
-
-        const interval = setInterval(() => {
-            fetchGameState();
-        }, 5000); // Poll every 5 seconds
-
-        return () => clearInterval(interval);
-    }, [gameId, fetchGameState]);
+        fetchGameState();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [gameId, playerAddress]);
 
     return {
         gameState,

--- a/src/hooks/game/useDealerPosition.ts
+++ b/src/hooks/game/useDealerPosition.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useGameStateContext } from "../../context/GameStateContext";
 
 /**
@@ -5,13 +6,16 @@ import { useGameStateContext } from "../../context/GameStateContext";
  * @returns Object containing dealer seat number and loading state
  */
 export const useDealerPosition = () => {
-    // Get game state directly from Context
     const { gameState, isLoading, error } = useGameStateContext();
 
-    // Return dealer seat number from game state
-    return {
-        dealerSeat: gameState?.dealer || null,
-        isLoading,
-        error
-    };
+    const dealerSeat = gameState?.dealer || null;
+
+    return useMemo(
+        () => ({
+            dealerSeat,
+            isLoading,
+            error
+        }),
+        [dealerSeat, isLoading, error]
+    );
 };

--- a/src/hooks/game/useGameResults.ts
+++ b/src/hooks/game/useGameResults.ts
@@ -1,12 +1,10 @@
+import { useMemo } from "react";
 import { useGameStateContext } from "../../context/GameStateContext";
 
 export const useGameResults = () => {
     const { gameState } = useGameStateContext();
-    
-    // Extract results from game state
+
     const results = gameState?.results || null;
-    
-    return {
-        results
-    };
+
+    return useMemo(() => ({ results }), [results]);
 };

--- a/src/hooks/game/useMinAndMaxBuyIns.ts
+++ b/src/hooks/game/useMinAndMaxBuyIns.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useGameStateContext } from "../../context/GameStateContext";
 import { MinAndMaxBuyInsReturn } from "../../types/index";
 
@@ -14,24 +15,26 @@ import { MinAndMaxBuyInsReturn } from "../../types/index";
  * @returns Object containing min/max buy-in values in USDC micro-units (6 decimals)
  */
 export const useMinAndMaxBuyIns = (): MinAndMaxBuyInsReturn => {
-    // Get game state directly from Context - real-time data via WebSocket
     const { gameState, isLoading, error } = useGameStateContext();
 
-    // Per Commandment 7: NO defaults - return undefined if data not available
-    if (isLoading || error || !gameState?.gameOptions) {
-        return {
-            minBuyIn: undefined,
-            maxBuyIn: undefined,
-            isLoading,
-            error
-        };
-    }
+    const minBuyIn = gameState?.gameOptions?.minBuyIn;
+    const maxBuyIn = gameState?.gameOptions?.maxBuyIn;
+    const dataReady = !isLoading && !error && !!gameState?.gameOptions;
 
-    // Pass through values directly from chain - no conversion heuristics
-    return {
-        minBuyIn: gameState.gameOptions.minBuyIn,
-        maxBuyIn: gameState.gameOptions.maxBuyIn,
-        isLoading: false,
-        error: null
-    };
+    return useMemo<MinAndMaxBuyInsReturn>(() => {
+        if (!dataReady) {
+            return {
+                minBuyIn: undefined,
+                maxBuyIn: undefined,
+                isLoading,
+                error
+            };
+        }
+        return {
+            minBuyIn,
+            maxBuyIn,
+            isLoading: false,
+            error: null
+        };
+    }, [dataReady, minBuyIn, maxBuyIn, isLoading, error]);
 };


### PR DESCRIPTION
Closes #422. Part of #421.

## Summary
- Removes the 5s `setInterval` in `useCosmosGameState` — the same data is already streamed via `GameStateContext` WebSocket. Hook had no consumers; left in place but no longer polls.
- Wraps three provider values in `useMemo` so consumers stop re-rendering on every parent re-render:
  - `GameSettingsContext` (8 settings + 8 togglers)
  - `NetworkContext` (also memoizes `setNetwork` / `addDiscoveredNetwork` / `removeDiscoveredNetwork` via `useCallback`)
  - `PaymentApiContext` (`new PaymentApi(...)` no longer reconstructed every render — preserves interceptors)
- Memoizes return objects of `useGameResults`, `useDealerPosition`, `useMinAndMaxBuyIns` so downstream `React.memo`'d components can actually skip work.

## Test plan
- [x] `yarn test` — 782/782 pass
- [x] `yarn lint` — no new errors in changed files (only pre-existing `react-refresh/only-export-components` warnings)
- [x] `yarn tsc --noEmit` — no new TS errors (one pre-existing error in `useForceCloseGame.ts` exists on `main`)
- [ ] Manual smoke: open a cash table, confirm WS updates still propagate and settings toggles still work
- [ ] Spot check React DevTools profiler: toggling a setting should no longer re-render the table tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)