### PR TITLE
fix(prod): pin production builds to chain transport via .env.production (#440)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,8 @@
+# Production builds use chain transport until the gateway can serve real
+# chain tables (cold-start recovery + chain-anchored hand starts —
+# poker-vm#2221, pokerchain#217). Without this, the gateway-default
+# (ui#442) makes prod subscribe chain tables into the gateway's void:
+# no game state, dead seats. Vite loads this file for `yarn build` only;
+# `yarn dev` keeps the gateway default. A real env var at build time
+# still overrides this file.
+VITE_GAME_TRANSPORT=chain


### PR DESCRIPTION
## What broke

Prod (app.block52.xyz) can't load any table: no game state, unclickable seats.

## Root cause — verified from the deployed bundle

The baked env object in `assets/index-Dja7gEPN.js` has **no `VITE_GAME_TRANSPORT` key** — the flag was added to the deploy environment, but Vite bakes env at **build** time, so the bundle fell through to the new gateway default (#442). Prod then subscribed real chain tables to the gateway, which doesn't know them (memory store, no chain bridge until pokerchain#217): `subscribed` → silence → `maxPlayers` undefined → seats can never activate.

## Fix

Commit `.env.production` with `VITE_GAME_TRANSPORT=chain`:
- `yarn build` (production mode) → chain transport, prod behaves exactly as before #442
- `yarn dev` → gateway default unchanged
- a real build-time env var still overrides the file when we're ready to flip prod

**After merging: rebuild + redeploy the prod FE.** Smoke check: no red gateway banner, table WS connects to `node1.block52.xyz/ws`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)