### PR TITLE
fix(gateway): route leave and top-up through the gateway transport (#440)

### DIFF
--- a/src/hooks/game/useTableTopUp.ts
+++ b/src/hooks/game/useTableTopUp.ts
@@ -1,5 +1,8 @@
 import { useState } from "react";
+import { NonPlayerActionType } from "@block52/poker-vm-sdk";
 import { getSigningClient } from "../../utils/cosmos/client";
+import { getGameTransport } from "../../utils/gameTransport";
+import { executeGatewayAction, getLatestGameState, nextActionIndex } from "../playerActions/transportAction";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 
 /**
@@ -45,9 +48,19 @@ export const useTableTopUp = (tableId: string, network: NetworkEndpoints) => {
                 throw new Error("Invalid top-up amount. Must be a positive number.");
             }
 
+            // Gateway transport (ui#440): top-up is a signed gateway action.
+            // The engine queues it (flushed at the next hand); the relayed tx
+            // settles it on-chain. KNOWN GAP: perform_action "top-up" queues
+            // the chips but the escrow DEPOSIT lives in MsgTopUp, so the
+            // optimistic chips aren't yet backed by a real deposit (#2243).
+            if (getGameTransport() === "gateway") {
+                const index = nextActionIndex(getLatestGameState());
+                const result = await executeGatewayAction(tableId, NonPlayerActionType.TOP_UP, index, topUpAmount, "", network);
+                return { hash: result.hash, gameId: tableId, amount: topUpAmount.toString() };
+            }
+
             // Call SigningCosmosClient.topUp()
             const transactionHash = await signingClient.topUp(tableId, topUpAmount);
-
 
             return {
                 hash: transactionHash,

--- a/src/hooks/playerActions/leaveTable.test.ts
+++ b/src/hooks/playerActions/leaveTable.test.ts
@@ -10,8 +10,17 @@ const mockGetSigningClient = getSigningClient as jest.MockedFunction<typeof getS
 type SigningClient = Awaited<ReturnType<typeof getSigningClient>>["signingClient"];
 
 describe("leaveTable", () => {
+    const savedTransport = process.env.VITE_GAME_TRANSPORT;
+
     beforeEach(() => {
         jest.clearAllMocks();
+        // These assert the chain-direct path; chain is now opt-out (#440).
+        process.env.VITE_GAME_TRANSPORT = "chain";
+    });
+
+    afterEach(() => {
+        process.env.VITE_GAME_TRANSPORT = savedTransport;
+        if (savedTransport === undefined) delete process.env.VITE_GAME_TRANSPORT;
     });
 
     const fakeNetwork = { name: "testnet", rpc: "http://x", rest: "http://y" } as unknown as NetworkEndpoints;

--- a/src/hooks/playerActions/leaveTable.ts
+++ b/src/hooks/playerActions/leaveTable.ts
@@ -1,5 +1,7 @@
 import { getSigningClient } from "../../utils/cosmos/client";
 import { NonPlayerActionType } from "@block52/poker-vm-sdk";
+import { getGameTransport } from "../../utils/gameTransport";
+import { executeGatewayAction, getLatestGameState, nextActionIndex } from "./transportAction";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { LeaveTableResult } from "../../types";
 
@@ -16,6 +18,15 @@ import type { LeaveTableResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the chain rejects the leave
  */
 export async function leaveTable(tableId: string, network: NetworkEndpoints): Promise<LeaveTableResult> {
+    // Gateway transport (ui#440): leave is a signed gateway action applied
+    // optimistically by the gateway and relayed to the chain for settlement
+    // (the engine's "leave" action triggers the escrow refund — spec §6.10).
+    if (getGameTransport() === "gateway") {
+        const index = nextActionIndex(getLatestGameState());
+        const result = await executeGatewayAction(tableId, NonPlayerActionType.LEAVE, index, 0n, "", network);
+        return { hash: result.hash, gameId: tableId, action: NonPlayerActionType.LEAVE };
+    }
+
     const { signingClient } = await getSigningClient(network);
     const hash = await signingClient.leaveGame(tableId);
     return { hash, gameId: tableId, action: NonPlayerActionType.LEAVE };


### PR DESCRIPTION
## Bug (today's report: leave & top-up not working)
Leave and top-up were the **only** player flows still chain-direct (`signingClient.leaveGame` / `topUp`) — never routed to the gateway when the 13 action helpers + join were. So in gateway mode (now default) they failed on gateway-only tables and had **no visible effect** on recovered tables (the gateway's optimistic state never reflected them).

## Fix
Route both through `executeGatewayAction` (same pattern as join): applied optimistically by the gateway at ~150ms **and** relayed as a signed tx for settlement.
- **leave** → `perform_action "leave"` triggers the chain's escrow refund (settles correctly).
- **top-up** → queued optimistically; the escrow **deposit** gap (`perform_action` vs `MsgTopUp`) is tracked in **poker-vm#2243** — flagged inline.
- Chain transport (opt-out) unchanged.
- `leaveTable.test` pins `VITE_GAME_TRANSPORT=chain` for its chain-path assertions.

## Tests
816/816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)