### PR TITLE
fix(gateway): route leave/top-up through gateway + pace auto-new-hand showdown

### DIFF
--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -260,7 +260,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
 
     // Auto-new-hand hook - automatically triggers new hand when conditions are met
     // Can be disabled via URL query param: ?autonewhand=false or via settings panel
-    useAutoNewHand(
+    const { isDealingNewHand } = useAutoNewHand(
         tableId,
         network,
         hasNewHandAction,
@@ -543,6 +543,22 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
                             label="START NEW HAND"
                             loading={loadingAction === "new-hand"}
                             onClick={() => handleActionWithTransaction("new-hand", () => handleStartNewHand(tableId, network))}
+                            variant="primary"
+                            className="px-6 lg:px-8 py-2 lg:py-3 text-sm lg:text-base font-bold"
+                        />
+                    </div>
+                )}
+
+                {/* Auto-new-hand: hold on the showdown for a beat, showing a
+                    "Dealing hand #X…" indicator before the next hand deals (ui#443) */}
+                {autoNewHandEnabled && isDealingNewHand && (
+                    <div className="flex justify-center mb-2 lg:mb-3">
+                        <ActionButton
+                            action="new-hand"
+                            label={`Dealing hand #${(gameState?.handNumber ?? 0) + 1}`}
+                            loading={true}
+                            disabled={true}
+                            onClick={() => {}}
                             variant="primary"
                             className="px-6 lg:px-8 py-2 lg:py-3 text-sm lg:text-base font-bold"
                         />

--- a/src/hooks/playerActions/useAutoNewHand.ts
+++ b/src/hooks/playerActions/useAutoNewHand.ts
@@ -1,8 +1,13 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import { startNewHand } from "./startNewHand";
 import { getAutoNewHandEnabled } from "../../utils/urlParams";
-import { isNullish } from "../../utils/guards";
+import { isNullish, hasValue } from "../../utils/guards";
+
+// Hold on the showdown for a beat before auto-dealing so the result is actually
+// visible (gateway transport delivers the next hand in ~150ms otherwise). During
+// this window the panel shows a "Dealing hand #X…" indicator. See ui#443.
+const AUTO_NEW_HAND_DELAY_MS = 2000;
 
 /**
  * Hook to automatically trigger new hand when the current hand ends.
@@ -27,6 +32,8 @@ import { isNullish } from "../../utils/guards";
  * @param onNewHandComplete - Optional callback when auto-new-hand completes
  * @param onNewHandError - Optional callback when auto-new-hand fails
  * @param enabled - Optional override for the URL param setting (reactive)
+ * @returns `{ isDealingNewHand }` — true during the pre-deal countdown and the
+ *          deal request, so the UI can show a "Dealing hand #X…" indicator.
  */
 export function useAutoNewHand(
     tableId: string,
@@ -37,13 +44,17 @@ export function useAutoNewHand(
     onNewHandComplete?: (txHash: string) => void,
     onNewHandError?: (error: Error) => void,
     enabled?: boolean
-): void {
+): { isDealingNewHand: boolean } {
     // Track if we've already triggered new hand for this opportunity
     const hasTriggeredRef = useRef<boolean>(false);
     // Track if new hand is currently in progress to prevent duplicate calls
     const isProcessingRef = useRef<boolean>(false);
     // Check if auto-new-hand is enabled — prefer the reactive `enabled` prop, fall back to URL param
     const autoNewHandEnabledRef = useRef<boolean>(enabled ?? getAutoNewHandEnabled());
+    // Pending pre-deal countdown timer.
+    const delayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Drives the "Dealing hand #X…" indicator (countdown + deal request).
+    const [isDealingNewHand, setIsDealingNewHand] = useState<boolean>(false);
 
     // Keep the ref up-to-date when the reactive `enabled` prop changes
     useEffect(() => {
@@ -68,9 +79,11 @@ export function useAutoNewHand(
             onNewHandError?.(error instanceof Error ? error : new Error(String(error)));
         } finally {
             isProcessingRef.current = false;
+            setIsDealingNewHand(false);
         }
     }, [tableId, network, onNewHandStarted, onNewHandComplete, onNewHandError]);
 
+    /* eslint-disable react-hooks/set-state-in-effect */
     useEffect(() => {
         // Check all conditions for auto-new-hand
         const shouldAutoNewHand =
@@ -82,13 +95,37 @@ export function useAutoNewHand(
 
         if (shouldAutoNewHand) {
             hasTriggeredRef.current = true;
-            triggerAutoNewHand();
+            // Show the showdown for AUTO_NEW_HAND_DELAY_MS, surfacing the
+            // "Dealing hand #X…" indicator, then deal the next hand.
+            setIsDealingNewHand(true);
+            delayTimerRef.current = setTimeout(() => {
+                delayTimerRef.current = null;
+                triggerAutoNewHand();
+            }, AUTO_NEW_HAND_DELAY_MS);
         }
 
-        // Reset the trigger flag when new hand action is no longer available
-        // This allows auto-new-hand to trigger again on the next opportunity
+        // New-hand opportunity gone (a hand started — by us or another player).
+        // Reset so the next END re-arms, and cancel any pending countdown.
         if (!hasNewHandAction) {
             hasTriggeredRef.current = false;
+            if (hasValue(delayTimerRef.current)) {
+                clearTimeout(delayTimerRef.current);
+                delayTimerRef.current = null;
+            }
+            setIsDealingNewHand(false);
         }
     }, [hasNewHandAction, isUsersTurn, triggerAutoNewHand]);
+    /* eslint-enable react-hooks/set-state-in-effect */
+
+    // Cancel a pending countdown on unmount.
+    useEffect(
+        () => () => {
+            if (hasValue(delayTimerRef.current)) {
+                clearTimeout(delayTimerRef.current);
+            }
+        },
+        []
+    );
+
+    return { isDealingNewHand };
 }


### PR DESCRIPTION
## Summary

Two gateway-transport UX fixes on this branch:

### 1. Route leave & top-up through the gateway transport (`40985b8`)
`LEAVE` and `TOP_UP` actions were still going down the chain path; routed them through the gateway transport so they behave consistently with the rest of the gateway action flow (#440).

- `src/hooks/playerActions/leaveTable.ts` (+ test)
- `src/hooks/game/useTableTopUp.ts`

### 2. Pace auto-new-hand — hold the showdown ~2s (`bbeb3cc`, refs #443 / #448)
Gateway transport delivers the next hand in ~150ms, so with `?autonewhand=true` (default) the showdown — hole-card flip, winner banner, pot push — flashed and the next hand dealt in the same frame. It was effectively invisible.

- `useAutoNewHand` now waits `AUTO_NEW_HAND_DELAY_MS` (2s) before dealing, leaving the showdown on screen, and returns `{ isDealingNewHand }`.
- `PokerActionPanel` renders a disabled, spinning **"DEALING HAND #X…"** indicator during the countdown + deal.
- `?autonewhand=false` is unchanged (manual **START NEW HAND** button).

| URL | Behaviour |
|-----|-----------|
| `?autonewhand=true` (default) | Showdown holds ~2s with a `DEALING HAND #X…` spinner, then deals. |
| `?autonewhand=false` | Manual button; showdown stays until clicked. |

Tunable: `AUTO_NEW_HAND_DELAY_MS` in `src/hooks/playerActions/useAutoNewHand.ts`.

## Test plan
- `yarn tsc --noEmit` ✅
- `yarn build` ✅
- `yarn test` — full suite passing ✅
- Manual: with `?autonewhand=true`, confirm the showdown holds ~2s and the `DEALING HAND #X…` indicator shows before the next hand deals; with `?autonewhand=false`, confirm unchanged.

Refs #443, #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)