### PR TITLE
feat(action): Option B step 1 — fire optimistic WS broadcast on every player action

### DIFF
--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -18,6 +18,7 @@ import { useTableState, useNextToActInfo } from "../../hooks";
 import { useActionSounds } from "../../hooks/notifications/useActionSounds";
 import { usePlayerLegalActions } from "../../hooks/playerActions/usePlayerLegalActions";
 import { useGameStateContext } from "../../context/GameStateContext";
+import { useGameActions } from "../../context/gameState/GameActionsContext";
 import { useGameSettings } from "../../context/GameSettingsContext";
 import { dealCardsWithEntropy } from "../../hooks/playerActions/dealCards";
 import { useAutoDeal } from "../../hooks/playerActions/useAutoDeal";
@@ -98,6 +99,10 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
 
     // Get game state and player data
     const { gameState, gameFormat } = useGameStateContext();
+    // Optimistic WS broadcaster — every click handler announces the action over
+    // the table's WebSocket before the REST submission, so other clients get a
+    // sub-100ms preview instead of waiting on chain commit (~5s).
+    const { sendAction } = useGameActions();
     const isTournament = isTournamentFormat(gameFormat);
     const players = gameState?.players || null;
     const { legalActions, isPlayerTurn, playerStatus } = usePlayerLegalActions();
@@ -398,7 +403,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         if (!tableId || smallBlindMicro === 0n) return;
 
         await handleActionWithTransaction("small-blind", async () => {
-            return await handlePostSmallBlind(tableId, smallBlindMicro, network);
+            return await handlePostSmallBlind(tableId, smallBlindMicro, network, sendAction);
         });
     };
 
@@ -406,7 +411,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         if (!tableId || bigBlindMicro === 0n) return;
 
         await handleActionWithTransaction("big-blind", async () => {
-            return await handlePostBigBlind(tableId, bigBlindMicro, network);
+            return await handlePostBigBlind(tableId, bigBlindMicro, network, sendAction);
         });
     };
 
@@ -415,7 +420,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         const amountMicro = fromDisplay(raiseAmount);
 
         await handleActionWithTransaction("bet", async () => {
-            return await handleBet(amountMicro, tableId, network);
+            return await handleBet(amountMicro, tableId, network, sendAction);
         });
     };
 
@@ -424,7 +429,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         const amountMicro = fromDisplay(raiseAmount);
 
         await handleActionWithTransaction("raise", async () => {
-            return await handleRaise(tableId, amountMicro, network);
+            return await handleRaise(tableId, amountMicro, network, sendAction);
         });
     };
 
@@ -472,7 +477,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         }
         await handleActionWithTransaction(
             hasRaiseAction ? "raise" : "bet",
-            async () => (hasRaiseAction ? await handleRaise(tableId, amountMicro, network) : await handleBet(amountMicro, tableId, network)),
+            async () => (hasRaiseAction ? await handleRaise(tableId, amountMicro, network, sendAction) : await handleBet(amountMicro, tableId, network, sendAction)),
             true
         );
     };
@@ -506,7 +511,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
                             action="new-hand"
                             label="START NEW HAND"
                             loading={loadingAction === "new-hand"}
-                            onClick={() => handleActionWithTransaction("new-hand", () => handleStartNewHand(tableId, network))}
+                            onClick={() => handleActionWithTransaction("new-hand", () => handleStartNewHand(tableId, network, sendAction))}
                             variant="primary"
                             className="px-6 lg:px-8 py-2 lg:py-3 text-sm lg:text-base font-bold"
                         />
@@ -522,8 +527,8 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
                                 canMuck={hasMuckAction}
                                 canShow={hasShowAction}
                                 loading={loadingAction}
-                                onMuck={() => handleActionWithTransaction("muck", () => handleMuck(tableId, network))}
-                                onShow={() => handleActionWithTransaction("show", () => handleShow(tableId, network))}
+                                onMuck={() => handleActionWithTransaction("muck", () => handleMuck(tableId, network, sendAction))}
+                                onShow={() => handleActionWithTransaction("show", () => handleShow(tableId, network, sendAction))}
                             />
                         )}
 
@@ -541,7 +546,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
                                 isTournament={isTournament}
                                 onPostSmallBlind={handlePostSmallBlindAction}
                                 onPostBigBlind={handlePostBigBlindAction}
-                                onFold={() => handleActionWithTransaction("fold", () => handleFold(tableId, network))}
+                                onFold={() => handleActionWithTransaction("fold", () => handleFold(tableId, network, sendAction))}
                             />
                         )}
 
@@ -569,9 +574,9 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
                                     previousActions={gameState?.previousActions || []}
                                     userAddress={userAddress || ""}
                                     isTournament={isTournament}
-                                    onFold={() => handleActionWithTransaction("fold", () => handleFold(tableId, network))}
-                                    onCheck={() => handleActionWithTransaction("check", () => handleCheck(tableId, network))}
-                                    onCall={() => handleActionWithTransaction("call", () => handleCall(callAmountMicro, tableId, network))}
+                                    onFold={() => handleActionWithTransaction("fold", () => handleFold(tableId, network, sendAction))}
+                                    onCheck={() => handleActionWithTransaction("check", () => handleCheck(tableId, network, sendAction))}
+                                    onCall={() => handleActionWithTransaction("call", () => handleCall(callAmountMicro, tableId, network, sendAction))}
                                     onBetOrRaise={hasRaiseAction ? handleRaiseAction : handleBetAction}
                                 />
 

--- a/src/components/common/actionHandlers.ts
+++ b/src/components/common/actionHandlers.ts
@@ -17,6 +17,30 @@ import {
 } from "../../hooks/playerActions";
 import type { SitInMethod, SitOutMethod } from "../../hooks/playerActions";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
+import { PlayerActionType, NonPlayerActionType } from "@block52/poker-vm-sdk";
+
+/**
+ * Optimistic WS broadcaster — the function returned by useGameActions().sendAction.
+ *
+ * Every click handler announces the action over the table's WebSocket *before*
+ * submitting the real REST transaction. The announcement gives other clients
+ * watching the same table a sub-100ms optimistic update; the REST submission
+ * (~50–100ms CheckTx + ~5s commit) is the authoritative path.
+ *
+ * Failure of the WS announcement is non-fatal — we always proceed with the
+ * REST submission so the user's action still goes through.
+ */
+export type OptimisticBroadcaster = (action: string, amount?: string) => Promise<void>;
+
+/**
+ * Fire-and-forget WS announcement. Swallows errors so a dead WebSocket
+ * never blocks the real REST submission below it.
+ */
+function announce(send: OptimisticBroadcaster, action: string, amount?: string): void {
+    send(action, amount).catch(err => {
+        console.warn(`[actionHandlers] optimistic broadcast for ${action} failed:`, err);
+    });
+}
 
 /**
  * Result type from player action functions
@@ -44,14 +68,18 @@ interface ActionHandlerOptions {
  */
 function createSimpleHandler(
     actionName: string,
+    wsAction: PlayerActionType | NonPlayerActionType,
     actionFn: (tableId: string, network: NetworkEndpoints) => Promise<ActionResult | null>,
     options: ActionHandlerOptions = {}
 ) {
     return async (
         tableId: string | undefined,
-        network: NetworkEndpoints
+        network: NetworkEndpoints,
+        send: OptimisticBroadcaster
     ): Promise<string | null> => {
         if (!tableId) return null;
+
+        announce(send, wsAction);
 
         try {
             const result = await actionFn(tableId, network);
@@ -70,15 +98,19 @@ function createSimpleHandler(
  */
 function createAmountFirstHandler(
     actionName: string,
+    wsAction: PlayerActionType | NonPlayerActionType,
     actionFn: (tableId: string, amount: bigint, network: NetworkEndpoints) => Promise<ActionResult | null>,
     options: ActionHandlerOptions = {}
 ) {
     return async (
         amount: bigint,
         tableId: string | undefined,
-        network: NetworkEndpoints
+        network: NetworkEndpoints,
+        send: OptimisticBroadcaster
     ): Promise<string | null> => {
         if (!tableId) return null;
+
+        announce(send, wsAction, amount.toString());
 
         try {
             const result = await actionFn(tableId, amount, network);
@@ -97,15 +129,19 @@ function createAmountFirstHandler(
  */
 function createTableIdAmountHandler(
     actionName: string,
+    wsAction: PlayerActionType | NonPlayerActionType,
     actionFn: (tableId: string, amount: bigint, network: NetworkEndpoints) => Promise<ActionResult | null>,
     options: ActionHandlerOptions = {}
 ) {
     return async (
         tableId: string | undefined,
         amount: bigint,
-        network: NetworkEndpoints
+        network: NetworkEndpoints,
+        send: OptimisticBroadcaster
     ): Promise<string | null> => {
         if (!tableId) return null;
+
+        announce(send, wsAction, amount.toString());
 
         try {
             const result = await actionFn(tableId, amount, network);
@@ -122,26 +158,28 @@ function createTableIdAmountHandler(
 // Simple handlers (tableId, network) -> Promise<string | null>
 // =============================================================================
 
-const handleCheck = createSimpleHandler("check", checkHand);
+const handleCheck = createSimpleHandler("check", PlayerActionType.CHECK, checkHand);
 
-const handleFold = createSimpleHandler("fold", foldHand);
+const handleFold = createSimpleHandler("fold", PlayerActionType.FOLD, foldHand);
 
-const handleMuck = createSimpleHandler("muck cards", muckCards);
+const handleMuck = createSimpleHandler("muck cards", PlayerActionType.MUCK, muckCards);
 
-const handleShow = createSimpleHandler("show cards", showCards);
+const handleShow = createSimpleHandler("show cards", PlayerActionType.SHOW, showCards);
 
-const handleDeal = createSimpleHandler("deal", dealCards, {
+const handleDeal = createSimpleHandler("deal", NonPlayerActionType.DEAL, dealCards, {
     successLog: "Deal completed successfully"
 });
 
-const handleStartNewHand = createSimpleHandler("start new hand", startNewHand);
+const handleStartNewHand = createSimpleHandler("start new hand", NonPlayerActionType.NEW_HAND, startNewHand);
 
 const handleSitOut = async (
     tableId: string | undefined,
     network: NetworkEndpoints,
+    send: OptimisticBroadcaster,
     method: SitOutMethod = SIT_OUT_METHOD_NEXT_HAND
 ): Promise<string | null> => {
     if (!tableId) return null;
+    announce(send, NonPlayerActionType.SIT_OUT);
     try {
         const result = await sitOut(tableId, network, method);
         return result?.hash || null;
@@ -154,6 +192,7 @@ const handleSitOut = async (
 const handleSitIn = async (
     tableId: string | undefined,
     network: NetworkEndpoints,
+    send: OptimisticBroadcaster,
     method: SitInMethod = SIT_IN_METHOD_POST_NOW
 ): Promise<string | null> => {
     console.log("🎲 handleSitIn called with:", { tableId, network, method });
@@ -161,6 +200,7 @@ const handleSitIn = async (
         console.error("❌ handleSitIn: tableId is undefined");
         return null;
     }
+    announce(send, NonPlayerActionType.SIT_IN);
     try {
         console.log("📞 Calling sitIn action...");
         const result = await sitIn(tableId, network, method);
@@ -180,13 +220,13 @@ const handleSitIn = async (
  * Handle call action
  * @param amount - Amount in micro-units as bigint (10^6 precision)
  */
-const handleCall = createAmountFirstHandler("call", callHand);
+const handleCall = createAmountFirstHandler("call", PlayerActionType.CALL, callHand);
 
 /**
  * Handle bet action
  * @param amount - Amount in micro-units as bigint (10^6 precision)
  */
-const handleBet = createAmountFirstHandler("bet", betHand);
+const handleBet = createAmountFirstHandler("bet", PlayerActionType.BET, betHand);
 
 // =============================================================================
 // TableId-amount handlers (tableId, amount, network) -> Promise<string | null>
@@ -196,7 +236,7 @@ const handleBet = createAmountFirstHandler("bet", betHand);
  * Handle post small blind action
  * @param amount - Amount in micro-units as bigint (10^6 precision)
  */
-const handlePostSmallBlind = createTableIdAmountHandler("post small blind", postSmallBlind, {
+const handlePostSmallBlind = createTableIdAmountHandler("post small blind", PlayerActionType.SMALL_BLIND, postSmallBlind, {
     attemptLog: "🎰 Attempting to post small blind:",
     successLog: "✅ Small blind posted successfully"
 });
@@ -205,7 +245,7 @@ const handlePostSmallBlind = createTableIdAmountHandler("post small blind", post
  * Handle post big blind action
  * @param amount - Amount in micro-units as bigint (10^6 precision)
  */
-const handlePostBigBlind = createTableIdAmountHandler("post big blind", postBigBlind, {
+const handlePostBigBlind = createTableIdAmountHandler("post big blind", PlayerActionType.BIG_BLIND, postBigBlind, {
     successLog: "✅ Big blind posted successfully"
 });
 
@@ -213,7 +253,7 @@ const handlePostBigBlind = createTableIdAmountHandler("post big blind", postBigB
  * Handle raise action
  * @param amount - Amount in micro-units as bigint (10^6 precision)
  */
-const handleRaise = createTableIdAmountHandler("raise", raiseHand);
+const handleRaise = createTableIdAmountHandler("raise", PlayerActionType.RAISE, raiseHand);
 
 // =============================================================================
 // Exports

--- a/src/components/playPage/Players/Player.tsx
+++ b/src/components/playPage/Players/Player.tsx
@@ -15,6 +15,7 @@ import { useSitAndGoPlayerResults } from "../../../hooks/game/useSitAndGoPlayerR
 import { useAllInEquity } from "../../../hooks/player/useAllInEquity";
 import { useProfileAvatar } from "../../../context/profile/ProfileAvatarContext";
 import { useNetwork } from "../../../context/NetworkContext";
+import { useGameActions } from "../../../context/gameState/GameActionsContext";
 import { handleSitIn } from "../../common/actionHandlers";
 import { SIT_IN_METHOD_POST_NOW } from "../../../hooks/playerActions";
 import styles from "./PlayersCommon.module.css";
@@ -31,13 +32,14 @@ const Player: React.FC<PlayerProps & { uiPosition?: number }> = memo(
         const { equities, shouldShow: shouldShowEquity } = useAllInEquity();
         const { getAvatarForAddress } = useProfileAvatar();
         const { currentNetwork } = useNetwork();
+        const { sendAction } = useGameActions();
 
         // Callback for "I'm Back" button on badge
         const handleSitInFromBadge = useCallback(() => {
             if (id) {
-                handleSitIn(id, currentNetwork, SIT_IN_METHOD_POST_NOW);
+                handleSitIn(id, currentNetwork, sendAction, SIT_IN_METHOD_POST_NOW);
             }
-        }, [id, currentNetwork]);
+        }, [id, currentNetwork, sendAction]);
 
         // Check if this seat is the dealer
         const isDealer = dealerSeat === index;

--- a/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.test.tsx
@@ -32,6 +32,20 @@ jest.mock("../../../../context/GameStateContext", () => ({
     useGameStateContext: () => mockGameStateContext,
 }));
 
+// Mock GameActionsContext — the optimistic-broadcast wiring landed for
+// Option B reads sendAction from this context. Static no-op stub keeps
+// these render/click tests focused on existing behaviour; the broadcast
+// itself is fire-and-forget so the action layer doesn't await it.
+const mockSendAction = jest.fn(async () => undefined);
+jest.mock("../../../../context/gameState/GameActionsContext", () => ({
+    useGameActions: () => ({
+        subscribeToTable: jest.fn(),
+        unsubscribeFromTable: jest.fn(),
+        sendAction: mockSendAction,
+        loadHistoricalState: jest.fn(),
+    }),
+}));
+
 // Mock GameSettingsContext — the seat-at-bottom toggle added in
 // block52/ui#392 reads from this context. Static stub keeps these
 // render/click tests focused on the existing behaviour.
@@ -146,6 +160,7 @@ describe("PlayerActionButtons", () => {
         expect(mockHandleSitIn).toHaveBeenCalledWith(
             "table-123",
             mockNetwork,
+            mockSendAction,
             SIT_IN_METHOD_POST_NOW
         );
     });

--- a/src/components/playPage/Table/components/PlayerActionButtons.tsx
+++ b/src/components/playPage/Table/components/PlayerActionButtons.tsx
@@ -17,6 +17,7 @@ import { toast } from "react-toastify";
 import BuyChipsButton from "../../../BuyChipsButton";
 import { useTableTopUp } from "../../../../hooks/game/useTableTopUp";
 import { useGameStateContext } from "../../../../context/GameStateContext";
+import { useGameActions } from "../../../../context/gameState/GameActionsContext";
 import { useGameSettings } from "../../../../context/GameSettingsContext";
 import { isNullish } from "../../../../utils/guards";
 import { findUserSeat } from "../../../../utils/playerSeatUtils";
@@ -87,6 +88,7 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
     //   • DIRTY_STATE_TIMEOUT_MS elapses (escape hatch)
     //   • handleSitIn throws (CheckTx rejected — clear immediately)
     const { gameState, gameFormat } = useGameStateContext();
+    const { sendAction } = useGameActions();
     const { seatAtBottom, toggleSeatAtBottom } = useGameSettings();
     const [sittingIn, setSittingIn] = useState(false);
     const [pendingActionCount, setPendingActionCount] = useState<number | null>(null);
@@ -101,7 +103,7 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
 
     const handleToggleSitOutNextHand = () => {
         setOptimisticChecked(!isChecked);
-        handleSitOut(tableId, currentNetwork);
+        handleSitOut(tableId, currentNetwork, sendAction);
     };
 
     useAutoSitOutNextBB(
@@ -144,13 +146,13 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
             hasTriggeredAutoSitIn.current = true;
             console.log("🚀 Bootstrap: auto-sending SIT_IN for table:", tableId);
             // Bootstrap: method is irrelevant, use post-now (next-bb deferred, poker-vm#1895)
-            handleSitIn(tableId, currentNetwork, SIT_IN_METHOD_POST_NOW);
+            handleSitIn(tableId, currentNetwork, sendAction, SIT_IN_METHOD_POST_NOW);
         }
         // Reset when no longer in auto-sit-in state
         if (display.kind !== "auto-sit-in") {
             hasTriggeredAutoSitIn.current = false;
         }
-    }, [display.kind, tableId, currentNetwork]);
+    }, [display.kind, tableId, currentNetwork, sendAction]);
 
     const handleSitInClick = async () => {
         if (!tableId) return toast.error("Table ID is missing. Cannot sit in.");
@@ -159,7 +161,7 @@ export const PlayerActionButtons: React.FC<PlayerActionButtonsProps> = ({
         setSittingIn(true);
         setPendingActionCount(submittedAt);
         try {
-            await handleSitIn(tableId, currentNetwork, SIT_IN_METHOD_POST_NOW);
+            await handleSitIn(tableId, currentNetwork, sendAction, SIT_IN_METHOD_POST_NOW);
             // Success path: let the watcher useEffect clear when the chain
             // confirms via actionCount, or the timeout fires.
         } catch (err) {


### PR DESCRIPTION
Part of #433 (Option B). Companion to #432 (Option A — not pursued).

## The problem this fixes

The optimistic-broadcast machinery already exists end-to-end (\`sendAction\` over the WS, backend rebroadcasts as \`event: \"pending\"\`, FE stores the result in \`pendingAction\` state), but **the click handlers never invoke it**. \`PokerActionPanel\`, \`Player\`, and \`PlayerActionButtons\` all call \`handleBet\` / \`handleFold\` / \`handleSitIn\` / etc. directly — those only run the REST submission.

Net effect: other observers wait the full ~5s chain commit before seeing any update, even though we built a system to give them a sub-100ms preview.

## What this PR does

1. **Bakes \`sendAction\` into \`actionHandlers.ts\`** as a required last parameter on every \`handle*\` factory and inline handler. Each handler announces its SDK enum value (\`PlayerActionType.FOLD\`, \`PlayerActionType.BET\`, \`NonPlayerActionType.SIT_IN\`, etc.) and amount (for bet/call/raise/blinds) over the WS *before* delegating to the SDK submission.
2. **Announcement is fire-and-forget.** A dead WebSocket logs a warn and the REST submission proceeds — the user's action still goes through.
3. **Threads \`sendAction\` through the three call-site components** via \`useGameActions()\` (which already returns stable refs thanks to the slice-context split, so \`Player.tsx\`'s memo boundary doesn't churn).

## What this PR does NOT do (deliberate, for follow-up)

- **Does not wire \`pendingAction\` into player-rendering hooks** (\`usePlayerData\`, \`usePlayerChipData\`, \`usePlayerLegalActions\`, etc.). The acting player still sees a spinner until the chain commit. This PR just ensures the optimistic announcement actually fires so the next PR can consume it.
- **Does not touch \`usePlayerTimer._handleAutoAction\`** (auto-fold/auto-check). It calls \`checkHand\`/\`foldHand\` directly and is currently dead code (the triggering \`useEffect\` is commented out). If/when re-enabled, route it through \`actionHandlers\` like everyone else.

## Test plan
- [x] \`yarn test\` — 793/793 pass (added \`GameActionsContext\` mock + updated sit-in arg assertion in \`PlayerActionButtons.test.tsx\`)
- [x] \`yarn tsc --noEmit\` — clean
- [x] \`yarn lint\` — no new errors (verified via stash-compare; the 18 pre-existing problems in the changed files are all on \`main\`)
- [ ] Manual smoke: open a cash table in two browsers, perform a bet from window A, confirm window B receives a \`pending\` WS message within ~50ms (visible in DevTools network tab → WS frames). Then confirm window A still submits the real tx and the canonical state arrives ~5s later.

## What you'll see in DevTools

Open the WS frames panel on a table and click a button. You should see two outbound messages now:
1. \`{ type: \"action\", action: \"bet\", amount: \"500000\", ... }\` — the new pre-announcement (~ms after click)
2. A subsequent inbound \`{ event: \"pending\", ... }\` — backend echoing to all subscribers

Followed by the existing chain path:
3. CheckTx response from \`performActionSync\` (~50-100ms)
4. Inbound \`{ event: \"state\", ... }\` — canonical state push after chain commit (~5s)

## Architectural framing

This is the smallest useful step toward Option B. After this lands and is confirmed working in DevTools, the follow-up PR will wire \`pendingAction\` into the UI render hooks so the acting player's seat visually mutates from the optimistic broadcast (current behaviour: spinner only). That's the harder reconciliation work — overlay merge + rollback on chain rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)