### PR TITLE
feat(gateway): attach signed cosmos tx for settlement relay (settlement §6.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "=https://paymentservice.texashodl.net",
   "dependencies": {
-    "@block52/poker-vm-sdk": "1.2.4",
+    "@block52/poker-vm-sdk": "1.2.5",
     "@metamask/sdk": "^0.34.0",
     "@reown/appkit": "1.6.7",
     "@reown/appkit-adapter-ethers": "1.6.7",

--- a/src/apis/GatewayApi.ts
+++ b/src/apis/GatewayApi.ts
@@ -15,6 +15,9 @@ export interface GatewayActionRequest {
     address: string;
     signature: string;
     data: string;
+    // tx is the base64 cosmos TxRaw for settlement relay (§6.10). Best-effort;
+    // absent for unfunded accounts.
+    tx?: string;
     clientTs?: number;
 }
 

--- a/src/hooks/playerActions/joinTable.ts
+++ b/src/hooks/playerActions/joinTable.ts
@@ -37,7 +37,7 @@ export async function joinTable(tableId: string, options: JoinTableOptions, netw
     // so the index comes from the table's shared next-action index.
     if (getGameTransport() === "gateway") {
         const index = nextActionIndex(getLatestGameState());
-        const result = await executeGatewayAction(tableId, NonPlayerActionType.JOIN, index, buyInAmount, `seat=${seat}`);
+        const result = await executeGatewayAction(tableId, NonPlayerActionType.JOIN, index, buyInAmount, `seat=${seat}`, network);
         return {
             hash: result.hash,
             gameId: tableId,

--- a/src/hooks/playerActions/transportAction.ts
+++ b/src/hooks/playerActions/transportAction.ts
@@ -18,6 +18,7 @@ import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
 import { getSigningClient } from "../../utils/cosmos/client";
 import { signActionMessage } from "../../utils/cosmos/signing";
+import { signSettlementTx } from "../../utils/cosmos/settlementTx";
 import { getGameTransport, getGatewayApi } from "../../utils/gameTransport";
 
 let latestGameState: TexasHoldemStateDTO | undefined;
@@ -73,7 +74,7 @@ export async function executeTransportAction(
             // Per Commandment 7: surface it — no guessed indices.
             throw new Error(`No legal action index available for ${action} — game state may be stale`);
         }
-        return executeGatewayAction(tableId, action, actionIndex, amount, data ?? "");
+        return executeGatewayAction(tableId, action, actionIndex, amount, data ?? "", network);
     }
 
     const { signingClient } = await getSigningClient(network);
@@ -86,7 +87,14 @@ export async function executeTransportAction(
     };
 }
 
-export async function executeGatewayAction(tableId: string, action: string, actionIndex: number, amount: bigint, data: string): Promise<PlayerActionResult> {
+export async function executeGatewayAction(
+    tableId: string,
+    action: string,
+    actionIndex: number,
+    amount: bigint,
+    data: string,
+    network: NetworkEndpoints
+): Promise<PlayerActionResult> {
     const address = localStorage.getItem("user_cosmos_address");
     if (!address) {
         throw new Error("No Block52 wallet address found. Please connect your wallet.");
@@ -99,6 +107,17 @@ export async function executeGatewayAction(tableId: string, action: string, acti
         throw new Error("Failed to sign action — wallet mnemonic unavailable");
     }
 
+    // Settlement relay (§6.10): sign the action as a cosmos tx and attach it
+    // for the gateway to relay to the chain. Best-effort — undefined for
+    // unfunded accounts (gameplay still proceeds on the EIP-191 path).
+    let tx: string | undefined;
+    try {
+        const { signingClient } = await getSigningClient(network);
+        tx = await signSettlementTx(signingClient, address, network, tableId, action, amount, data);
+    } catch (err) {
+        console.error("[settlement] tx signing skipped:", err);
+    }
+
     const response = await getGatewayApi().submitAction({
         gameId: tableId,
         action,
@@ -108,6 +127,7 @@ export async function executeGatewayAction(tableId: string, action: string, acti
         address,
         signature,
         data,
+        tx,
         clientTs: Date.now()
     });
 

--- a/src/tests/settlementTx.test.ts
+++ b/src/tests/settlementTx.test.ts
@@ -1,0 +1,69 @@
+import { signSettlementTx, resetSettlementSequence } from "../utils/cosmos/settlementTx";
+import type { NetworkEndpoints } from "../context/NetworkContext";
+
+// getCosmosUrls is used to derive the REST endpoint.
+jest.mock("../utils/cosmos/client", () => ({
+    getCosmosUrls: () => ({ rpcEndpoint: "http://rpc", restEndpoint: "http://rest" })
+}));
+
+const network = {} as NetworkEndpoints;
+
+function mockSigningClient(base64 = "dHhyYXc=") {
+    return {
+        signPerformAction: jest.fn().mockResolvedValue({ base64, sequence: 0, accountNumber: 1 })
+    } as any;
+}
+
+describe("signSettlementTx", () => {
+    const ADDR = "b52funded";
+
+    beforeEach(() => {
+        resetSettlementSequence(ADDR);
+        jest.restoreAllMocks();
+    });
+
+    it("signs and returns the base64 tx for a funded account, tracking sequence locally", async () => {
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ account: { account_number: "7", sequence: "3" } })
+        }) as any;
+        const client = mockSigningClient();
+
+        const tx1 = await signSettlementTx(client, ADDR, network, "g1", "call", 100n, "");
+        const tx2 = await signSettlementTx(client, ADDR, network, "g1", "check", 0n, "");
+
+        expect(tx1).toBe("dHhyYXc=");
+        expect(tx2).toBe("dHhyYXc=");
+        // account queried ONCE; sequence incremented locally (3 then 4).
+        expect((global.fetch as jest.Mock)).toHaveBeenCalledTimes(1);
+        expect(client.signPerformAction).toHaveBeenNthCalledWith(1, "g1", "call", 100n, "", expect.objectContaining({ accountNumber: 7, sequence: 3 }));
+        expect(client.signPerformAction).toHaveBeenNthCalledWith(2, "g1", "check", 0n, "", expect.objectContaining({ sequence: 4 }));
+    });
+
+    it("returns undefined (no settlement) for an unfunded account — gameplay still proceeds", async () => {
+        global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 }) as any;
+        const client = mockSigningClient();
+
+        const tx = await signSettlementTx(client, "b52unfunded", network, "g1", "call", 100n, "");
+
+        expect(tx).toBeUndefined();
+        expect(client.signPerformAction).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined and resets sequence on a sign error so the next action re-syncs", async () => {
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({ account: { account_number: "1", sequence: "0" } })
+        }) as any;
+        const client = {
+            signPerformAction: jest.fn().mockRejectedValueOnce(new Error("sign boom"))
+        } as any;
+
+        const tx = await signSettlementTx(client, ADDR, network, "g1", "raise", 200n, "");
+        expect(tx).toBeUndefined();
+
+        // After a reset, the next call re-fetches the account.
+        await signSettlementTx(client, ADDR, network, "g1", "raise", 200n, "").catch(() => {});
+        expect((global.fetch as jest.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+});

--- a/src/utils/cosmos/settlementTx.ts
+++ b/src/utils/cosmos/settlementTx.ts
@@ -1,0 +1,103 @@
+/**
+ * Settlement-tx signing for the optimistic gateway (poker-vm spec §6.10).
+ *
+ * In gateway mode each action is signed as a cosmos MsgPerformAction TxRaw
+ * (SDK signPerformAction, no broadcast) and attached to the gateway POST;
+ * the gateway relays the bytes to the chain's existing pipeline so balances
+ * settle at the boundaries (hand-end/leave). This is ADDITIVE — the EIP-191
+ * gateway action still drives gameplay; the tx is best-effort settlement.
+ *
+ * Sequence is tracked LOCALLY (query the account once, +1 per signed action):
+ * optimistic actions are signed faster than the chain commits, so a
+ * per-action sequence query would return the stale committed value.
+ *
+ * Graceful degradation:
+ *   - account not on-chain (unfunded) → no tx (gameplay still works, no settlement)
+ *   - sign error → no tx + sequence reset so the next action re-syncs
+ */
+import type { SigningCosmosClient } from "@block52/poker-vm-sdk";
+
+import type { NetworkEndpoints } from "../../context/NetworkContext";
+import { getCosmosUrls } from "./client";
+
+interface SeqState {
+    accountNumber: number;
+    sequence: number;
+}
+
+const seqByAddress = new Map<string, SeqState>();
+const unfundedWarned = new Set<string>();
+
+/** Clears tracked sequence so the next action re-fetches it (call on re-sync). */
+export function resetSettlementSequence(address: string): void {
+    seqByAddress.delete(address);
+}
+
+async function loadSeqState(address: string, restEndpoint: string): Promise<SeqState | null> {
+    const cached = seqByAddress.get(address);
+    if (cached) {
+        return cached;
+    }
+    try {
+        const res = await fetch(`${restEndpoint}/cosmos/auth/v1beta1/accounts/${address}`);
+        if (!res.ok) {
+            // 404 = account doesn't exist on-chain (unfunded). Settle nothing.
+            if (!unfundedWarned.has(address)) {
+                console.error(`[settlement] account ${address} not on-chain (unfunded) — actions play but won't settle until funded`);
+                unfundedWarned.add(address);
+            }
+            return null;
+        }
+        const body = await res.json();
+        if (!body.account) {
+            return null;
+        }
+        const state: SeqState = {
+            accountNumber: Number(body.account.account_number),
+            sequence: Number(body.account.sequence)
+        };
+        seqByAddress.set(address, state);
+        return state;
+    } catch (err) {
+        console.error("[settlement] failed to load account sequence:", err);
+        return null;
+    }
+}
+
+/**
+ * Signs the action as a cosmos tx for settlement relay; returns the base64
+ * TxRaw, or undefined when settlement isn't possible (unfunded account / sign
+ * error) — in which case the caller proceeds with gameplay only.
+ */
+export async function signSettlementTx(
+    signingClient: SigningCosmosClient,
+    address: string,
+    network: NetworkEndpoints,
+    tableId: string,
+    action: string,
+    amount: bigint,
+    data: string
+): Promise<string | undefined> {
+    const { restEndpoint } = getCosmosUrls(network);
+    const state = await loadSeqState(address, restEndpoint);
+    if (!state) {
+        return undefined;
+    }
+    try {
+        const { base64 } = await signingClient.signPerformAction(tableId, action, amount, data, {
+            accountNumber: state.accountNumber,
+            sequence: state.sequence,
+            chainId: COSMOS_CHAIN_ID
+        });
+        state.sequence += 1; // advance locally for the next action
+        return base64;
+    } catch (err) {
+        console.error("[settlement] sign failed, resetting sequence:", err);
+        resetSettlementSequence(address);
+        return undefined;
+    }
+}
+
+// pokerchain chain id (matches COSMOS_CONSTANTS.CHAIN_ID; inlined to avoid a
+// values import in this tx-signing util).
+const COSMOS_CHAIN_ID = "pokerchain";

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,10 +306,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@block52/poker-vm-sdk@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.2.4.tgz#1488b50c7460cbcbca72a83f3ab20bec76253737"
-  integrity sha512-IL3Ckfa/g5dPwlty5BvlSicFYuc5RxkybC0PZSSqTFVDTgMpoPHPlmPU6WhOEHf6/I9WDBG0bX5rkXbo9ggLBw==
+"@block52/poker-vm-sdk@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@block52/poker-vm-sdk/-/poker-vm-sdk-1.2.5.tgz#9451d48a839964e2b02f66757450b2e59d4bc5eb"
+  integrity sha512-+YTmfQ9jDR7Hf6MfVuB0Bu2kwaMQxdhJC+vmv2FiBgoeNx352ghLRZ+CLBJgTSw2jbeodqOZrBIIn+Uohny2bw==
   dependencies:
     "@bufbuild/protobuf" "^2.10.0"
     "@cosmjs/crypto" "^0.32.4"


### PR DESCRIPTION
Phase 2b of settlement — the FE half. Completes the loop with the merged gateway relay (poker-vm#2238) + SDK 1.2.5 (`signPerformAction`).

## What
In gateway mode each action is also signed as a cosmos `MsgPerformAction` `TxRaw` (no broadcast) and attached to the gateway POST as `tx`. The gateway relays the bytes to the chain's existing pipeline → balances settle at the boundaries (hand-end/leave). **Additive**: the EIP-191 action still drives gameplay; the tx is best-effort settlement.

- `settlementTx.ts`: signs with **locally-tracked sequence** (query account once, +1 per action — optimistic actions outrun chain commits, so per-action sequence queries return stale values). Graceful degradation: unfunded account → no tx (gameplay proceeds); sign error → reset + re-sync.
- `executeGatewayAction` threads `network` + attaches `tx`; `GatewayApi` gains `tx?`; SDK bumped to 1.2.5.

## Tests
816/816. New `settlementTx.test.ts`: funded account signs + tracks sequence locally (account queried once), unfunded → undefined (no settlement), sign error → undefined + resync.

## Verification (needs a funded account)
Real settlement only happens for **funded on-chain accounts** (the relayed tx needs account_number + sequence). With a funded wallet: play a hand through the gateway, watch the relayed txs settle the balance on-chain at hand-end/leave. Known watch-item: the gateway-mode `deal`/`new-hand` carries a client deck; the chain's VRF enforcement may reject those settlement txs — to confirm in e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)