### PR TITLE
chore(playerActions): lint cleanup across hand-action hooks

### DIFF
--- a/src/hooks/playerActions/betHand.ts
+++ b/src/hooks/playerActions/betHand.ts
@@ -15,13 +15,11 @@ import type { PlayerActionResult } from "../../types";
 export async function betHand(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         PlayerActionType.BET,
         amount
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/callHand.ts
+++ b/src/hooks/playerActions/callHand.ts
@@ -15,13 +15,11 @@ import type { PlayerActionResult } from "../../types";
 export async function callHand(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         PlayerActionType.CALL,
         amount
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/checkHand.ts
+++ b/src/hooks/playerActions/checkHand.ts
@@ -14,13 +14,11 @@ import type { PlayerActionResult } from "../../types";
 export async function checkHand(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         PlayerActionType.CHECK,
         0n
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/dealCards.ts
+++ b/src/hooks/playerActions/dealCards.ts
@@ -14,13 +14,11 @@ import type { PlayerActionResult } from "../../types";
 export async function dealCards(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         NonPlayerActionType.DEAL,
         0n
     );
-
 
     return {
         hash: transactionHash,
@@ -45,14 +43,12 @@ export async function dealCardsWithEntropy(
 ): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         NonPlayerActionType.DEAL,
         0n,
         entropy  // Pass entropy as optional data parameter
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/foldHand.ts
+++ b/src/hooks/playerActions/foldHand.ts
@@ -14,13 +14,11 @@ import type { PlayerActionResult } from "../../types";
 export async function foldHand(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         PlayerActionType.FOLD,
         0n
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/joinTable.ts
+++ b/src/hooks/playerActions/joinTable.ts
@@ -1,5 +1,4 @@
 import { COSMOS_CONSTANTS } from "@block52/poker-vm-sdk";
-import { NonPlayerActionType } from "@block52/poker-vm-sdk";
 import { getSigningClient } from "../../utils/cosmos/client";
 import type { JoinTableOptions } from "./types";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
@@ -21,7 +20,6 @@ export async function joinTable(tableId: string, options: JoinTableOptions, netw
 
     const { signingClient } = await getSigningClient(network);
 
-
     // Convert buy-in amount from USDC to micro-USDC (b52usdc)
     // options.amount is in USDC (e.g., "5.00"), need to convert to micro-units (e.g., 5000000)
     const amountInUsdc = parseFloat(options.amount);
@@ -32,14 +30,12 @@ export async function joinTable(tableId: string, options: JoinTableOptions, netw
         ? options.seatNumber
         : 0;
 
-
     // Call SigningCosmosClient.joinGame()
     const transactionHash = await signingClient.joinGame(
         tableId,
         seat,
         buyInAmount
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/muckCards.ts
+++ b/src/hooks/playerActions/muckCards.ts
@@ -14,13 +14,11 @@ import type { PlayerActionResult } from "../../types";
 export async function muckCards(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         PlayerActionType.MUCK,
         0n
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/postBigBlind.ts
+++ b/src/hooks/playerActions/postBigBlind.ts
@@ -15,13 +15,11 @@ import type { PlayerActionResult } from "../../types";
 export async function postBigBlind(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         PlayerActionType.BIG_BLIND,
         amount
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/postSmallBlind.ts
+++ b/src/hooks/playerActions/postSmallBlind.ts
@@ -15,13 +15,11 @@ import type { PlayerActionResult } from "../../types";
 export async function postSmallBlind(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         PlayerActionType.SMALL_BLIND,
         amount
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/raiseHand.ts
+++ b/src/hooks/playerActions/raiseHand.ts
@@ -15,13 +15,11 @@ import type { PlayerActionResult } from "../../types";
 export async function raiseHand(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         PlayerActionType.RAISE,
         amount
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/showCards.ts
+++ b/src/hooks/playerActions/showCards.ts
@@ -14,13 +14,11 @@ import type { PlayerActionResult } from "../../types";
 export async function showCards(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         PlayerActionType.SHOW,
         0n
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/sitIn.ts
+++ b/src/hooks/playerActions/sitIn.ts
@@ -22,16 +22,7 @@ export async function sitIn(
     network: NetworkEndpoints,
     method: SitInMethod = SIT_IN_METHOD_POST_NOW
 ): Promise<PlayerActionResult> {
-    console.log("🔧 sitIn() called with:", { tableId, method });
-    console.log("🔑 Getting signing client...");
     const { signingClient } = await getSigningClient(network);
-
-    console.log("📡 Calling SDK performAction with:", {
-        tableId,
-        action: NonPlayerActionType.SIT_IN,
-        amount: "0n",
-        data: `method=${method}`
-    });
 
     const transactionHash = await signingClient.performActionSync(
         tableId,
@@ -39,8 +30,6 @@ export async function sitIn(
         0n,
         `method=${method}`
     );
-
-    console.log("✅ performAction returned hash:", transactionHash);
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/startNewHand.ts
+++ b/src/hooks/playerActions/startNewHand.ts
@@ -14,13 +14,11 @@ import type { PlayerActionResult } from "../../types";
 export async function startNewHand(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         NonPlayerActionType.NEW_HAND,
         0n
     );
-
 
     return {
         hash: transactionHash,

--- a/src/hooks/playerActions/useAutoShowCards.ts
+++ b/src/hooks/playerActions/useAutoShowCards.ts
@@ -55,7 +55,6 @@ export function useAutoShowCards(
     useEffect(() => {
         const shouldAutoShow = hasShowAction && isUsersTurn && timeRemaining === 0 && !hasTriggeredRef.current && !isProcessingRef.current;
 
-        console.log("useAutoShowCards conditions:", shouldAutoShow);
         if (shouldAutoShow) {
             hasTriggeredRef.current = true;
             const timeoutId = setTimeout(() => {

--- a/src/hooks/playerActions/useOptimisticAction.ts
+++ b/src/hooks/playerActions/useOptimisticAction.ts
@@ -67,13 +67,11 @@ async function executeAction(
 ): Promise<PlayerActionResult> {
     const { signingClient } = await getSigningClient(network);
 
-
     const transactionHash = await signingClient.performActionSync(
         tableId,
         action,
         amount
     );
-
 
     return {
         hash: transactionHash,
@@ -113,11 +111,13 @@ export function useOptimisticAction(): UseOptimisticActionReturn {
                 throw new Error(`Amount required for ${action}`);
             }
 
-            // Step 1: Send via WebSocket for immediate optimistic broadcast
+            // Step 1: Send via WebSocket for immediate optimistic broadcast.
+            // If this fails, fall through to the SDK transaction anyway — the WS
+            // broadcast is purely a latency optimization for other subscribers.
             try {
                 await sendAction(action, amount?.toString());
-            } catch (wsError) {
-                // WebSocket notification failed - continue with transaction anyway
+            } catch {
+                // intentional: WS broadcast is best-effort
             }
 
             // Step 2: Execute the blockchain transaction via SDK

--- a/src/hooks/playerActions/usePlayerLegalActions.ts
+++ b/src/hooks/playerActions/usePlayerLegalActions.ts
@@ -28,24 +28,17 @@ const debugLog = (eventType: string, data: any) => {
  * @returns Object containing the player's legal actions and related information
  */
 export function usePlayerLegalActions(): PlayerLegalActionsResult {
-    // 🎯 PERFORMANCE FIX: Move localStorage access outside render cycle
-    const [userAddress, setUserAddress] = useState<string | null>(null);
-
-    useEffect(() => {
-        // Use Cosmos address instead of Ethereum address
-        const address = localStorage.getItem("user_cosmos_address")?.toLowerCase();
-        setUserAddress(address || null);
-    }, []);
+    // localStorage is synchronous — read once via useState's initializer so we
+    // don't trigger an extra render with a setState-in-effect.
+    const [userAddress] = useState<string | null>(
+        () => localStorage.getItem("user_cosmos_address")?.toLowerCase() || null
+    );
 
     const { gameState } = useGameData();
     const { isLoading, error } = useGameUI();
 
     // Add ref to track last logged state to prevent spam
     const lastLoggedStateRef = useRef<string>("");
-
-    // 🔍 DEBUG: Only log when meaningful state changes occur
-    const renderCount = useRef(0);
-    renderCount.current += 1;
 
     // 🎯 PERFORMANCE FIX: Memoize expensive calculations
     // Only recalculate when relevant game state properties change
@@ -158,8 +151,7 @@ export function usePlayerLegalActions(): PlayerLegalActionsResult {
                 isPlayerTurn: result.isPlayerTurn,
                 gameRound: gameState?.round,
                 nextToAct: gameState?.nextToAct,
-                legalActionCount: result.legalActions.length,
-                renderCount: renderCount.current
+                legalActionCount: result.legalActions.length
             });
 
             // Only log if the state actually changed
@@ -176,7 +168,6 @@ export function usePlayerLegalActions(): PlayerLegalActionsResult {
                         max: action.max,
                         index: action.index
                     })),
-                    renderCount: renderCount.current,
                     source: "usePlayerLegalActions (memoized)"
                 });
                 lastLoggedStateRef.current = currentState;


### PR DESCRIPTION
Pre-cleanup for #427 (signing client singleton), but valuable on its own. All lint errors and warnings under \`src/hooks/playerActions/\` now resolved.

## Summary
- **\`usePlayerLegalActions\`** — deletes the debug render-counter (mutating a ref during render is a hard lint error in the current rule set, and the counter was only echoed into debug logs). Switches the \`userAddress\` localStorage read from a \`useState\` + \`useEffect\` dance to a \`useState\` initializer, so we don't trigger an extra render on mount.
- **\`useOptimisticAction\`** — drops the unused \`wsError\` binding (catch is intentionally swallowing — comment explains why).
- **\`sitIn\` / \`useAutoShowCards\`** — removes stray debug \`console.log\` calls.
- **\`joinTable\`** — drops the unused \`NonPlayerActionType\` import.
- **All action files** — collapses double-blank-line gaps to single blanks, matching the existing style.

No behavioural changes.

## Test plan
- [x] \`npx eslint src/hooks/playerActions/\` — 0 problems
- [x] \`yarn tsc --noEmit\` — clean
- [x] \`yarn test\` — 782/782 pass
- [ ] Manual smoke: join a cash table, perform a bet → call → raise → fold sequence, confirm actions still broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)