### PR TITLE
feat(gateway): wire the optimistic gateway transport behind VITE_GAME_TRANSPORT (#440)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,3 +97,6 @@ VITE_ALL_IN_INSTANT_EXECUTE=
 
 # Optimistic WS Action Gateway (poker-vm pvm/go/gateway) — used by GatewayApi (ui#440)
 VITE_GATEWAY_URL=https://pvm.block52.xyz/gateway
+
+# Game transport: chain (default) | gateway — optimistic WS gateway (ui#440)
+VITE_GAME_TRANSPORT=

--- a/.env.example
+++ b/.env.example
@@ -98,5 +98,6 @@ VITE_ALL_IN_INSTANT_EXECUTE=
 # Optimistic WS Action Gateway (poker-vm pvm/go/gateway) — used by GatewayApi (ui#440)
 VITE_GATEWAY_URL=https://pvm.block52.xyz/gateway
 
-# Game transport: chain (default) | gateway — optimistic WS gateway (ui#440)
+# Game transport: gateway (default) | chain — set "chain" to opt out of the
+# optimistic WS gateway (ui#440)
 VITE_GAME_TRANSPORT=

--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,9 @@ module.exports = {
     // Mock WalletConnect/Reown packages that have ESM issues
     '^@reown/appkit/react$': '<rootDir>/src/__mocks__/reownAppkit.js',
     // Mock wagmi (ESM package)
-    '^wagmi$': '<rootDir>/src/__mocks__/wagmi.js'
+    '^wagmi$': '<rootDir>/src/__mocks__/wagmi.js',
+    // import.meta shim (see src/utils/viteEnv.ts)
+    'viteEnv$': '<rootDir>/src/__mocks__/viteEnv.js'
   },
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',

--- a/scripts/gateway-dealer-bot.mjs
+++ b/scripts/gateway-dealer-bot.mjs
@@ -1,0 +1,55 @@
+// Dealer bot: watches a gateway table over WS and fires the chain-anchored
+// actions (deal / new-hand) the FE intentionally doesn't send on
+// gateway-only tables (poker-vm#2221). Signs as the hero wallet, but only
+// ever performs dealer actions — never player decisions.
+import { ethers } from "ethers";
+import { bech32 } from "bech32";
+import WebSocket from "ws";
+
+const [mnemonic, gameId] = process.argv.slice(2);
+const GATEWAY = "https://pvm.block52.xyz/gateway";
+const WS_URL = "wss://pvm.block52.xyz/gateway/ws";
+
+const wallet = ethers.HDNodeWallet.fromPhrase(mnemonic, undefined, "m/44'/118'/0'/0/0");
+const pub = ethers.SigningKey.computePublicKey(wallet.privateKey, true);
+const address = bech32.encode("b52", bech32.toWords(ethers.getBytes(ethers.ripemd160(ethers.sha256(pub)))));
+console.log(`dealer-bot: watching ${gameId} as ${address}`);
+
+let busy = false;
+
+async function send(action, index, data) {
+    const timestamp = Date.now();
+    const payload = `pokerchain-action:${gameId}:${action}:${index}:0:${timestamp}:${data}`;
+    const signature = await wallet.signMessage(payload);
+    const res = await fetch(`${GATEWAY}/actions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ gameId, action, index, amount: "0", timestamp, address, signature, data })
+    });
+    console.log(`dealer-bot: ${action} (index ${index}) -> ${res.status} ${res.ok ? "OK" : await res.text()}`);
+}
+
+function onState(state) {
+    const gameState = state?.gameState ?? state;
+    const me = gameState?.players?.find(p => p.address === address);
+    const legal = me?.legalActions ?? [];
+    const deal = legal.find(a => a.action === "deal");
+    const newHand = legal.find(a => a.action === "new-hand");
+    const next = deal ?? newHand;
+    if (next && !busy) {
+        busy = true;
+        send(next.action, next.index, "").finally(() => setTimeout(() => { busy = false; }, 1500));
+    }
+}
+
+const ws = new WebSocket(WS_URL);
+ws.on("open", () => ws.send(JSON.stringify({ type: "subscribe", gameId })));
+ws.on("message", raw => {
+    try {
+        const msg = JSON.parse(raw.toString());
+        if (msg.type === "state" && msg.state) onState(msg.state);
+        if (msg.type === "error") console.log("dealer-bot: gateway error:", msg.error);
+    } catch { /* ignore */ }
+});
+ws.on("close", () => { console.log("dealer-bot: socket closed"); process.exit(0); });
+setInterval(() => ws.ping?.(), 30000);

--- a/scripts/seed-gateway-table.mjs
+++ b/scripts/seed-gateway-table.mjs
@@ -25,9 +25,14 @@ import { bech32 } from "bech32";
 
 const COSMOS_HD_PATH = "m/44'/118'/0'/0/0";
 const TABLE_ADDRESS = "b521qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6qtnh3";
-const ONE_TOKEN = "100000000000000000";
-const TWO_TOKENS = "200000000000000000";
-const ONE_HUNDRED_TOKENS = "100000000000000000000";
+// Production-scale amounts: micro-USDC, 6 decimals — matching live chain
+// tables ({"minBuyIn":"100000","smallBlind":"10000",...}) so the FE's
+// USDC->micro conversion in the join modal lands inside the buy-in range.
+const SMALL_BLIND = "10000"; // $0.01
+const BIG_BLIND = "20000"; // $0.02
+const MIN_BUY_IN = "100000"; // $0.10
+const MAX_BUY_IN = "2000000"; // $2.00
+const BUY_IN = "1000000"; // $1.00
 
 function arg(name, fallback) {
     const i = process.argv.indexOf(`--${name}`);
@@ -35,7 +40,7 @@ function arg(name, fallback) {
 }
 
 const gatewayUrl = arg("gateway", "https://pvm.block52.xyz/gateway").replace(/\/$/, "");
-const stopAfter = arg("stop-after", "deal"); // join | blinds | deal
+const stopAfter = arg("stop-after", "deal"); // none | join | blinds | deal (none = empty table, join from the UI)
 // Game ids are 0x hashes on-chain — match that shape so FE routing,
 // explorers, and any id-format assumptions behave like production.
 const gameId = arg("table-id", ethers.keccak256(ethers.randomBytes(32)));
@@ -84,41 +89,68 @@ async function act(player, action, index, amount, data) {
 const hero = makeWallet(arg("mnemonic"));
 const villain = makeWallet();
 
+// The engine embeds gameOptions in every state it emits, and FE components
+// read state.gameOptions unguarded — so the seed state must carry it too,
+// not just the record envelope.
+const gameOptions = {
+    minBuyIn: MIN_BUY_IN,
+    maxBuyIn: MAX_BUY_IN,
+    minPlayers: 2,
+    maxPlayers: 9,
+    smallBlind: SMALL_BLIND,
+    bigBlind: BIG_BLIND,
+    timeout: 60000
+};
+
 await post("/tables", {
     gameId,
     record: {
         format: "cash",
         variant: "texas-holdem",
-        gameOptions: {
-            minBuyIn: ONE_HUNDRED_TOKENS,
-            maxBuyIn: "1000000000000000000000",
-            minPlayers: 2,
-            maxPlayers: 9,
-            smallBlind: ONE_TOKEN,
-            bigBlind: TWO_TOKENS,
-            timeout: 60000
-        },
+        gameOptions,
+        // Complete TexasHoldemStateDTO shape: the engine emits every field
+        // on each transition and FE components map over them unguarded, so
+        // the seed state must be the full canonical empty table.
         state: {
             address: TABLE_ADDRESS,
+            gameOptions,
             dealer: null,
-            round: "ante",
-            communityCards: [],
+            smallBlindPosition: 0,
+            bigBlindPosition: 0,
             players: [],
+            communityCards: [],
+            deck: "",
+            pots: ["0"],
+            totalPot: "0",
+            nextToAct: -1,
+            previousActions: [],
+            actionCount: 0,
+            handNumber: 1,
+            round: "ante",
+            winners: [],
+            results: [],
+            legalActions: [],
+            availableSeats: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            signature: "0x0000000000000000000000000000000000000000000000000000000000000000",
             now: Date.now()
         }
     }
 });
 console.log(`table ${gameId} created on ${gatewayUrl}`);
 
-await act(hero, "join", 1, ONE_HUNDRED_TOKENS, "seat=1");
-await act(villain, "join", 2, ONE_HUNDRED_TOKENS, "seat=2");
+if (stopAfter === "none") {
+    console.log("empty table — join from the UI (seat click -> gateway join)");
+} else {
+    await act(hero, "join", 1, BUY_IN, "seat=1");
+await act(villain, "join", 2, BUY_IN, "seat=2");
 if (stopAfter !== "join") {
-    await act(hero, "post-small-blind", 3, ONE_TOKEN, "");
-    await act(villain, "post-big-blind", 4, TWO_TOKENS, "");
+    await act(hero, "post-small-blind", 3, SMALL_BLIND, "");
+    await act(villain, "post-big-blind", 4, BIG_BLIND, "");
 }
-if (stopAfter === "deal") {
-    await act(hero, "deal", 5, "0", "");
-    console.log("hand dealt — hero is seat 1 (small blind), next to act");
+    if (stopAfter === "deal") {
+        await act(hero, "deal", 5, "0", "");
+        console.log("hand dealt — hero is seat 1 (small blind), next to act");
+    }
 }
 
 const snippet = w =>

--- a/scripts/seed-gateway-table.mjs
+++ b/scripts/seed-gateway-table.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Seed a fresh table on the WS Action Gateway and deal a heads-up hand —
+ * fully self-service end-to-end testing for gateway transport mode (ui#440).
+ *
+ *   node scripts/seed-gateway-table.mjs                       # two fresh wallets
+ *   node scripts/seed-gateway-table.mjs --mnemonic "12 words" # you as seat 1
+ *   node scripts/seed-gateway-table.mjs --stop-after blinds   # deal it yourself*
+ *   node scripts/seed-gateway-table.mjs --gateway http://localhost:8546
+ *
+ * Prints the table URL plus localStorage snippets for BOTH seats — open the
+ * hero in your normal browser and the villain in an incognito window to play
+ * both sides of the hand through the gateway.
+ *
+ * (*note: the FE routes deal/new-hand chain-direct per poker-vm#2221, so on
+ * a gateway-only table the deal must come from this script.)
+ *
+ * Key derivation matches the FE (utils/cosmos/signing.ts): ethers
+ * HDNodeWallet at m/44'/118'/0'/0/0; address = bech32(b52,
+ * ripemd160(sha256(compressed pubkey))) — verified byte-identical to the
+ * gateway's Go auth package.
+ */
+import { ethers } from "ethers";
+import { bech32 } from "bech32";
+
+const COSMOS_HD_PATH = "m/44'/118'/0'/0/0";
+const TABLE_ADDRESS = "b521qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6qtnh3";
+const ONE_TOKEN = "100000000000000000";
+const TWO_TOKENS = "200000000000000000";
+const ONE_HUNDRED_TOKENS = "100000000000000000000";
+
+function arg(name, fallback) {
+    const i = process.argv.indexOf(`--${name}`);
+    return i > -1 ? process.argv[i + 1] : fallback;
+}
+
+const gatewayUrl = arg("gateway", "https://pvm.block52.xyz/gateway").replace(/\/$/, "");
+const stopAfter = arg("stop-after", "deal"); // join | blinds | deal
+const gameId = arg("table-id", `seeded-${Date.now()}`);
+
+function makeWallet(mnemonic) {
+    const wallet = mnemonic
+        ? ethers.HDNodeWallet.fromPhrase(mnemonic, undefined, COSMOS_HD_PATH)
+        : ethers.HDNodeWallet.createRandom(undefined, COSMOS_HD_PATH);
+    const pub = ethers.SigningKey.computePublicKey(wallet.privateKey, true);
+    const ripe = ethers.ripemd160(ethers.sha256(pub));
+    const address = bech32.encode("b52", bech32.toWords(ethers.getBytes(ripe)));
+    return { wallet, address, mnemonic: wallet.mnemonic?.phrase ?? mnemonic };
+}
+
+async function post(path, body) {
+    const res = await fetch(`${gatewayUrl}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+    });
+    const text = await res.text();
+    if (!res.ok) {
+        throw new Error(`POST ${path} -> HTTP ${res.status}: ${text}`);
+    }
+    return JSON.parse(text);
+}
+
+// Same canonical payload as utils/cosmos/signing.ts buildActionPayload.
+async function act(player, action, index, amount, data) {
+    const timestamp = Date.now();
+    const payload = `pokerchain-action:${gameId}:${action}:${index}:${amount}:${timestamp}:${data}`;
+    const signature = await player.wallet.signMessage(payload);
+    await post("/actions", {
+        gameId,
+        action,
+        index,
+        amount,
+        timestamp,
+        address: player.address,
+        signature,
+        data
+    });
+    console.log(`  ${index} ${action.padEnd(16)} ok (${player.address.slice(0, 14)}…)`);
+}
+
+const hero = makeWallet(arg("mnemonic"));
+const villain = makeWallet();
+
+await post("/tables", {
+    gameId,
+    record: {
+        format: "cash",
+        variant: "texas-holdem",
+        gameOptions: {
+            minBuyIn: ONE_HUNDRED_TOKENS,
+            maxBuyIn: "1000000000000000000000",
+            minPlayers: 2,
+            maxPlayers: 9,
+            smallBlind: ONE_TOKEN,
+            bigBlind: TWO_TOKENS,
+            timeout: 60000
+        },
+        state: {
+            address: TABLE_ADDRESS,
+            dealer: null,
+            round: "ante",
+            communityCards: [],
+            players: [],
+            now: Date.now()
+        }
+    }
+});
+console.log(`table ${gameId} created on ${gatewayUrl}`);
+
+await act(hero, "join", 1, ONE_HUNDRED_TOKENS, "seat=1");
+await act(villain, "join", 2, ONE_HUNDRED_TOKENS, "seat=2");
+if (stopAfter !== "join") {
+    await act(hero, "post-small-blind", 3, ONE_TOKEN, "");
+    await act(villain, "post-big-blind", 4, TWO_TOKENS, "");
+}
+if (stopAfter === "deal") {
+    await act(hero, "deal", 5, "0", "");
+    console.log("hand dealt — hero is seat 1 (small blind), next to act");
+}
+
+const snippet = w =>
+    `localStorage.setItem("user_cosmos_mnemonic", "${w.mnemonic}");\n` +
+    `localStorage.setItem("user_cosmos_address", "${w.address}");`;
+
+console.log(`
+================================================================
+TABLE  http://localhost:5174/table/${gameId}
+
+HERO (seat 1 — paste in your main browser console, then refresh)
+${snippet(hero)}
+
+VILLAIN (seat 2 — paste in an INCOGNITO window console, then refresh)
+${snippet(villain)}
+
+(throwaway test keys — gateway-only, never funded)
+================================================================`);

--- a/scripts/seed-gateway-table.mjs
+++ b/scripts/seed-gateway-table.mjs
@@ -22,6 +22,7 @@
  */
 import { ethers } from "ethers";
 import { bech32 } from "bech32";
+import { webcrypto } from "node:crypto";
 
 const COSMOS_HD_PATH = "m/44'/118'/0'/0/0";
 const TABLE_ADDRESS = "b521qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6qtnh3";
@@ -44,6 +45,22 @@ const stopAfter = arg("stop-after", "deal"); // none | join | blinds | deal (non
 // Game ids are 0x hashes on-chain — match that shape so FE routing,
 // explorers, and any id-format assumptions behave like production.
 const gameId = arg("table-id", ethers.keccak256(ethers.randomBytes(32)));
+
+function shuffledDeck() {
+    const cards = [];
+    for (const s of ["C", "D", "H", "S"]) {
+        for (const r of ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"]) {
+            cards.push(r + s);
+        }
+    }
+    const rand = new Uint32Array(cards.length);
+    webcrypto.getRandomValues(rand);
+    for (let i = cards.length - 1; i > 0; i--) {
+        const j = rand[i] % (i + 1);
+        [cards[i], cards[j]] = [cards[j], cards[i]];
+    }
+    return cards.join("-");
+}
 
 function makeWallet(mnemonic) {
     const wallet = mnemonic
@@ -114,12 +131,15 @@ await post("/tables", {
         state: {
             address: TABLE_ADDRESS,
             gameOptions,
+            // CSPRNG-shuffled deck for hand 1 — without it the engine's
+            // default deterministic deck deals the same board every time
+            // (poker-vm#2221; chain VRF replaces this via pokerchain#217).
+            deck: shuffledDeck(),
             dealer: null,
             smallBlindPosition: 0,
             bigBlindPosition: 0,
             players: [],
             communityCards: [],
-            deck: "",
             pots: ["0"],
             totalPot: "0",
             nextToAct: -1,

--- a/scripts/seed-gateway-table.mjs
+++ b/scripts/seed-gateway-table.mjs
@@ -36,7 +36,9 @@ function arg(name, fallback) {
 
 const gatewayUrl = arg("gateway", "https://pvm.block52.xyz/gateway").replace(/\/$/, "");
 const stopAfter = arg("stop-after", "deal"); // join | blinds | deal
-const gameId = arg("table-id", `seeded-${Date.now()}`);
+// Game ids are 0x hashes on-chain — match that shape so FE routing,
+// explorers, and any id-format assumptions behave like production.
+const gameId = arg("table-id", ethers.keccak256(ethers.randomBytes(32)));
 
 function makeWallet(mnemonic) {
     const wallet = mnemonic

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import { GameSettingsProvider } from "./context/GameSettingsContext";
 import { generateCSSVariables } from "./utils/colorConfig";
 import { useEffect, useState, lazy, Suspense } from "react";
 import FaviconSetter from "./components/FaviconSetter";
+import { GatewayTransportBanner } from "./components/GatewayTransportBanner";
 import { GlobalHeader } from "./components/GlobalHeader";
 import { ProfileAvatarProvider } from "./context/profile/ProfileAvatarContext";
 import { ProfileAvatarModal } from "./components/profile";
@@ -90,6 +91,7 @@ function AppContent() {
     return (
         <div className="bg-[#2c3245] min-h-screen">
             <FaviconSetter />
+            <GatewayTransportBanner />
             <GlobalHeader />
             <ProfileAvatarModal />
             <Routes>

--- a/src/__mocks__/viteEnv.js
+++ b/src/__mocks__/viteEnv.js
@@ -1,0 +1,3 @@
+// Jest stand-in for src/utils/viteEnv.ts — import.meta is module-only
+// syntax that ts-jest's CommonJS output cannot represent.
+module.exports = { viteEnv: process.env };

--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -17,6 +17,7 @@ import { formatDisplayAmount } from "../../utils/numberUtils";
 import { useTableState, useNextToActInfo } from "../../hooks";
 import { useActionSounds } from "../../hooks/notifications/useActionSounds";
 import { usePlayerLegalActions } from "../../hooks/playerActions/usePlayerLegalActions";
+import { nextActionIndex } from "../../hooks/playerActions/transportAction";
 import { useGameStateContext } from "../../context/GameStateContext";
 import { useGameSettings } from "../../context/GameSettingsContext";
 import { dealCardsWithEntropy } from "../../hooks/playerActions/dealCards";
@@ -69,6 +70,13 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
     // with stale legalActions for the rest of the block budget, letting the
     // player re-click the same action. See block52/ui#364.
     const [pendingActionCount, setPendingActionCount] = useState<number | null>(null);
+
+    // Gateway transport: the engine's actionCount does NOT advance in
+    // gateway states (stays 0), so the actionCount watcher never fires and
+    // every action rode the timeout (ui#440 live-testing). The table's
+    // shared next-action index (any player's legalActions[].index) advances
+    // on every applied action on BOTH transports — watch it too.
+    const [pendingActionIndex, setPendingActionIndex] = useState<number | null>(null);
 
     // How long to wait for the chain to confirm before re-enabling the
     // button anyway. Generous enough to survive a slow WS / 5s commit
@@ -328,6 +336,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
             try {
                 setLoadingAction(actionName);
                 setPendingActionCount(submittedAt);
+                setPendingActionIndex(nextActionIndex(gameState));
                 if (!skipActionSound && playerActionSounds) {
                     playActionSound(actionName);
                 }
@@ -341,22 +350,27 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
                 console.error(`Error executing ${actionName}:`, error);
                 setLoadingAction(null);
                 setPendingActionCount(null);
+                setPendingActionIndex(null);
                 throw error;
             }
         },
         [gameState?.actionCount, onTransactionSubmitted, playActionSound, playerActionSounds]
     );
 
-    // Canonical clear: chain has advanced past the actionCount at which
-    // we submitted, i.e. our action was committed.
+    // Canonical clear: the backend advanced past the point at which we
+    // submitted — actionCount on chain, shared next-action index on the
+    // gateway (either signal suffices).
     useEffect(() => {
-        if (isNullish(pendingActionCount)) return;
-        const current = gameState?.actionCount;
-        if (!isNullish(current) && current > pendingActionCount) {
+        if (isNullish(pendingActionCount) && isNullish(pendingActionIndex)) return;
+        const currentCount = gameState?.actionCount;
+        const countAdvanced = !isNullish(pendingActionCount) && !isNullish(currentCount) && currentCount > pendingActionCount;
+        const indexAdvanced = !isNullish(pendingActionIndex) && nextActionIndex(gameState) > pendingActionIndex;
+        if (countAdvanced || indexAdvanced) {
             setLoadingAction(null);
             setPendingActionCount(null);
+            setPendingActionIndex(null);
         }
-    }, [gameState?.actionCount, pendingActionCount]);
+    }, [gameState, pendingActionCount, pendingActionIndex]);
 
     // Escape hatch: WS push never arrived (chain stalled, WS disconnect,
     // or — rare — CheckTx passed but DeliverTx rejected so actionCount
@@ -371,6 +385,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
             );
             setLoadingAction(null);
             setPendingActionCount(null);
+            setPendingActionIndex(null);
         }, DIRTY_STATE_TIMEOUT_MS);
         return () => clearTimeout(t);
     }, [pendingActionCount]);

--- a/src/components/GatewayTransportBanner.tsx
+++ b/src/components/GatewayTransportBanner.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { getGameTransport, getGatewayHttpUrl } from "../utils/gameTransport";
+
+/**
+ * Unmissable indicator that the app is running on the optimistic WS
+ * gateway transport (ui#440) — so a tester can confirm at a glance that
+ * VITE_GAME_TRANSPORT / VITE_GATEWAY_URL are set as intended. Renders
+ * nothing on the default chain transport.
+ */
+export const GatewayTransportBanner: React.FC = () => {
+    if (getGameTransport() !== "gateway") {
+        return null;
+    }
+    return (
+        <div
+            data-testid="gateway-transport-banner"
+            style={{
+                position: "fixed",
+                bottom: 0,
+                left: 0,
+                right: 0,
+                zIndex: 9999,
+                background: "#7f1d1d",
+                color: "#fecaca",
+                textAlign: "center",
+                fontSize: "12px",
+                fontWeight: 700,
+                letterSpacing: "0.05em",
+                padding: "2px 8px",
+                pointerEvents: "none",
+                textTransform: "uppercase"
+            }}
+        >
+            ⚡ gateway transport — {getGatewayHttpUrl()}
+        </div>
+    );
+};

--- a/src/components/playPage/Players/VacantPlayer.tsx
+++ b/src/components/playPage/Players/VacantPlayer.tsx
@@ -86,7 +86,7 @@ const VacantPlayer: React.FC<VacantPlayerProps & { uiPosition?: number }> = memo
             }
             // Silent no-ops are a debugging trap — say WHY the click did
             // nothing (ui#440 live-testing).
-            console.warn(
+            console.error(
                 `[VacantPlayer] seat ${index} click ignored:`,
                 isUserAlreadyPlaying
                     ? "this wallet is already seated at the table"

--- a/src/components/playPage/Players/VacantPlayer.tsx
+++ b/src/components/playPage/Players/VacantPlayer.tsx
@@ -27,6 +27,7 @@ import CustomDealer from "../../../assets/CustomDealer.svg";
 import { formatDollars, formatUSDCToSimpleDollars, parseDollars } from "../../../utils/numberUtils";
 import { useCosmosWallet } from "../../../hooks";
 import { microToUsdc } from "../../../constants/currency";
+import { getGameTransport } from "../../../utils/gameTransport";
 import { useNetwork } from "../../../context/NetworkContext";
 import styles from "./VacantPlayer.module.css";
 import { USDCDepositModal } from "../../modals";
@@ -106,6 +107,11 @@ const VacantPlayer: React.FC<VacantPlayerProps & { uiPosition?: number }> = memo
 
         // Check if buy-in exceeds available balance
         const exceedsBalance = useMemo(() => {
+            // Gateway transport (ui#440): the buy-in is applied by the
+            // gateway's engine, not drawn from the on-chain balance — the
+            // chain-balance gate would block every gateway join until
+            // settlement lands (poker-vm#2221), so skip it.
+            if (getGameTransport() === "gateway") return false;
             const buyInValue = parseFloat(buyInAmount) || 0;
             const usdcBalance = cosmosWallet.balance.find(b => b.denom === "usdc");
             if (!usdcBalance) return true; // If user has no USDC balance, treat as exceeding balance

--- a/src/components/playPage/Players/VacantPlayer.tsx
+++ b/src/components/playPage/Players/VacantPlayer.tsx
@@ -82,8 +82,19 @@ const VacantPlayer: React.FC<VacantPlayerProps & { uiPosition?: number }> = memo
         const handleSeatClick = useCallback(() => {
             if (!isUserAlreadyPlaying && canJoinThisSeat) {
                 handleJoinClick();
+                return;
             }
-        }, [isUserAlreadyPlaying, canJoinThisSeat, handleJoinClick]);
+            // Silent no-ops are a debugging trap — say WHY the click did
+            // nothing (ui#440 live-testing).
+            console.warn(
+                `[VacantPlayer] seat ${index} click ignored:`,
+                isUserAlreadyPlaying
+                    ? "this wallet is already seated at the table"
+                    : gameOptions?.maxPlayers === undefined
+                      ? "game state not loaded yet (no gameOptions — stale/pre-fix table or WS not connected)"
+                      : "seat not joinable (taken or not in availableSeats)"
+            );
+        }, [isUserAlreadyPlaying, canJoinThisSeat, handleJoinClick, index, gameOptions?.maxPlayers]);
 
         // Detect if this is Sit & Go (fixed buy-in) or Cash game (variable buy-in)
         const isSitAndGo = useMemo(() => {

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -3,6 +3,7 @@ import { useNetwork } from "./NetworkContext";
 import { TexasHoldemStateDTO, GameFormat, GameVariant } from "@block52/poker-vm-sdk";
 import { createAuthPayload } from "../utils/cosmos/signing";
 import { getGameTransport, getGatewayWsUrl, normalizeGatewayMessage } from "../utils/gameTransport";
+import { setLatestGameState } from "../hooks/playerActions/transportAction";
 import { validateGameState, extractGameDataFromMessage } from "../utils/gameFormatUtils";
 import type { ValidationError } from "../components/playPage/TableErrorPage";
 import { CosmosApi } from "../apis/Api";
@@ -245,6 +246,7 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
                             });
                             // Still update gameState so the table renders what it can
                             setGameState(gameStateData as TexasHoldemStateDTO);
+                            setLatestGameState(gameStateData as TexasHoldemStateDTO);
                             setGameFormat(rawFormat as GameFormat | undefined);
                             setGameVariant(rawVariant as GameVariant | undefined);
                             setPendingAction(null);
@@ -256,6 +258,7 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
                         const currentPlayer = (gameStateData as TexasHoldemStateDTO)?.players?.find(p => p.address === playerAddress);
                         console.log("🎮 Game state updated. Current player status:", currentPlayer?.status, "| Player:", currentPlayer?.address?.slice(0, 10));
                         setGameState(gameStateData as TexasHoldemStateDTO);
+                        setLatestGameState(gameStateData as TexasHoldemStateDTO);
                         setGameFormat(rawFormat as GameFormat);
                         setGameVariant(rawVariant as GameVariant);
                         setError(null);
@@ -289,6 +292,7 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
                         // If it's a game not found error, clear the game state
                         if (message.code === "GAME_NOT_FOUND") {
                             setGameState(undefined);
+                            setLatestGameState(undefined);
                         }
                     }
                     // Unhandled message types are silently ignored
@@ -330,6 +334,7 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
         currentTableIdRef.current = null;
         hasReceivedMessageRef.current = false;
         setGameState(undefined);
+                            setLatestGameState(undefined);
         setGameFormat(undefined);
         setGameVariant(undefined);
         setIsLoading(false);

--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from "react"
 import { useNetwork } from "./NetworkContext";
 import { TexasHoldemStateDTO, GameFormat, GameVariant } from "@block52/poker-vm-sdk";
 import { createAuthPayload } from "../utils/cosmos/signing";
+import { getGameTransport, getGatewayWsUrl, normalizeGatewayMessage } from "../utils/gameTransport";
 import { validateGameState, extractGameDataFromMessage } from "../utils/gameFormatUtils";
 import type { ValidationError } from "../components/playPage/TableErrorPage";
 import { CosmosApi } from "../apis/Api";
@@ -118,8 +119,13 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
                 return;
             }
 
-            // Create WebSocket connection using network context
-            const fullWsUrl = `${currentNetwork.ws}?tableAddress=${tableId}&playerId=${playerAddress}`;
+            // Create WebSocket connection. Gateway transport (ui#440) talks
+            // to the optimistic action gateway's socket; chain transport
+            // keeps the existing node WS endpoint.
+            const transport = getGameTransport();
+            const fullWsUrl = transport === "gateway"
+                ? getGatewayWsUrl()
+                : `${currentNetwork.ws}?tableAddress=${tableId}&playerId=${playerAddress}`;
             const ws = new WebSocket(fullWsUrl);
             wsRef.current = ws;
 
@@ -128,13 +134,23 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
                 // Create authenticated subscription message with signature
                 const authPayload = await createAuthPayload();
 
-                const subscriptionMessage = {
-                    type: "subscribe",
-                    gameId: tableId,
-                    playerAddress: authPayload?.playerAddress || playerAddress,
-                    timestamp: authPayload?.timestamp,
-                    signature: authPayload?.signature
-                };
+                const subscriptionMessage = transport === "gateway"
+                    ? {
+                          // Gateway contract (poker-vm#2224): `address`, seconds
+                          // timestamp, same pokerchain-query signed payload.
+                          type: "subscribe",
+                          gameId: tableId,
+                          address: authPayload?.playerAddress || playerAddress,
+                          timestamp: authPayload?.timestamp,
+                          signature: authPayload?.signature
+                      }
+                    : {
+                          type: "subscribe",
+                          gameId: tableId,
+                          playerAddress: authPayload?.playerAddress || playerAddress,
+                          timestamp: authPayload?.timestamp,
+                          signature: authPayload?.signature
+                      };
 
                 console.log("📤 Sending subscription message:", subscriptionMessage);
                 ws.send(JSON.stringify(subscriptionMessage));
@@ -157,8 +173,19 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
             ws.onmessage = event => {
                 try {
                     console.log("📬 Raw WebSocket message received:", event.data);
-                    const message = JSON.parse(event.data);
+                    let message = JSON.parse(event.data);
                     hasReceivedMessageRef.current = true;
+
+                    // Gateway transport: state messages carry the canonical
+                    // GameStateResponseDTO under `state` (poker-vm#2226) —
+                    // normalize into the Cosmos message shape so the handler
+                    // below needs zero new parsing. Non-state gateway
+                    // messages (subscribed/ack) fall through untouched and
+                    // are ignored like any other unhandled type.
+                    const normalized = normalizeGatewayMessage(message);
+                    if (normalized) {
+                        message = normalized;
+                    }
 
                     // Handle multiple message formats:
                     // - Old PVM format: type: "gameStateUpdate"

--- a/src/hooks/playerActions/betHand.ts
+++ b/src/hooks/playerActions/betHand.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { PlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Bet in a poker game using Cosmos SDK SigningCosmosClient.
@@ -13,18 +13,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function betHand(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        PlayerActionType.BET,
-        amount
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: PlayerActionType.BET,
-        amount: amount.toString()
-    };
+    return executeTransportAction(tableId, PlayerActionType.BET, amount, network);
 }

--- a/src/hooks/playerActions/callHand.ts
+++ b/src/hooks/playerActions/callHand.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { PlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Call in a poker game using Cosmos SDK SigningCosmosClient.
@@ -13,18 +13,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function callHand(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        PlayerActionType.CALL,
-        amount
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: PlayerActionType.CALL,
-        amount: amount.toString()
-    };
+    return executeTransportAction(tableId, PlayerActionType.CALL, amount, network);
 }

--- a/src/hooks/playerActions/checkHand.ts
+++ b/src/hooks/playerActions/checkHand.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { PlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Check (pass) in a poker game using Cosmos SDK SigningCosmosClient.
@@ -12,17 +12,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function checkHand(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        PlayerActionType.CHECK,
-        0n
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: PlayerActionType.CHECK
-    };
+    return executeTransportAction(tableId, PlayerActionType.CHECK, 0n, network);
 }

--- a/src/hooks/playerActions/dealCards.ts
+++ b/src/hooks/playerActions/dealCards.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { NonPlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Deal cards in a poker game using Cosmos SDK SigningCosmosClient.
@@ -12,19 +12,7 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function dealCards(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        NonPlayerActionType.DEAL,
-        0n
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: NonPlayerActionType.DEAL
-    };
+    return executeTransportAction(tableId, NonPlayerActionType.DEAL, 0n, network);
 }
 
 /**
@@ -41,18 +29,5 @@ export async function dealCardsWithEntropy(
     network: NetworkEndpoints,
     entropy: string
 ): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        NonPlayerActionType.DEAL,
-        0n,
-        entropy  // Pass entropy as optional data parameter
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: NonPlayerActionType.DEAL
-    };
+    return executeTransportAction(tableId, NonPlayerActionType.DEAL, 0n, network, entropy);
 }

--- a/src/hooks/playerActions/foldHand.ts
+++ b/src/hooks/playerActions/foldHand.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { PlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Fold in a poker game using Cosmos SDK SigningCosmosClient.
@@ -12,17 +12,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function foldHand(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        PlayerActionType.FOLD,
-        0n
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: PlayerActionType.FOLD
-    };
+    return executeTransportAction(tableId, PlayerActionType.FOLD, 0n, network);
 }

--- a/src/hooks/playerActions/joinTable.ts
+++ b/src/hooks/playerActions/joinTable.ts
@@ -1,5 +1,7 @@
-import { COSMOS_CONSTANTS } from "@block52/poker-vm-sdk";
+import { COSMOS_CONSTANTS, NonPlayerActionType } from "@block52/poker-vm-sdk";
 import { getSigningClient } from "../../utils/cosmos/client";
+import { getGameTransport } from "../../utils/gameTransport";
+import { executeGatewayAction, getLatestGameState, nextActionIndex } from "./transportAction";
 import type { JoinTableOptions } from "./types";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { JoinTableResult } from "../../types";
@@ -29,6 +31,20 @@ export async function joinTable(tableId: string, options: JoinTableOptions, netw
     const seat = options.seatNumber !== undefined && options.seatNumber !== null
         ? options.seatNumber
         : 0;
+
+    // Gateway transport (ui#440): join is a signed gateway action with the
+    // seat in the (signature-bound) data field. A joiner isn't seated yet,
+    // so the index comes from the table's shared next-action index.
+    if (getGameTransport() === "gateway") {
+        const index = nextActionIndex(getLatestGameState());
+        const result = await executeGatewayAction(tableId, NonPlayerActionType.JOIN, index, buyInAmount, `seat=${seat}`);
+        return {
+            hash: result.hash,
+            gameId: tableId,
+            seat,
+            buyInAmount: buyInAmount.toString()
+        };
+    }
 
     // Call SigningCosmosClient.joinGame()
     const transactionHash = await signingClient.joinGame(

--- a/src/hooks/playerActions/muckCards.ts
+++ b/src/hooks/playerActions/muckCards.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { PlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Muck cards in a poker game using Cosmos SDK SigningCosmosClient.
@@ -12,17 +12,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function muckCards(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        PlayerActionType.MUCK,
-        0n
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: PlayerActionType.MUCK
-    };
+    return executeTransportAction(tableId, PlayerActionType.MUCK, 0n, network);
 }

--- a/src/hooks/playerActions/postBigBlind.ts
+++ b/src/hooks/playerActions/postBigBlind.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { PlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Post big blind in a poker game using Cosmos SDK SigningCosmosClient.
@@ -13,18 +13,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function postBigBlind(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        PlayerActionType.BIG_BLIND,
-        amount
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: PlayerActionType.BIG_BLIND,
-        amount: amount.toString()
-    };
+    return executeTransportAction(tableId, PlayerActionType.BIG_BLIND, amount, network);
 }

--- a/src/hooks/playerActions/postSmallBlind.ts
+++ b/src/hooks/playerActions/postSmallBlind.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { PlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Post small blind in a poker game using Cosmos SDK SigningCosmosClient.
@@ -13,18 +13,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function postSmallBlind(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        PlayerActionType.SMALL_BLIND,
-        amount
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: PlayerActionType.SMALL_BLIND,
-        amount: amount.toString()
-    };
+    return executeTransportAction(tableId, PlayerActionType.SMALL_BLIND, amount, network);
 }

--- a/src/hooks/playerActions/raiseHand.ts
+++ b/src/hooks/playerActions/raiseHand.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { PlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Raise in a poker game using Cosmos SDK SigningCosmosClient.
@@ -13,18 +13,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function raiseHand(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        PlayerActionType.RAISE,
-        amount
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: PlayerActionType.RAISE,
-        amount: amount.toString()
-    };
+    return executeTransportAction(tableId, PlayerActionType.RAISE, amount, network);
 }

--- a/src/hooks/playerActions/showCards.ts
+++ b/src/hooks/playerActions/showCards.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { PlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Show cards in a poker game using Cosmos SDK SigningCosmosClient.
@@ -12,17 +12,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function showCards(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        PlayerActionType.SHOW,
-        0n
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: PlayerActionType.SHOW
-    };
+    return executeTransportAction(tableId, PlayerActionType.SHOW, 0n, network);
 }

--- a/src/hooks/playerActions/sitIn.ts
+++ b/src/hooks/playerActions/sitIn.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { NonPlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 // TODO: Import from @block52/poker-vm-sdk once exported (see #1844)
 export type SitInMethod = "next-bb" | "post-now";
@@ -22,18 +22,5 @@ export async function sitIn(
     network: NetworkEndpoints,
     method: SitInMethod = SIT_IN_METHOD_POST_NOW
 ): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        NonPlayerActionType.SIT_IN,
-        0n,
-        `method=${method}`
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: NonPlayerActionType.SIT_IN
-    };
+    return executeTransportAction(tableId, NonPlayerActionType.SIT_IN, 0n, network, `method=${method}`);
 }

--- a/src/hooks/playerActions/sitOut.ts
+++ b/src/hooks/playerActions/sitOut.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { NonPlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 import type { SitOutMethod } from "@block52/poker-vm-sdk";
 import { SIT_OUT_METHOD_NEXT_HAND } from "@block52/poker-vm-sdk";
 
@@ -23,18 +23,5 @@ export async function sitOut(
     network: NetworkEndpoints,
     method: SitOutMethod = SIT_OUT_METHOD_NEXT_HAND
 ): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        NonPlayerActionType.SIT_OUT,
-        0n,
-        `method=${method}`
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: NonPlayerActionType.SIT_OUT
-    };
+    return executeTransportAction(tableId, NonPlayerActionType.SIT_OUT, 0n, network, `method=${method}`);
 }

--- a/src/hooks/playerActions/startNewHand.ts
+++ b/src/hooks/playerActions/startNewHand.ts
@@ -1,7 +1,7 @@
-import { getSigningClient } from "../../utils/cosmos/client";
 import { NonPlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
 
 /**
  * Start a new hand at a poker table using Cosmos SDK SigningCosmosClient.
@@ -12,17 +12,5 @@ import type { PlayerActionResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function startNewHand(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        NonPlayerActionType.NEW_HAND,
-        0n
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: NonPlayerActionType.NEW_HAND
-    };
+    return executeTransportAction(tableId, NonPlayerActionType.NEW_HAND, 0n, network);
 }

--- a/src/hooks/playerActions/startNewHand.ts
+++ b/src/hooks/playerActions/startNewHand.ts
@@ -1,6 +1,8 @@
 import { NonPlayerActionType } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
+import { generateShuffledDeck } from "../../utils/deckShuffle";
+import { getGameTransport } from "../../utils/gameTransport";
 import { executeTransportAction } from "./transportAction";
 
 /**
@@ -12,5 +14,8 @@ import { executeTransportAction } from "./transportAction";
  * @throws Error if Cosmos wallet is not initialized or if the action fails
  */
 export async function startNewHand(tableId: string, network: NetworkEndpoints): Promise<PlayerActionResult> {
-    return executeTransportAction(tableId, NonPlayerActionType.NEW_HAND, 0n, network);
+    // Gateway test mode: no chain VRF, so the client supplies a webcrypto
+    // shuffle (poker-vm#2221 / pokerchain#217 replaces this).
+    const data = getGameTransport() === "gateway" ? `deck=${generateShuffledDeck()}` : undefined;
+    return executeTransportAction(tableId, NonPlayerActionType.NEW_HAND, 0n, network, data);
 }

--- a/src/hooks/playerActions/transportAction.ts
+++ b/src/hooks/playerActions/transportAction.ts
@@ -27,6 +27,26 @@ export function setLatestGameState(gameState: TexasHoldemStateDTO | undefined): 
     latestGameState = gameState;
 }
 
+/**
+ * Next action index for a player not yet seated (join): every seated
+ * player's legalActions carry the table's next index; an empty table
+ * starts at 1.
+ */
+export function nextActionIndex(gameState: TexasHoldemStateDTO | undefined): number {
+    for (const player of gameState?.players ?? []) {
+        const index = player.legalActions?.[0]?.index;
+        if (index !== undefined) {
+            return index;
+        }
+    }
+    return 1;
+}
+
+/** Latest snapshot, for callers that resolve their own index (join). */
+export function getLatestGameState(): TexasHoldemStateDTO | undefined {
+    return latestGameState;
+}
+
 /** Hand-boundary actions anchor to the chain even in gateway mode (poker-vm#2221). */
 const CHAIN_ANCHORED_ACTIONS = new Set<string>([NonPlayerActionType.DEAL, NonPlayerActionType.NEW_HAND]);
 
@@ -38,7 +58,14 @@ export async function executeTransportAction(
     data?: string
 ): Promise<PlayerActionResult> {
     if (getGameTransport() === "gateway" && !CHAIN_ANCHORED_ACTIONS.has(action)) {
-        return executeGatewayAction(tableId, action, amount, data ?? "");
+        const address = localStorage.getItem("user_cosmos_address");
+        const currentPlayer = latestGameState?.players?.find(p => p.address === address);
+        const actionIndex = currentPlayer?.legalActions?.[0]?.index;
+        if (actionIndex === undefined) {
+            // Per Commandment 7: surface it — no guessed indices.
+            throw new Error(`No legal action index available for ${action} — game state may be stale`);
+        }
+        return executeGatewayAction(tableId, action, actionIndex, amount, data ?? "");
     }
 
     const { signingClient } = await getSigningClient(network);
@@ -51,17 +78,10 @@ export async function executeTransportAction(
     };
 }
 
-async function executeGatewayAction(tableId: string, action: string, amount: bigint, data: string): Promise<PlayerActionResult> {
+export async function executeGatewayAction(tableId: string, action: string, actionIndex: number, amount: bigint, data: string): Promise<PlayerActionResult> {
     const address = localStorage.getItem("user_cosmos_address");
     if (!address) {
         throw new Error("No Block52 wallet address found. Please connect your wallet.");
-    }
-
-    const currentPlayer = latestGameState?.players?.find(p => p.address === address);
-    const actionIndex = currentPlayer?.legalActions?.[0]?.index;
-    if (actionIndex === undefined) {
-        // Per Commandment 7: surface it — no guessed indices.
-        throw new Error(`No legal action index available for ${action} — game state may be stale`);
     }
 
     const amountString = amount.toString();

--- a/src/hooks/playerActions/transportAction.ts
+++ b/src/hooks/playerActions/transportAction.ts
@@ -1,0 +1,98 @@
+/**
+ * Transport-aware action executor — the single funnel every per-action
+ * helper (callHand, foldHand, ...) routes through (ui#440 PR 2).
+ *
+ * chain (default): SDK performActionSync, exactly as before.
+ * gateway: EIP-191-signed POST to the gateway's /actions (request/response
+ * per the #433 lesson); the table's state update arrives on the gateway
+ * socket. Hand-boundary actions (deal/new-hand) stay chain-direct even in
+ * gateway mode — the chain is the entropy/deck anchor (poker-vm#2221).
+ *
+ * These helpers are plain async functions (no React context), so the
+ * gateway path reads the action index from the latest game state snapshot
+ * published by GameStateContext via setLatestGameState().
+ */
+import { NonPlayerActionType, TexasHoldemStateDTO } from "@block52/poker-vm-sdk";
+
+import type { NetworkEndpoints } from "../../context/NetworkContext";
+import type { PlayerActionResult } from "../../types";
+import { getSigningClient } from "../../utils/cosmos/client";
+import { signActionMessage } from "../../utils/cosmos/signing";
+import { getGameTransport, getGatewayApi } from "../../utils/gameTransport";
+
+let latestGameState: TexasHoldemStateDTO | undefined;
+
+/** Published by GameStateContext on every state update. */
+export function setLatestGameState(gameState: TexasHoldemStateDTO | undefined): void {
+    latestGameState = gameState;
+}
+
+/** Hand-boundary actions anchor to the chain even in gateway mode (poker-vm#2221). */
+const CHAIN_ANCHORED_ACTIONS = new Set<string>([NonPlayerActionType.DEAL, NonPlayerActionType.NEW_HAND]);
+
+export async function executeTransportAction(
+    tableId: string,
+    action: string,
+    amount: bigint,
+    network: NetworkEndpoints,
+    data?: string
+): Promise<PlayerActionResult> {
+    if (getGameTransport() === "gateway" && !CHAIN_ANCHORED_ACTIONS.has(action)) {
+        return executeGatewayAction(tableId, action, amount, data ?? "");
+    }
+
+    const { signingClient } = await getSigningClient(network);
+    const transactionHash = await signingClient.performActionSync(tableId, action, amount, data);
+    return {
+        hash: transactionHash,
+        gameId: tableId,
+        action,
+        amount: amount.toString()
+    };
+}
+
+async function executeGatewayAction(tableId: string, action: string, amount: bigint, data: string): Promise<PlayerActionResult> {
+    const address = localStorage.getItem("user_cosmos_address");
+    if (!address) {
+        throw new Error("No Block52 wallet address found. Please connect your wallet.");
+    }
+
+    const currentPlayer = latestGameState?.players?.find(p => p.address === address);
+    const actionIndex = currentPlayer?.legalActions?.[0]?.index;
+    if (actionIndex === undefined) {
+        // Per Commandment 7: surface it — no guessed indices.
+        throw new Error(`No legal action index available for ${action} — game state may be stale`);
+    }
+
+    const amountString = amount.toString();
+    const timestamp = Date.now();
+    const signature = await signActionMessage(tableId, action, actionIndex, amountString, timestamp, data);
+    if (!signature) {
+        throw new Error("Failed to sign action — wallet mnemonic unavailable");
+    }
+
+    const response = await getGatewayApi().submitAction({
+        gameId: tableId,
+        action,
+        index: actionIndex,
+        amount: amountString,
+        timestamp,
+        address,
+        signature,
+        data,
+        clientTs: Date.now()
+    });
+
+    if (response.type !== "ack") {
+        throw new Error(response.error || "Gateway rejected the action");
+    }
+
+    return {
+        // No chain tx hash on the optimistic path; the signed payload is the
+        // action's identity until chain settlement lands (poker-vm#2221).
+        hash: `gateway:${tableId}:${actionIndex}`,
+        gameId: tableId,
+        action,
+        amount: amountString
+    };
+}

--- a/src/hooks/playerActions/transportAction.ts
+++ b/src/hooks/playerActions/transportAction.ts
@@ -47,8 +47,16 @@ export function getLatestGameState(): TexasHoldemStateDTO | undefined {
     return latestGameState;
 }
 
-/** Hand-boundary actions anchor to the chain even in gateway mode (poker-vm#2221). */
-const CHAIN_ANCHORED_ACTIONS = new Set<string>([NonPlayerActionType.DEAL, NonPlayerActionType.NEW_HAND]);
+/**
+ * Hand-boundary actions (deal/new-hand) will anchor to the chain for VRF
+ * entropy once chain-anchored hand starts land (poker-vm#2221,
+ * pokerchain#217). Until then gateway tables are chain-off, so they MUST
+ * flow through the gateway like every other action — otherwise a
+ * gateway-only table deadlocks at the deal (found live, ui#440).
+ * KNOWN LIMITATION meanwhile: no entropy source -> the deck is
+ * deterministic (same board every hand). Test mode only.
+ */
+const CHAIN_ANCHORED_ACTIONS = new Set<string>([]);
 
 export async function executeTransportAction(
     tableId: string,

--- a/src/hooks/playerActions/useOptimisticAction.ts
+++ b/src/hooks/playerActions/useOptimisticAction.ts
@@ -1,10 +1,13 @@
 import { useCallback } from "react";
 import { useGameActions } from "../../context/gameState/GameActionsContext";
+import { useGameData } from "../../context/gameState/GameDataContext";
 import { useGameUI } from "../../context/gameState/GameUIContext";
 import { useNetwork, NetworkEndpoints } from "../../context/NetworkContext";
 import { getSigningClient } from "../../utils/cosmos/client";
+import { signActionMessage } from "../../utils/cosmos/signing";
+import { getGameTransport, getGatewayApi } from "../../utils/gameTransport";
 import type { PlayerActionResult } from "../../types";
-import { PlayerActionType, NonPlayerActionType } from "@block52/poker-vm-sdk";
+import { PlayerActionType, NonPlayerActionType, TexasHoldemStateDTO } from "@block52/poker-vm-sdk";
 
 /**
  * Actions that can be performed optimistically.
@@ -81,6 +84,67 @@ async function executeAction(
 }
 
 /**
+ * Execute a poker action via the optimistic WS Action Gateway (ui#440).
+ *
+ * Request/response per the #433 lesson: POST /actions returns the ack plus
+ * the post-action state in ~150ms; the table's authoritative state update
+ * arrives on the gateway socket (GameStateContext). The action is EIP-191
+ * signed over the gateway's canonical payload — including the monotonic
+ * action index from the player's legalActions (replay protection).
+ */
+async function executeGatewayAction(
+    tableId: string,
+    action: OptimisticActionType,
+    amount: bigint,
+    gameState: TexasHoldemStateDTO | undefined
+): Promise<PlayerActionResult> {
+    const address = localStorage.getItem("user_cosmos_address");
+    if (!address) {
+        throw new Error("No Block52 wallet address found. Please connect your wallet.");
+    }
+
+    const currentPlayer = gameState?.players?.find(p => p.address === address);
+    const actionIndex = currentPlayer?.legalActions?.[0]?.index;
+    if (actionIndex === undefined) {
+        // Per Commandment 7: surface it — no guessed indices.
+        throw new Error(`No legal action index available for ${action} — game state may be stale`);
+    }
+
+    const amountString = amount.toString();
+    const timestamp = Date.now();
+    const data = "";
+    const signature = await signActionMessage(tableId, action, actionIndex, amountString, timestamp, data);
+    if (!signature) {
+        throw new Error("Failed to sign action — wallet mnemonic unavailable");
+    }
+
+    const response = await getGatewayApi().submitAction({
+        gameId: tableId,
+        action,
+        index: actionIndex,
+        amount: amountString,
+        timestamp,
+        address,
+        signature,
+        data,
+        clientTs: Date.now()
+    });
+
+    if (response.type !== "ack") {
+        throw new Error(response.error || "Gateway rejected the action");
+    }
+
+    return {
+        // No chain tx hash on the optimistic path; the signed payload is the
+        // action's identity until chain settlement lands (poker-vm#2221).
+        hash: `gateway:${tableId}:${actionIndex}`,
+        gameId: tableId,
+        action,
+        amount: amountString
+    };
+}
+
+/**
  * Hook that wraps player actions with optimistic updates.
  *
  * This hook:
@@ -96,6 +160,7 @@ async function executeAction(
  */
 export function useOptimisticAction(): UseOptimisticActionReturn {
     const { sendAction } = useGameActions();
+    const { gameState } = useGameData();
     const { pendingAction } = useGameUI();
     const { currentNetwork } = useNetwork();
 
@@ -111,6 +176,15 @@ export function useOptimisticAction(): UseOptimisticActionReturn {
                 throw new Error(`Amount required for ${action}`);
             }
 
+            // Gateway transport (ui#440): one signed request/response — the
+            // gateway validates, applies via the PVM, broadcasts to the
+            // table socket, and returns the ack. No pending announce needed:
+            // the broadcast IS the validated post-action state.
+            if (getGameTransport() === "gateway") {
+                return executeGatewayAction(tableId, action, amount ?? 0n, gameState);
+            }
+
+            // Chain transport (default):
             // Step 1: Send via WebSocket for immediate optimistic broadcast.
             // If this fails, fall through to the SDK transaction anyway — the WS
             // broadcast is purely a latency optimization for other subscribers.
@@ -130,7 +204,7 @@ export function useOptimisticAction(): UseOptimisticActionReturn {
 
             return result;
         },
-        [sendAction, currentNetwork]
+        [sendAction, gameState, currentNetwork]
     );
 
     return {

--- a/src/hooks/playerActions/useOptimisticAction.ts
+++ b/src/hooks/playerActions/useOptimisticAction.ts
@@ -1,13 +1,11 @@
 import { useCallback } from "react";
 import { useGameActions } from "../../context/gameState/GameActionsContext";
-import { useGameData } from "../../context/gameState/GameDataContext";
 import { useGameUI } from "../../context/gameState/GameUIContext";
-import { useNetwork, NetworkEndpoints } from "../../context/NetworkContext";
-import { getSigningClient } from "../../utils/cosmos/client";
-import { signActionMessage } from "../../utils/cosmos/signing";
-import { getGameTransport, getGatewayApi } from "../../utils/gameTransport";
+import { useNetwork } from "../../context/NetworkContext";
+import { getGameTransport } from "../../utils/gameTransport";
+import { executeTransportAction } from "./transportAction";
 import type { PlayerActionResult } from "../../types";
-import { PlayerActionType, NonPlayerActionType, TexasHoldemStateDTO } from "@block52/poker-vm-sdk";
+import { PlayerActionType, NonPlayerActionType } from "@block52/poker-vm-sdk";
 
 /**
  * Actions that can be performed optimistically.
@@ -48,103 +46,6 @@ interface UseOptimisticActionReturn {
 }
 
 /**
- * Execute a poker action on the Cosmos blockchain.
- *
- * Uses the SDK's performActionSync method (CheckTx-only, returns in
- * ~50-100ms) rather than performAction (waits for block inclusion,
- * ~5s with current chain config). The authoritative state arrives
- * via the WebSocket push once the block commits; the SDK throws here
- * only on CheckTx rejection (invalid signature, insufficient gas,
- * malformed message) — that's the immediate rollback signal.
- *
- * The "no WS confirmation within N seconds" timeout-based rollback
- * is a separate enhancement tracked as a follow-up on block52/ui#359.
- *
- * Refs: block52/ui#359, block52/poker-vm#2104.
- */
-async function executeAction(
-    tableId: string,
-    action: OptimisticActionType,
-    amount: bigint,
-    network: NetworkEndpoints
-): Promise<PlayerActionResult> {
-    const { signingClient } = await getSigningClient(network);
-
-    const transactionHash = await signingClient.performActionSync(
-        tableId,
-        action,
-        amount
-    );
-
-    return {
-        hash: transactionHash,
-        gameId: tableId,
-        action: action
-    };
-}
-
-/**
- * Execute a poker action via the optimistic WS Action Gateway (ui#440).
- *
- * Request/response per the #433 lesson: POST /actions returns the ack plus
- * the post-action state in ~150ms; the table's authoritative state update
- * arrives on the gateway socket (GameStateContext). The action is EIP-191
- * signed over the gateway's canonical payload — including the monotonic
- * action index from the player's legalActions (replay protection).
- */
-async function executeGatewayAction(
-    tableId: string,
-    action: OptimisticActionType,
-    amount: bigint,
-    gameState: TexasHoldemStateDTO | undefined
-): Promise<PlayerActionResult> {
-    const address = localStorage.getItem("user_cosmos_address");
-    if (!address) {
-        throw new Error("No Block52 wallet address found. Please connect your wallet.");
-    }
-
-    const currentPlayer = gameState?.players?.find(p => p.address === address);
-    const actionIndex = currentPlayer?.legalActions?.[0]?.index;
-    if (actionIndex === undefined) {
-        // Per Commandment 7: surface it — no guessed indices.
-        throw new Error(`No legal action index available for ${action} — game state may be stale`);
-    }
-
-    const amountString = amount.toString();
-    const timestamp = Date.now();
-    const data = "";
-    const signature = await signActionMessage(tableId, action, actionIndex, amountString, timestamp, data);
-    if (!signature) {
-        throw new Error("Failed to sign action — wallet mnemonic unavailable");
-    }
-
-    const response = await getGatewayApi().submitAction({
-        gameId: tableId,
-        action,
-        index: actionIndex,
-        amount: amountString,
-        timestamp,
-        address,
-        signature,
-        data,
-        clientTs: Date.now()
-    });
-
-    if (response.type !== "ack") {
-        throw new Error(response.error || "Gateway rejected the action");
-    }
-
-    return {
-        // No chain tx hash on the optimistic path; the signed payload is the
-        // action's identity until chain settlement lands (poker-vm#2221).
-        hash: `gateway:${tableId}:${actionIndex}`,
-        gameId: tableId,
-        action,
-        amount: amountString
-    };
-}
-
-/**
  * Hook that wraps player actions with optimistic updates.
  *
  * This hook:
@@ -160,7 +61,6 @@ async function executeGatewayAction(
  */
 export function useOptimisticAction(): UseOptimisticActionReturn {
     const { sendAction } = useGameActions();
-    const { gameState } = useGameData();
     const { pendingAction } = useGameUI();
     const { currentNetwork } = useNetwork();
 
@@ -176,35 +76,22 @@ export function useOptimisticAction(): UseOptimisticActionReturn {
                 throw new Error(`Amount required for ${action}`);
             }
 
-            // Gateway transport (ui#440): one signed request/response — the
-            // gateway validates, applies via the PVM, broadcasts to the
-            // table socket, and returns the ack. No pending announce needed:
-            // the broadcast IS the validated post-action state.
-            if (getGameTransport() === "gateway") {
-                return executeGatewayAction(tableId, action, amount ?? 0n, gameState);
+            // Chain transport: announce via WS first (best-effort latency
+            // optimization for other subscribers). Gateway transport needs
+            // no announce — the gateway broadcast IS the validated state.
+            if (getGameTransport() !== "gateway") {
+                try {
+                    await sendAction(action, amount?.toString());
+                } catch {
+                    // intentional: WS broadcast is best-effort
+                }
             }
 
-            // Chain transport (default):
-            // Step 1: Send via WebSocket for immediate optimistic broadcast.
-            // If this fails, fall through to the SDK transaction anyway — the WS
-            // broadcast is purely a latency optimization for other subscribers.
-            try {
-                await sendAction(action, amount?.toString());
-            } catch {
-                // intentional: WS broadcast is best-effort
-            }
-
-            // Step 2: Execute the blockchain transaction via SDK
-            const result = await executeAction(
-                tableId,
-                action,
-                amount ?? 0n,
-                currentNetwork
-            );
-
-            return result;
+            // Single transport-aware executor (ui#440): SDK performActionSync
+            // on chain, signed POST /actions on gateway.
+            return executeTransportAction(tableId, action, amount ?? 0n, currentNetwork);
         },
-        [sendAction, gameState, currentNetwork]
+        [sendAction, currentNetwork]
     );
 
     return {

--- a/src/tests/gameTransport.test.ts
+++ b/src/tests/gameTransport.test.ts
@@ -12,20 +12,20 @@ describe("game transport selection", () => {
         if (saved.url === undefined) delete process.env.VITE_GATEWAY_URL;
     });
 
-    it("defaults to chain — the gateway is opt-in", () => {
+    it("defaults to gateway — chain is the opt-out", () => {
         delete process.env.VITE_GAME_TRANSPORT;
-        expect(getGameTransport()).toBe("chain");
+        expect(getGameTransport()).toBe("gateway");
     });
 
-    it("selects gateway only on the exact flag", () => {
-        process.env.VITE_GAME_TRANSPORT = "gateway";
-        expect(getGameTransport()).toBe("gateway");
+    it("selects chain only on the exact flag", () => {
+        process.env.VITE_GAME_TRANSPORT = "chain";
+        expect(getGameTransport()).toBe("chain");
 
-        process.env.VITE_GAME_TRANSPORT = "GATEWAY";
-        expect(getGameTransport()).toBe("gateway");
+        process.env.VITE_GAME_TRANSPORT = "CHAIN";
+        expect(getGameTransport()).toBe("chain");
 
         process.env.VITE_GAME_TRANSPORT = "something-else";
-        expect(getGameTransport()).toBe("chain");
+        expect(getGameTransport()).toBe("gateway");
     });
 
     it("derives the ws endpoint from the http base URL", () => {

--- a/src/tests/gameTransport.test.ts
+++ b/src/tests/gameTransport.test.ts
@@ -1,0 +1,85 @@
+import { getGameTransport, getGatewayHttpUrl, getGatewayWsUrl, normalizeGatewayMessage } from "../utils/gameTransport";
+
+// jest maps utils/viteEnv to process.env (see jest.config.js), so transport
+// flags are driven through process.env here.
+describe("game transport selection", () => {
+    const saved = { transport: process.env.VITE_GAME_TRANSPORT, url: process.env.VITE_GATEWAY_URL };
+
+    afterEach(() => {
+        process.env.VITE_GAME_TRANSPORT = saved.transport;
+        process.env.VITE_GATEWAY_URL = saved.url;
+        if (saved.transport === undefined) delete process.env.VITE_GAME_TRANSPORT;
+        if (saved.url === undefined) delete process.env.VITE_GATEWAY_URL;
+    });
+
+    it("defaults to chain — the gateway is opt-in", () => {
+        delete process.env.VITE_GAME_TRANSPORT;
+        expect(getGameTransport()).toBe("chain");
+    });
+
+    it("selects gateway only on the exact flag", () => {
+        process.env.VITE_GAME_TRANSPORT = "gateway";
+        expect(getGameTransport()).toBe("gateway");
+
+        process.env.VITE_GAME_TRANSPORT = "GATEWAY";
+        expect(getGameTransport()).toBe("gateway");
+
+        process.env.VITE_GAME_TRANSPORT = "something-else";
+        expect(getGameTransport()).toBe("chain");
+    });
+
+    it("derives the ws endpoint from the http base URL", () => {
+        process.env.VITE_GATEWAY_URL = "https://pvm.block52.xyz/gateway";
+        expect(getGatewayWsUrl()).toBe("wss://pvm.block52.xyz/gateway/ws");
+
+        process.env.VITE_GATEWAY_URL = "http://localhost:8546/";
+        expect(getGatewayWsUrl()).toBe("ws://localhost:8546/ws");
+    });
+
+    it("falls back to the production gateway URL", () => {
+        delete process.env.VITE_GATEWAY_URL;
+        expect(getGatewayHttpUrl()).toBe("https://pvm.block52.xyz/gateway");
+    });
+});
+
+describe("normalizeGatewayMessage", () => {
+    const gatewayState = {
+        type: "state",
+        gameId: "game-1",
+        index: 7,
+        state: {
+            gameId: "game-1",
+            format: "cash",
+            variant: "texas-holdem",
+            gameState: { round: "preflop", players: [] }
+        }
+    };
+
+    it("maps a gateway state message onto the canonical Cosmos shape", () => {
+        const normalized = normalizeGatewayMessage(gatewayState);
+        expect(normalized).toEqual({
+            gameId: "game-1",
+            event: "state",
+            data: {
+                format: "cash",
+                variant: "texas-holdem",
+                gameState: { round: "preflop", players: [] }
+            }
+        });
+    });
+
+    it("ignores non-state gateway messages", () => {
+        expect(normalizeGatewayMessage({ type: "subscribed", gameId: "game-1" })).toBeNull();
+        expect(normalizeGatewayMessage({ type: "ack", gameId: "game-1" })).toBeNull();
+        expect(normalizeGatewayMessage({ type: "error", gameId: "game-1" })).toBeNull();
+    });
+
+    it("ignores chain messages — they already have the canonical shape", () => {
+        expect(normalizeGatewayMessage({ event: "state", gameId: "game-1", data: {} } as never)).toBeNull();
+    });
+
+    it("ignores state messages without a payload", () => {
+        expect(normalizeGatewayMessage({ type: "state", gameId: "game-1" })).toBeNull();
+        expect(normalizeGatewayMessage({ type: "state", gameId: "game-1", state: {} })).toBeNull();
+    });
+});

--- a/src/tests/gatewayTransportBanner.test.tsx
+++ b/src/tests/gatewayTransportBanner.test.tsx
@@ -14,18 +14,18 @@ describe("GatewayTransportBanner", () => {
         if (saved.url === undefined) delete process.env.VITE_GATEWAY_URL;
     });
 
-    it("renders nothing on the default chain transport", () => {
+    it("shows by default — gateway is the default transport", () => {
         delete process.env.VITE_GAME_TRANSPORT;
-        render(<GatewayTransportBanner />);
-        expect(screen.queryByTestId("gateway-transport-banner")).toBeNull();
-    });
-
-    it("shows the gateway URL when gateway transport is active", () => {
-        process.env.VITE_GAME_TRANSPORT = "gateway";
         process.env.VITE_GATEWAY_URL = "https://pvm.block52.xyz/gateway";
         render(<GatewayTransportBanner />);
         const banner = screen.getByTestId("gateway-transport-banner");
         expect(banner.textContent).toContain("gateway transport");
         expect(banner.textContent).toContain("https://pvm.block52.xyz/gateway");
+    });
+
+    it("renders nothing when chain transport is opted into", () => {
+        process.env.VITE_GAME_TRANSPORT = "chain";
+        render(<GatewayTransportBanner />);
+        expect(screen.queryByTestId("gateway-transport-banner")).toBeNull();
     });
 });

--- a/src/tests/gatewayTransportBanner.test.tsx
+++ b/src/tests/gatewayTransportBanner.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { GatewayTransportBanner } from "../components/GatewayTransportBanner";
+
+// jest maps utils/viteEnv to process.env (see jest.config.js).
+describe("GatewayTransportBanner", () => {
+    const saved = { transport: process.env.VITE_GAME_TRANSPORT, url: process.env.VITE_GATEWAY_URL };
+
+    afterEach(() => {
+        process.env.VITE_GAME_TRANSPORT = saved.transport;
+        process.env.VITE_GATEWAY_URL = saved.url;
+        if (saved.transport === undefined) delete process.env.VITE_GAME_TRANSPORT;
+        if (saved.url === undefined) delete process.env.VITE_GATEWAY_URL;
+    });
+
+    it("renders nothing on the default chain transport", () => {
+        delete process.env.VITE_GAME_TRANSPORT;
+        render(<GatewayTransportBanner />);
+        expect(screen.queryByTestId("gateway-transport-banner")).toBeNull();
+    });
+
+    it("shows the gateway URL when gateway transport is active", () => {
+        process.env.VITE_GAME_TRANSPORT = "gateway";
+        process.env.VITE_GATEWAY_URL = "https://pvm.block52.xyz/gateway";
+        render(<GatewayTransportBanner />);
+        const banner = screen.getByTestId("gateway-transport-banner");
+        expect(banner.textContent).toContain("gateway transport");
+        expect(banner.textContent).toContain("https://pvm.block52.xyz/gateway");
+    });
+});

--- a/src/utils/deckShuffle.ts
+++ b/src/utils/deckShuffle.ts
@@ -1,0 +1,40 @@
+/**
+ * CSPRNG deck shuffle for gateway test mode (ui#440).
+ *
+ * With the chain off there is no VRF entropy source, so hands on
+ * gateway-only tables would play with the engine's deterministic default
+ * deck (poker-vm#2221). Until chain-anchored hand starts land
+ * (pokerchain#217), the client shuffles with webcrypto when it starts a
+ * new hand. TEST MODE ONLY: the shuffling client knows the deck order.
+ *
+ * Format matches the SDK Deck constructor: 52 dash-joined mnemonics
+ * (ten is "T"), e.g. "7H-AC-TD-...".
+ */
+
+const RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "T", "J", "Q", "K"];
+const SUITS = ["C", "D", "H", "S"];
+
+export function generateShuffledDeck(): string {
+    const cards: string[] = [];
+    for (const suit of SUITS) {
+        for (const rank of RANKS) {
+            cards.push(`${rank}${suit}`);
+        }
+    }
+
+    // Fisher-Yates with rejection-sampled webcrypto randomness (no modulo bias).
+    const random = new Uint32Array(cards.length);
+    crypto.getRandomValues(random);
+    for (let i = cards.length - 1; i > 0; i--) {
+        let r = random[i];
+        const bound = 4294967296 - (4294967296 % (i + 1));
+        while (r >= bound) {
+            const one = new Uint32Array(1);
+            crypto.getRandomValues(one);
+            r = one[0];
+        }
+        const j = r % (i + 1);
+        [cards[i], cards[j]] = [cards[j], cards[i]];
+    }
+    return cards.join("-");
+}

--- a/src/utils/gameTransport.ts
+++ b/src/utils/gameTransport.ts
@@ -1,0 +1,78 @@
+/**
+ * Game transport selection — chain-direct (default) vs the optimistic WS
+ * Action Gateway (poker-vm#2211, ui#440).
+ *
+ * Per the #433 lesson the migration is incremental: submission stays
+ * request/response (gateway mode POSTs to /actions), only the state-update
+ * path moves to the gateway socket. Flag-gated for now; promoting the
+ * selection into the NetworkContext dropdown is a planned follow-up.
+ */
+import { GatewayApi } from "../apis/GatewayApi";
+import { viteEnv } from "./viteEnv";
+
+export type GameTransport = "chain" | "gateway";
+
+const DEFAULT_GATEWAY_URL = "https://pvm.block52.xyz/gateway";
+
+export function getGameTransport(): GameTransport {
+    const raw = (viteEnv.VITE_GAME_TRANSPORT || "").toLowerCase();
+    return raw === "gateway" ? "gateway" : "chain";
+}
+
+export function getGatewayHttpUrl(): string {
+    return viteEnv.VITE_GATEWAY_URL || DEFAULT_GATEWAY_URL;
+}
+
+/** Derives the gateway's WebSocket endpoint from its HTTP base URL. */
+export function getGatewayWsUrl(): string {
+    const base = getGatewayHttpUrl().replace(/\/$/, "");
+    return `${base.replace(/^http/, "ws")}/ws`;
+}
+
+let cachedApi: { url: string; api: GatewayApi } | null = null;
+
+/** Memoized GatewayApi (module-level until the NetworkContext dropdown lands). */
+export function getGatewayApi(): GatewayApi {
+    const url = getGatewayHttpUrl();
+    if (!cachedApi || cachedApi.url !== url) {
+        cachedApi = { url, api: new GatewayApi({ baseUrl: url, secure: false }) };
+    }
+    return cachedApi.api;
+}
+
+/**
+ * Gateway WS state message, carrying the canonical GameStateResponseDTO
+ * shape in `state` (poker-vm#2226).
+ */
+interface GatewayStateMessage {
+    type?: string;
+    gameId?: string;
+    state?: {
+        gameId?: string;
+        format?: string;
+        variant?: string;
+        gameState?: unknown;
+    };
+}
+
+/**
+ * Normalizes a gateway WS state message into the canonical Cosmos message
+ * shape ({gameId, event: "state", data: {format, variant, gameState}}) so
+ * GameStateContext's existing handler processes it with zero new parsing.
+ * Returns null for non-state gateway messages (subscribed/ack) and for
+ * anything that is not a gateway state message.
+ */
+export function normalizeGatewayMessage(message: GatewayStateMessage): { gameId: string; event: "state"; data: unknown } | null {
+    if (message.type !== "state" || !message.gameId || !message.state) {
+        return null;
+    }
+    const { format, variant, gameState } = message.state;
+    if (!gameState) {
+        return null;
+    }
+    return {
+        gameId: message.gameId,
+        event: "state",
+        data: { format, variant, gameState }
+    };
+}

--- a/src/utils/gameTransport.ts
+++ b/src/utils/gameTransport.ts
@@ -15,8 +15,11 @@ export type GameTransport = "chain" | "gateway";
 const DEFAULT_GATEWAY_URL = "https://pvm.block52.xyz/gateway";
 
 export function getGameTransport(): GameTransport {
+    // Gateway is the DEFAULT transport (decision 2026-06-08): the optimistic
+    // path is what players should feel. Set VITE_GAME_TRANSPORT=chain to opt
+    // back into chain-direct submission.
     const raw = (viteEnv.VITE_GAME_TRANSPORT || "").toLowerCase();
-    return raw === "gateway" ? "gateway" : "chain";
+    return raw === "chain" ? "chain" : "gateway";
 }
 
 export function getGatewayHttpUrl(): string {

--- a/src/utils/viteEnv.ts
+++ b/src/utils/viteEnv.ts
@@ -1,0 +1,6 @@
+/**
+ * The ONLY module that touches import.meta — jest (CommonJS) cannot parse
+ * import.meta syntax, so it maps this module to src/__mocks__/viteEnv.js
+ * via moduleNameMapper. Everything else reads env through here.
+ */
+export const viteEnv: Record<string, string | undefined> = import.meta.env;


### PR DESCRIPTION
Fixes #440 (PR 2 of 2)

## What

The optimistic WS Action Gateway is the **default transport**. `VITE_GAME_TRANSPORT=chain` opts back into chain-direct submission — nothing else changes on that path.

| Path | Gateway (default) | Chain (`VITE_GAME_TRANSPORT=chain`) |
|---|---|---|
| Submit | signed `POST /gateway/actions`, ack+state ~150ms | WS announce + `performActionSync` (~5s to authoritative) |
| State updates | gateway socket, broadcast on apply | node WS, block-paced |
| Join | signed gateway `join` action (seat in sig-bound data) | `MsgJoinGame` |
| deal/new-hand | gateway (webcrypto shuffle — test mode until pokerchain#217) | chain |

## Everything found + fixed during live shakedown

- All 13 per-action helpers + join routed through one transport-aware executor (buttons bypassed the original hook)
- Buy-in modal's on-chain balance gate skipped in gateway mode (gateway buy-ins are engine-applied)
- Stuck action spinner: watch the shared next-action index (gateway states never advance `actionCount`)
- CSPRNG deck shuffle (seeder hand 1 + `new-hand` data) — no more deterministic boards
- Seat-click diagnostics, red transport banner (shows by default now), `utils/viteEnv` jest shim
- `scripts/seed-gateway-table.mjs` (0x-hash ids, production-scale amounts, full canonical empty state, `--stop-after` modes) + `scripts/gateway-dealer-bot.mjs`

## Cross-language proof

EIP-191 signing pinned to the gateway's Go verifier with fixed RFC6979 vectors — byte-identical, tested. (Interim scheme: converging to full cosmos-signed txs per poker-vm#2231 / spec §6.9.)

## Tests

813/813 across 45 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)