### PR TITLE
perf(action): memoize getSigningClient — kill per-action PBKDF2 stall + RPC handshake

### DIFF
--- a/src/components/CosmosWalletPage.tsx
+++ b/src/components/CosmosWalletPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { generateWallet as generateWalletSDK, createWalletFromMnemonic as createWalletSDK, getAddressFromMnemonic } from "@block52/poker-vm-sdk";
 import { setCosmosMnemonic, setCosmosAddress, getCosmosMnemonic, getCosmosAddress, clearCosmosData, isValidSeedPhrase } from "../utils/cosmos";
+import { clearCosmosClient } from "../utils/cosmos/client";
 import { AnimatedBackground } from "./common/AnimatedBackground";
 import useUserWalletConnect from "../hooks/wallet/useUserWalletConnect";
 import styles from "./CosmosWalletPage.module.css";
@@ -139,6 +140,8 @@ const CosmosWalletPage = () => {
     const handleClearWallet = () => {
         if (window.confirm("Are you sure you want to clear your wallet? Make sure you have saved your seed phrase!")) {
             clearCosmosData();
+            // Drop both cached clients so derived keys don't outlive the wallet.
+            clearCosmosClient();
             setMnemonic("");
             setAddress("");
             setShowMnemonic(false);

--- a/src/utils/cosmos/client.test.ts
+++ b/src/utils/cosmos/client.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for the promise-memoized signing client.
+ *
+ * The whole point of caching is to dedupe an expensive PBKDF2 derivation
+ * across actions in a single session. Without a test that pins the dedup
+ * behaviour, the cache can silently regress (e.g. the cache key drifts
+ * out of sync with the inputs, or someone refactors away the cache hit).
+ */
+
+import type { NetworkEndpoints } from "./urls";
+
+// Mock the SDK so we can count derivations without doing real BIP39 work.
+const createSigningClientFromMnemonic = jest.fn();
+
+jest.mock("@block52/poker-vm-sdk", () => ({
+    CosmosClient: jest.fn(),
+    SigningCosmosClient: jest.fn(),
+    createSigningClientFromMnemonic: (...args: unknown[]) => createSigningClientFromMnemonic(...args),
+    getDefaultCosmosConfig: () => ({
+        chainId: "test-chain",
+        prefix: "b52",
+        denom: "stake",
+        gasPrice: "0stake"
+    }),
+    COSMOS_CONSTANTS: {
+        CHAIN_ID: "test-chain",
+        ADDRESS_PREFIX: "b52"
+    }
+}));
+
+// Mock storage so we don't need a real localStorage.
+const mockAddress = jest.fn<string | null, []>();
+const mockMnemonic = jest.fn<string | null, []>();
+jest.mock("./storage", () => ({
+    getCosmosAddress: () => mockAddress(),
+    getCosmosMnemonic: () => mockMnemonic()
+}));
+
+import { getSigningClient, clearSigningClientCache, withSigningClientRetry } from "./client";
+
+const NETWORK_A: NetworkEndpoints = {
+    name: "A",
+    rpc: "https://node-a.example/rpc/",
+    rest: "https://node-a.example",
+    grpc: "grpcs://node-a.example:9443",
+    ws: "wss://node-a.example/ws"
+};
+
+const NETWORK_B: NetworkEndpoints = {
+    name: "B",
+    rpc: "https://node-b.example/rpc/",
+    rest: "https://node-b.example",
+    grpc: "grpcs://node-b.example:9443",
+    ws: "wss://node-b.example/ws"
+};
+
+const MNEMONIC = "test test test test test test test test test test test junk";
+const ADDRESS_1 = "b521aaaa";
+const ADDRESS_2 = "b521bbbb";
+
+describe("getSigningClient", () => {
+    beforeEach(() => {
+        clearSigningClientCache();
+        createSigningClientFromMnemonic.mockReset();
+        mockAddress.mockReturnValue(ADDRESS_1);
+        mockMnemonic.mockReturnValue(MNEMONIC);
+
+        // Default: each derivation returns a fresh fake client.
+        createSigningClientFromMnemonic.mockImplementation(async () => ({
+            performActionSync: jest.fn(),
+            disconnect: jest.fn()
+        }));
+    });
+
+    it("derives the signing client only once across repeated calls in the same session", async () => {
+        await getSigningClient(NETWORK_A);
+        await getSigningClient(NETWORK_A);
+        await getSigningClient(NETWORK_A);
+
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(1);
+    });
+
+    it("dedupes concurrent callers into a single in-flight derivation", async () => {
+        // Slow derivation so both calls land while the first is still pending.
+        let resolveDerivation!: (client: unknown) => void;
+        createSigningClientFromMnemonic.mockImplementationOnce(
+            () => new Promise(resolve => { resolveDerivation = resolve; })
+        );
+
+        const first = getSigningClient(NETWORK_A);
+        const second = getSigningClient(NETWORK_A);
+
+        resolveDerivation({ performActionSync: jest.fn() });
+        const [a, b] = await Promise.all([first, second]);
+
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(1);
+        expect(a.signingClient).toBe(b.signingClient);
+    });
+
+    it("rebuilds when the network endpoints change", async () => {
+        await getSigningClient(NETWORK_A);
+        await getSigningClient(NETWORK_B);
+
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(2);
+    });
+
+    it("rebuilds when the wallet address changes (wallet swap)", async () => {
+        mockAddress.mockReturnValue(ADDRESS_1);
+        await getSigningClient(NETWORK_A);
+
+        mockAddress.mockReturnValue(ADDRESS_2);
+        await getSigningClient(NETWORK_A);
+
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(2);
+    });
+
+    it("rebuilds after clearSigningClientCache()", async () => {
+        await getSigningClient(NETWORK_A);
+        clearSigningClientCache();
+        await getSigningClient(NETWORK_A);
+
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(2);
+    });
+
+    it("drops the cache when derivation rejects so the next call retries", async () => {
+        createSigningClientFromMnemonic.mockRejectedValueOnce(new Error("boom"));
+
+        await expect(getSigningClient(NETWORK_A)).rejects.toThrow("boom");
+
+        // Allow the rejection-handler microtask to run.
+        await Promise.resolve();
+
+        // Second call should build a fresh promise rather than returning the rejected one.
+        createSigningClientFromMnemonic.mockResolvedValueOnce({ performActionSync: jest.fn() });
+        await getSigningClient(NETWORK_A);
+
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws if the wallet is not initialized", async () => {
+        mockMnemonic.mockReturnValue(null);
+
+        await expect(getSigningClient(NETWORK_A)).rejects.toThrow(/wallet not initialized/i);
+        expect(createSigningClientFromMnemonic).not.toHaveBeenCalled();
+    });
+});
+
+describe("withSigningClientRetry", () => {
+    beforeEach(() => {
+        clearSigningClientCache();
+        createSigningClientFromMnemonic.mockReset();
+        mockAddress.mockReturnValue(ADDRESS_1);
+        mockMnemonic.mockReturnValue(MNEMONIC);
+        createSigningClientFromMnemonic.mockImplementation(async () => ({
+            performActionSync: jest.fn(),
+            disconnect: jest.fn()
+        }));
+    });
+
+    it("passes through successful results without rebuilding the client", async () => {
+        const result = await withSigningClientRetry(NETWORK_A, async ({ signingClient }) => {
+            return signingClient ? "ok" : "no-client";
+        });
+
+        expect(result).toBe("ok");
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry application errors (e.g. CheckTx rejection)", async () => {
+        const appError = new Error("insufficient gas");
+
+        await expect(
+            withSigningClientRetry(NETWORK_A, async () => { throw appError; })
+        ).rejects.toThrow("insufficient gas");
+
+        // No second client build — we don't want to double-submit a tx the chain rejected.
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries once on transport errors with a fresh client", async () => {
+        let callCount = 0;
+        await withSigningClientRetry(NETWORK_A, async () => {
+            callCount++;
+            if (callCount === 1) throw new Error("ECONNRESET: socket disconnected");
+            return "recovered";
+        });
+
+        // First client + rebuilt client = 2 derivations.
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(2);
+        expect(callCount).toBe(2);
+    });
+
+    it("only retries once even if the rebuilt client also fails with a transport error", async () => {
+        const err = new Error("network unreachable");
+
+        await expect(
+            withSigningClientRetry(NETWORK_A, async () => { throw err; })
+        ).rejects.toThrow("network unreachable");
+
+        // First client + one rebuild attempt = 2 derivations, no more.
+        expect(createSigningClientFromMnemonic).toHaveBeenCalledTimes(2);
+    });
+});

--- a/src/utils/cosmos/client.ts
+++ b/src/utils/cosmos/client.ts
@@ -5,7 +5,7 @@
  * with singleton pattern for the frontend.
  */
 
-import { CosmosClient, createSigningClientFromMnemonic, getDefaultCosmosConfig as getDefaultCosmosConfigSDK, COSMOS_CONSTANTS } from "@block52/poker-vm-sdk";
+import { CosmosClient, SigningCosmosClient, createSigningClientFromMnemonic, getDefaultCosmosConfig as getDefaultCosmosConfigSDK, COSMOS_CONSTANTS } from "@block52/poker-vm-sdk";
 import { getCosmosAddress, getCosmosMnemonic } from "./storage";
 import { getCosmosUrls, type NetworkEndpoints } from "./urls";
 
@@ -107,26 +107,49 @@ export const getCosmosClient = (
 };
 
 /**
- * Clear the cached client instance (useful when changing wallets or networks)
+ * Clear the cached client instance (useful when changing wallets or networks).
+ * Also clears the signing-client cache so the next action rebuilds against
+ * fresh endpoints / wallet material.
  */
 export const clearCosmosClient = (): void => {
     clientInstance = null;
     currentEndpoints = null;
+    clearSigningClientCache();
 };
 
 /**
- * Creates a signing client for performing player actions on the Cosmos blockchain.
+ * Promise-memoized signing client.
  *
- * This is a wrapper around createSigningClientFromMnemonic that:
- * - Retrieves the mnemonic from storage
- * - Configures the client with the correct network endpoints
- * - Uses consistent chain configuration (chainId, prefix, denom, gasPrice)
+ * createSigningClientFromMnemonic does two expensive things on every call:
+ *   1. HD wallet derivation from the mnemonic — BIP39 PBKDF2 (2048 rounds)
+ *      plus secp256k1 BIP32 derivation. Tens of ms on the main thread.
+ *   2. connectWithSigner opens a Tendermint RPC connection and does a
+ *      status handshake — a network round-trip.
  *
- * @param network - The network configuration to use
- * @returns Promise with the signing client
+ * Neither needs to be redone per bet/call/raise — the result is identical
+ * for the whole session. We cache the *promise* (not the resolved value)
+ * so concurrent callers (e.g. a rapid bet→raise misclick) share a single
+ * in-flight construction instead of building two clients in parallel.
+ *
+ * The cache key is `address|rpcEndpoint|restEndpoint` so it invalidates
+ * naturally on wallet swap or network switch.
+ */
+type SigningClientResult = { signingClient: SigningCosmosClient; userAddress: string };
+
+let signingClientCache: {
+    key: string;
+    promise: Promise<SigningClientResult>;
+} | null = null;
+
+/**
+ * Get (or build and cache) the signing client for the current wallet + network.
+ *
+ * Returns the same Promise across concurrent calls within a session, so
+ * the expensive PBKDF2 derivation runs once per (wallet, network) pair.
+ *
  * @throws Error if Cosmos wallet is not initialized (no mnemonic or address)
  */
-export async function getSigningClient(network: NetworkEndpoints) {
+export async function getSigningClient(network: NetworkEndpoints): Promise<SigningClientResult> {
     const userAddress = getCosmosAddress();
     const mnemonic = getCosmosMnemonic();
 
@@ -135,8 +158,13 @@ export async function getSigningClient(network: NetworkEndpoints) {
     }
 
     const { rpcEndpoint, restEndpoint } = getCosmosUrls(network);
+    const key = `${userAddress}|${rpcEndpoint}|${restEndpoint}`;
 
-    const signingClient = await createSigningClientFromMnemonic(
+    if (signingClientCache?.key === key) {
+        return signingClientCache.promise;
+    }
+
+    const promise = createSigningClientFromMnemonic(
         {
             rpcEndpoint,
             restEndpoint,
@@ -146,7 +174,89 @@ export async function getSigningClient(network: NetworkEndpoints) {
             gasPrice: "0stake" // Gasless
         },
         mnemonic
-    );
+    ).then(signingClient => ({ signingClient, userAddress }));
 
-    return { signingClient, userAddress };
+    // If construction rejects, drop the cache so the next call retries
+    // instead of returning a permanently-failed promise.
+    promise.catch(() => {
+        if (signingClientCache?.promise === promise) {
+            signingClientCache = null;
+        }
+    });
+
+    signingClientCache = { key, promise };
+    return promise;
+}
+
+/**
+ * Clear the cached signing client.
+ *
+ * Call on: logout, wallet import/change, network switch.
+ *
+ * Also call from the action layer's error handler when a broadcast fails
+ * with a connection-level error (stale RPC socket, node restart, etc.) —
+ * see withSigningClientRetry below for the standard retry-once wrapper.
+ */
+export function clearSigningClientCache(): void {
+    const previous = signingClientCache;
+    signingClientCache = null;
+    // Best-effort cleanup — disconnect if the SDK exposes it.
+    previous?.promise
+        .then(c => (c.signingClient as { disconnect?: () => void }).disconnect?.())
+        .catch(() => { /* already-rejected promise, nothing to disconnect */ });
+}
+
+/**
+ * Run an action against the signing client. If it fails with a transport-
+ * shaped error (the cached connection went stale), clear the cache and
+ * retry exactly once with a fresh client.
+ *
+ * Use this in the action layer wherever you'd previously call
+ * `const { signingClient } = await getSigningClient(network)` directly:
+ *
+ *   const hash = await withSigningClientRetry(network, ({ signingClient }) =>
+ *       signingClient.performActionSync(tableId, action, amount)
+ *   );
+ *
+ * CheckTx rejections (invalid signature, insufficient gas, malformed msg)
+ * are application errors, not transport errors — those are NOT retried.
+ */
+export async function withSigningClientRetry<T>(
+    network: NetworkEndpoints,
+    fn: (client: SigningClientResult) => Promise<T>
+): Promise<T> {
+    const client = await getSigningClient(network);
+    try {
+        return await fn(client);
+    } catch (err) {
+        if (!isTransportError(err)) {
+            throw err;
+        }
+        clearSigningClientCache();
+        const fresh = await getSigningClient(network);
+        return fn(fresh);
+    }
+}
+
+/**
+ * Heuristic: does this error look like a dead RPC connection rather than
+ * a chain-level rejection? We err on the side of NOT retrying — a false
+ * negative here just means we don't retry a recoverable failure; a false
+ * positive could double-submit a tx that was actually rejected.
+ */
+function isTransportError(err: unknown): boolean {
+    if (!err || typeof err !== "object") return false;
+    const message = (err as { message?: unknown }).message;
+    if (typeof message !== "string") return false;
+    const lower = message.toLowerCase();
+    return (
+        lower.includes("network") ||
+        lower.includes("fetch") ||
+        lower.includes("socket") ||
+        lower.includes("econnreset") ||
+        lower.includes("econnrefused") ||
+        lower.includes("etimedout") ||
+        lower.includes("disconnected") ||
+        lower.includes("connection")
+    );
 }


### PR DESCRIPTION
Closes #427. Part of #421.

## Summary
- Caches \`createSigningClientFromMnemonic\` by \`(address, rpcEndpoint, restEndpoint)\` for the session. Eliminates the per-action BIP39 PBKDF2 derivation (2048 rounds, tens of ms on the main thread) plus the \`connectWithSigner\` RPC handshake — both were being paid on every bet/call/raise even though the result is identical session-wide.
- Caches the *promise* rather than the resolved value, so concurrent callers (rapid bet→raise misclick) share a single in-flight build instead of triggering two parallel derivations. If derivation rejects, the cache drops itself so the next call retries rather than returning a permanently-failed promise.
- Adds \`withSigningClientRetry(network, fn)\` for the action layer: runs \`fn\` against the cached client; on a *transport-shaped* error (socket disconnected, network unreachable) clears the cache and retries once with a fresh client. CheckTx rejections (insufficient gas, invalid signature) are NOT retried — those are application errors and retrying could double-submit a tx the chain rejected.

## Invalidation triggers
| Event | Path |
|---|---|
| Network switch | Automatic — endpoint cache-key miss, next call rebuilds |
| Wallet swap / logout | \`clearCosmosClient()\` now chains into \`clearSigningClientCache()\`, and \`CosmosWalletPage\`'s clear-wallet handler calls \`clearCosmosClient()\` |
| Stale RPC connection mid-session | \`withSigningClientRetry\` opt-in wrapper handles transport errors with a fresh-client retry |

## What I deliberately did NOT do
- **Did not migrate the ~20 action wrappers** (\`betHand\`, \`callHand\`, etc.) to use \`withSigningClientRetry\`. They still call \`getSigningClient\` directly. The retry wrapper is an opt-in helper — migrating each call site is a follow-up so reviewers can ship the cache win immediately without auditing every action path.
- **Did not move the derivation off the main thread.** \`performActionSync\` is CheckTx-only (~50–100ms per #427's research), so the PBKDF2 stall is the dominant first-action UX symptom. A Web Worker move is the stretch goal in #427; this PR ships the foundational caching first.
- **Did not change \`NetworkContext\`.** The cache key includes endpoints, so network switches invalidate by miss. No explicit clear needed.

## Test plan
- [x] \`yarn test\` — 793/793 pass (11 new unit tests for the singleton)
- [x] \`yarn tsc --noEmit\` — clean
- [x] \`yarn lint\` — no new errors

New tests pin the dedup behaviour explicitly:
- Repeated calls in a session derive once
- Concurrent callers share the in-flight promise (not two parallel derivations)
- Network switch rebuilds
- Wallet swap rebuilds
- \`clearSigningClientCache\` rebuilds
- Post-rejection cache drop (next call retries instead of returning the rejected promise)
- \`withSigningClientRetry\` passes through success
- \`withSigningClientRetry\` does NOT retry application errors (would risk double-submission)
- \`withSigningClientRetry\` retries once on transport errors with a fresh client
- \`withSigningClientRetry\` retries exactly once even if the rebuilt client also fails

## Manual smoke (for reviewer)
- [ ] Join a cash table, perform a bet → call → raise → fold sequence — confirm actions still submit
- [ ] Switch networks mid-session, perform an action — confirm it works (new client gets built)
- [ ] Clear the wallet via CosmosWalletPage, re-import, perform an action — confirm fresh derivation
- [ ] Optional: Chrome DevTools Performance tab on the first action vs subsequent actions — should see a noticeable drop in main-thread time on actions 2+ (PBKDF2 no longer running)

## Follow-ups (out of scope)
- Migrate \`useOptimisticAction\` and individual action wrappers to use \`withSigningClientRetry\` so stale-connection failures self-heal
- Move \`createSigningClientFromMnemonic\` into a Web Worker (#427 stretch goal) to get the first-action PBKDF2 stall fully off the main thread
- Architectural decision between #432 and #433 on how the action layer should look — this PR is compatible with either

🤖 Generated with [Claude Code](https://claude.com/claude-code)