### PR TITLE
refactor: adopt guard helpers across utils + hooks (PR 2b of #449)

### DIFF
--- a/src/hooks/animations/useChipPositions.ts
+++ b/src/hooks/animations/useChipPositions.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { chipPosition } from "../../utils/PositionArray";
 import { useTableState } from "../game/useTableState";
 import { ChipPositionsReturn, TableStateReturn, PositionArray } from "../../types/index";
+import { hasElements } from "../../utils/guards";
 
 /**
  * Custom hook to manage chip positions based on table size
@@ -33,7 +34,7 @@ export const useChipPositions = (startIndex: number = 0): ChipPositionsReturn =>
     }
     
     // Apply reordering if needed
-    if (startIndex > 0 && baseArray.length > 0) {
+    if (startIndex > 0 && hasElements(baseArray)) {
       const reorderedArray = [
         ...baseArray.slice(startIndex),
         ...baseArray.slice(0, startIndex)

--- a/src/hooks/game/useBlindLevel.ts
+++ b/src/hooks/game/useBlindLevel.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useGameStateContext } from "../../context/GameStateContext";
 import { isSitAndGoFormat, isTournamentFormat } from "../../utils/gameFormatUtils";
 import { formatChipCount } from "../../utils/potDisplayUtils";
-import { hasContent, hasValue } from "../../utils/guards";
+import { hasContent, hasValue, isNullish } from "../../utils/guards";
 
 export interface BlindLevelInfo {
     /** Current blind level (0-based), undefined if not provided by backend */
@@ -70,10 +70,10 @@ export const useBlindLevel = (startTime?: number): BlindLevelInfo => {
     const levelDurationSeconds = blindLevelDuration ? blindLevelDuration * 60 : 0;
 
     // Timer: compute seconds remaining in current level
-    const hasTimer = isActive && levelDurationSeconds > 0 && startTime !== undefined && startTime > 0;
+    const hasTimer = isActive && levelDurationSeconds > 0 && hasValue(startTime) && startTime > 0;
 
     const secondsRemaining = useMemo(() => {
-        if (!hasTimer || !startTime || level === undefined) return -1;
+        if (!hasTimer || !startTime || isNullish(level)) return -1;
         const elapsedMs = now - startTime;
         const elapsedSeconds = Math.floor(elapsedMs / 1000);
         const currentLevelEndSeconds = (level + 1) * levelDurationSeconds;

--- a/src/hooks/game/useNewTable.ts
+++ b/src/hooks/game/useNewTable.ts
@@ -5,6 +5,7 @@ import { useNetwork } from "../../context/NetworkContext";
 import {  convertBlindsForBlockchain } from "../../utils/gameFormatUtils";
 import { DEFAULT_TIMEOUT_SECONDS } from "../../utils/timerUtils";
 import { usdcToMicroBigInt } from "../../constants/currency";
+import { hasValue } from "../../utils/guards";
 
 // Type for rake configuration options
 export interface RakeOptions {
@@ -145,7 +146,7 @@ export const useNewTable = (): UseNewTableReturn => {
                 // have failed (non-zero code). Surface the raw_log so the UI
                 // doesn't show a misleading success state.
                 const code = tx?.tx_response?.code;
-                if (code !== undefined && code !== 0) {
+                if (hasValue(code) && code !== 0) {
                     throw new Error(tx?.tx_response?.raw_log || `tx failed with code ${code}`);
                 }
 

--- a/src/hooks/game/useNextToActInfo.ts
+++ b/src/hooks/game/useNextToActInfo.ts
@@ -3,6 +3,7 @@ import { PlayerDTO, LegalActionDTO } from "@block52/poker-vm-sdk";
 import { NextToActInfoReturn } from "../../types/index";
 import { useGameStateContext } from "../../context/GameStateContext";
 import { getTimeoutMs, timeoutToSeconds } from "../../utils/timerUtils";
+import { isNullish } from "../../utils/guards";
 
 /**
  * Custom hook to fetch and provide information about who is next to act
@@ -36,7 +37,7 @@ export const useNextToActInfo = (_tableId?: string): NextToActInfoReturn => {
             }
 
             const nextToActSeat = gameState.nextToAct;
-            if (nextToActSeat === undefined || nextToActSeat === null) {
+            if (isNullish(nextToActSeat)) {
                 return defaultValues;
             }
 

--- a/src/hooks/game/useReplayMode.ts
+++ b/src/hooks/game/useReplayMode.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
+import { hasValue } from "../../utils/guards";
 
 interface UseReplayModeReturn {
     isReplayMode: boolean;
@@ -34,7 +35,7 @@ export const useReplayMode = (): UseReplayModeReturn => {
         return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
     }, [searchParams]);
 
-    const isReplayMode = handNumber !== null && actionIndex !== null;
+    const isReplayMode = hasValue(handNumber) && hasValue(actionIndex);
 
     const clearReplayParams = () => {
         const newParams = new URLSearchParams(searchParams);

--- a/src/hooks/game/useSitAndGoPlayerResults.ts
+++ b/src/hooks/game/useSitAndGoPlayerResults.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { ResultDTO, GameFormat } from "@block52/poker-vm-sdk";
 import { useGameStateContext } from "../../context/GameStateContext";
+import { hasElements } from "../../utils/guards";
 
 // Hook return type for individual player result
 export interface PlayerResultData {
@@ -42,7 +43,7 @@ export const useSitAndGoPlayerResults = (): SitAndGoPlayerResultsReturn => {
 
     // Check if game has results
     const hasResults = useMemo(() => {
-        return allResults.length > 0;
+        return hasElements(allResults);
     }, [allResults]);
 
     // Get result for a specific player address.

--- a/src/hooks/game/useTablePlayerCounts.ts
+++ b/src/hooks/game/useTablePlayerCounts.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { getCosmosUrls } from "../../utils/cosmos/urls";
 import { useNetwork } from "../../context/NetworkContext";
 import { PlayerDTO } from "@block52/poker-vm-sdk";
+import { isEmpty } from "../../utils/guards";
 
 interface TablePlayerCount {
     tableId: string;
@@ -28,7 +29,7 @@ export const useTablePlayerCounts = (tableAddresses: string[]) => {
 
     useEffect(() => {
         const fetchPlayerCounts = async () => {
-            if (!tableAddresses || tableAddresses.length === 0) return;
+            if (isEmpty(tableAddresses)) return;
 
             setIsLoading(true);
             const newCounts = new Map<string, TablePlayerCount>();

--- a/src/hooks/game/useTableTurnIndex.ts
+++ b/src/hooks/game/useTableTurnIndex.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useGameStateContext } from "../../context/GameStateContext";
 import { TableTurnIndexReturn } from "../../types/index";
+import { isEmpty } from "../../utils/guards";
 
 /**
  * Custom hook to get the next turn index for actions at a table
@@ -21,7 +22,7 @@ export function useTableTurnIndex(): TableTurnIndexReturn {
       // Get the previousActions array
       const previousActions = gameState.previousActions || [];
       
-      if (previousActions.length === 0) {
+      if (isEmpty(previousActions)) {
         return 0; // If no previous actions, start with index 0
       }
       

--- a/src/hooks/game/useVacantSeatData.ts
+++ b/src/hooks/game/useVacantSeatData.ts
@@ -3,6 +3,7 @@ import { useGameStateContext } from "../../context/GameStateContext";
 import { PlayerDTO } from "@block52/poker-vm-sdk";
 import { VacantSeatResponse } from "../../types/index";
 import { isValidPlayerAddress } from "../../utils/addressUtils";
+import { isEmpty, isNullish, hasElements } from "../../utils/guards";
 
 /**
  * Custom hook to manage data for vacant seats
@@ -26,7 +27,7 @@ export const useVacantSeatData = (): VacantSeatResponse => {
 
     // Check if user is already playing at the table
     const isUserAlreadyPlaying = React.useMemo(() => {
-        return !!(userAddress && players.length > 0 && 
+        return !!(userAddress && hasElements(players) &&
             players.some((player: PlayerDTO) => player.address?.toLowerCase() === userAddress));
     }, [players, userAddress]);
 
@@ -44,9 +45,9 @@ export const useVacantSeatData = (): VacantSeatResponse => {
     // Get array of all empty seat indexes - optimized to avoid repeated function calls
     const emptySeatIndexes: number[] = React.useMemo(() => {
         // Game state not loaded yet — no seats to show
-        if (maxPlayers === undefined) return [];
+        if (isNullish(maxPlayers)) return [];
 
-        if (players.length === 0) {
+        if (isEmpty(players)) {
             // If no players, all seats are empty
             return Array.from({ length: maxPlayers }, (_, i) => i + 1);
         }

--- a/src/hooks/game/useWinnerInfo.ts
+++ b/src/hooks/game/useWinnerInfo.ts
@@ -2,6 +2,7 @@ import { useGameStateContext } from "../../context/GameStateContext";
 import { PlayerDTO, TexasHoldemStateDTO, WinnerDTO } from "@block52/poker-vm-sdk";
 import { formatUSDCToSimpleDollars } from "../../utils/numberUtils";
 import { WinnerInfo, WinnerInfoReturn } from "../../types/index";
+import { hasElements } from "../../utils/guards";
 
 /**
  * Extract winner information from game state
@@ -12,7 +13,7 @@ function getWinnerInfo(gameData: TexasHoldemStateDTO) {
     if (!gameData) return null;
 
     // Check for explicit winners array in the game data
-    if (gameData.winners && gameData.winners.length > 0) {
+    if (hasElements(gameData.winners)) {
         return gameData.winners.map((winner: WinnerDTO) => {
             // Get the player object for this winner to find their seat
             const player = gameData.players?.find((p: PlayerDTO) => p.address?.toLowerCase() === winner.address?.toLowerCase());

--- a/src/hooks/player/useAllInEquity.ts
+++ b/src/hooks/player/useAllInEquity.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { useGameStateContext } from "../../context/GameStateContext";
 import { useShowingCardsByAddress } from "./useShowingCardsByAddress";
+import { hasValue } from "../../utils/guards";
 import {
     PlayerStatus,
     PlayerDTO,
@@ -169,7 +170,7 @@ export function useAllInEquity(): AllInEquityResult {
             const newEquities = new Map<number, number>();
             winPercentages.forEach((pct, idx) => {
                 const seat = playersWithVisibleCards[idx]?.seat;
-                if (seat !== undefined) {
+                if (hasValue(seat)) {
                     newEquities.set(seat, pct);
                 }
             });

--- a/src/hooks/player/usePlayerActionDropBox.ts
+++ b/src/hooks/player/usePlayerActionDropBox.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { useGameProgress } from "../game/useGameProgress";
 import { PlayerActionType, NonPlayerActionType } from "@block52/poker-vm-sdk";
 import { formatUSDCToSimpleDollars } from "../../utils/numberUtils";
+import { isEmpty } from "../../utils/guards";
 
 export interface PlayerActionDisplay {
   action: string;
@@ -73,7 +74,7 @@ export const usePlayerActionDropBox = (seatIndex: number): PlayerActionDisplay =
 
   // Performance optimization: Cache the most recent action index to avoid recalculating
   const mostRecentActionIndex = useMemo(() => {
-    if (!previousActions || previousActions.length === 0) return -1;
+    if (isEmpty(previousActions)) return -1;
 
     // Find the highest index efficiently
     return Math.max(...previousActions.map(action => action.index));
@@ -81,7 +82,7 @@ export const usePlayerActionDropBox = (seatIndex: number): PlayerActionDisplay =
 
   // Get the GLOBALLY most recent action and check if it belongs to this player
   const latestAction = useMemo(() => {
-    if (!previousActions || previousActions.length === 0 || mostRecentActionIndex === -1) return null;
+    if (isEmpty(previousActions) || mostRecentActionIndex === -1) return null;
 
     // Find the action with the most recent index
     const globallyMostRecentAction = previousActions.find(action => action.index === mostRecentActionIndex) || null;

--- a/src/hooks/player/usePlayerChipData.ts
+++ b/src/hooks/player/usePlayerChipData.ts
@@ -4,6 +4,7 @@ import { PlayerChipDataReturn } from "../../types/index";
 import { useGameData } from "../../context/gameState/GameDataContext";
 import { useGameUI } from "../../context/gameState/GameUIContext";
 import { shouldShowChips, getRelevantChipAmounts, calculateCurrentRoundBetting, hasPlayerBetInRound } from "../../utils/chipUtils";
+import { hasElements } from "../../utils/guards";
 
 /**
  * Per-seat chip data for a single player.
@@ -30,7 +31,7 @@ export const usePlayerChipData = (seatIndex: number): PlayerChipDataReturn => {
     const previousActions: ActionDTO[] = gameState?.previousActions ?? [];
     // Monotonic fingerprint of the action log — changes only when a new
     // action lands, not on every gameState identity flip.
-    const lastActionIndex = previousActions.length > 0 ? previousActions[previousActions.length - 1].index : -1;
+    const lastActionIndex = hasElements(previousActions) ? previousActions[previousActions.length - 1].index : -1;
     const actionsFingerprint = `${previousActions.length}:${lastActionIndex}`;
 
     const chipAmount = useMemo<string>(() => {
@@ -57,7 +58,7 @@ export const usePlayerChipData = (seatIndex: number): PlayerChipDataReturn => {
         if (!round) return [];
 
         const amounts = getRelevantChipAmounts(player.address, round, previousActions);
-        if (amounts.length > 0) return amounts;
+        if (hasElements(amounts)) return amounts;
 
         // Fallback: render the running total as a single group when no per-action
         // amounts matched (covers edge cases like first-action sumOfBets display)

--- a/src/hooks/player/usePlayerTimer.ts
+++ b/src/hooks/player/usePlayerTimer.ts
@@ -8,6 +8,7 @@ import { foldHand } from "../playerActions/foldHand";
 import { checkHand } from "../playerActions/checkHand";
 import { usePlayerLegalActions } from "../playerActions/usePlayerLegalActions";
 import { useGameOptions } from "../game/useGameOptions";
+import { isEmpty, isNullish } from "../../utils/guards";
 import { getTimeoutMs, timeoutToSeconds, getLatestActionTimestampMs, calcTimeRemaining, calcProgressPercent } from "../../utils/timerUtils";
 
 // Global state to track time extensions per seat
@@ -49,7 +50,7 @@ export const usePlayerTimer = (tableId?: string, playerSeat?: number): PlayerTim
 
     // Find the player by seat number
     const player = useMemo((): PlayerDTO | null => {
-        if (!gameState?.players || playerSeat === undefined) {
+        if (!gameState?.players || isNullish(playerSeat)) {
             return null;
         }
         return gameState.players.find((p: PlayerDTO) => p.seat === playerSeat) || null;
@@ -146,7 +147,7 @@ export const usePlayerTimer = (tableId?: string, playerSeat?: number): PlayerTim
         }
 
         // Check if player has legal actions (can actually act)
-        if (!legalActions || legalActions.length === 0) {
+        if (isEmpty(legalActions)) {
             latestValues.current.isExecutingAutoAction = false;
             return;
         }

--- a/src/hooks/playerActions/joinTable.ts
+++ b/src/hooks/playerActions/joinTable.ts
@@ -5,6 +5,7 @@ import { executeGatewayAction, getLatestGameState, nextActionIndex } from "./tra
 import type { JoinTableOptions } from "./types";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { JoinTableResult } from "../../types";
+import { hasValue } from "../../utils/guards";
 
 /**
  * Joins a poker table using Cosmos SDK SigningCosmosClient.
@@ -28,7 +29,7 @@ export async function joinTable(tableId: string, options: JoinTableOptions, netw
     const buyInAmount = BigInt(Math.floor(amountInUsdc * Math.pow(10, COSMOS_CONSTANTS.USDC_DECIMALS)));
 
     // If seatNumber is not provided, default to 0
-    const seat = options.seatNumber !== undefined && options.seatNumber !== null
+    const seat = hasValue(options.seatNumber)
         ? options.seatNumber
         : 0;
 

--- a/src/hooks/playerActions/transportAction.ts
+++ b/src/hooks/playerActions/transportAction.ts
@@ -20,6 +20,7 @@ import { getSigningClient } from "../../utils/cosmos/client";
 import { signActionMessage } from "../../utils/cosmos/signing";
 import { signSettlementTx } from "../../utils/cosmos/settlementTx";
 import { getGameTransport, getGatewayApi } from "../../utils/gameTransport";
+import { hasValue, isNullish } from "../../utils/guards";
 
 let latestGameState: TexasHoldemStateDTO | undefined;
 
@@ -36,7 +37,7 @@ export function setLatestGameState(gameState: TexasHoldemStateDTO | undefined): 
 export function nextActionIndex(gameState: TexasHoldemStateDTO | undefined): number {
     for (const player of gameState?.players ?? []) {
         const index = player.legalActions?.[0]?.index;
-        if (index !== undefined) {
+        if (hasValue(index)) {
             return index;
         }
     }
@@ -70,7 +71,7 @@ export async function executeTransportAction(
         const address = localStorage.getItem("user_cosmos_address");
         const currentPlayer = latestGameState?.players?.find(p => p.address === address);
         const actionIndex = currentPlayer?.legalActions?.[0]?.index;
-        if (actionIndex === undefined) {
+        if (isNullish(actionIndex)) {
             // Per Commandment 7: surface it — no guessed indices.
             throw new Error(`No legal action index available for ${action} — game state may be stale`);
         }

--- a/src/hooks/playerActions/useOptimisticAction.ts
+++ b/src/hooks/playerActions/useOptimisticAction.ts
@@ -6,6 +6,7 @@ import { getGameTransport } from "../../utils/gameTransport";
 import { executeTransportAction } from "./transportAction";
 import type { PlayerActionResult } from "../../types";
 import { PlayerActionType, NonPlayerActionType } from "@block52/poker-vm-sdk";
+import { isNullish, hasValue } from "../../utils/guards";
 
 /**
  * Actions that can be performed optimistically.
@@ -72,7 +73,7 @@ export function useOptimisticAction(): UseOptimisticActionReturn {
         ): Promise<PlayerActionResult> => {
 
             // Validate amount for actions that require it
-            if (ACTIONS_REQUIRING_AMOUNT.has(action) && amount === undefined) {
+            if (ACTIONS_REQUIRING_AMOUNT.has(action) && isNullish(amount)) {
                 throw new Error(`Amount required for ${action}`);
             }
 
@@ -96,6 +97,6 @@ export function useOptimisticAction(): UseOptimisticActionReturn {
 
     return {
         performOptimisticAction,
-        isPending: pendingAction !== null
+        isPending: hasValue(pendingAction)
     };
 }

--- a/src/hooks/playerActions/usePlayerLegalActions.ts
+++ b/src/hooks/playerActions/usePlayerLegalActions.ts
@@ -3,6 +3,7 @@ import { useGameUI } from "../../context/gameState/GameUIContext";
 import { PlayerLegalActionsResult } from "./types";
 import { LegalActionDTO, PlayerActionType, PlayerDTO } from "@block52/poker-vm-sdk";
 import { useRef, useMemo, useState, useEffect } from "react";
+import { hasElements } from "../../utils/guards";
 
 // 🔍 DEBUG: Enhanced logging utility for easy data export (same as GameStateContext)
 const debugLog = (eventType: string, data: any) => {
@@ -71,7 +72,7 @@ export function usePlayerLegalActions(): PlayerLegalActionsResult {
             let currentPlayer: PlayerDTO | null = null;
             let isPlayerInGame = false;
 
-            if (gameState.players?.length > 0) {
+            if (hasElements(gameState.players)) {
                 // Find player with exact address match (case-insensitive)
                 currentPlayer = gameState.players?.find((player: PlayerDTO) => player.address?.toLowerCase() === userAddress) ?? null;
                 isPlayerInGame = !!currentPlayer;
@@ -145,7 +146,7 @@ export function usePlayerLegalActions(): PlayerLegalActionsResult {
 
     // 🔍 DEBUG: Optimized logging - only when result actually changes
     useEffect(() => {
-        if (result.isPlayerTurn || result.legalActions.length > 0) {
+        if (result.isPlayerTurn || hasElements(result.legalActions)) {
             const currentState = JSON.stringify({
                 playerSeat: result.playerSeat,
                 isPlayerTurn: result.isPlayerTurn,

--- a/src/hooks/profile/useWalletNfts.ts
+++ b/src/hooks/profile/useWalletNfts.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { ETH_CHAIN_ID } from "../../config/constants";
 import { normalizeIpfsUri, isAllowedAvatarUrl } from "../../utils/profile/ipfs";
 import type { WalletNftAsset } from "../../types/profile/avatar";
+import { hasContent } from "../../utils/guards";
 
 interface ProfileNftConfig {
     chainId: number;
@@ -104,7 +105,7 @@ export const useWalletNfts = (walletAddress: string | undefined, isConnected: bo
     const [nftsWarning, setNftsWarning] = useState<string | null>(null);
 
     const hasIndexerConfigured = useMemo(() => {
-        return PROFILE_NFT_CONFIG.indexerUrlTemplate.trim().length > 0 || PROFILE_NFT_CONFIG.fallbackAlchemyUrl.trim().length > 0;
+        return hasContent(PROFILE_NFT_CONFIG.indexerUrlTemplate.trim()) || hasContent(PROFILE_NFT_CONFIG.fallbackAlchemyUrl.trim());
     }, []);
     const hasSourceConfigured = hasIndexerConfigured;
 

--- a/src/utils/b52AccountUtils.ts
+++ b/src/utils/b52AccountUtils.ts
@@ -4,6 +4,7 @@
 
 // NodeRpcClient removed from SDK - using CosmosClient instead
 // import { NodeRpcClient } from "@block52/poker-vm-sdk";
+import { hasValue } from "./guards";
 
 // Singleton instance for NodeRpcClient (deprecated - kept for potential future use)
 let clientInstance: unknown = null;
@@ -58,7 +59,7 @@ export const clearPrivateKey = (): void => {
  * @returns True if private key exists in storage
  */
 export const hasPrivateKey = (): boolean => {
-    return getPrivateKey() !== null;
+    return hasValue(getPrivateKey());
 };
 
 /**

--- a/src/utils/potDisplayUtils.ts
+++ b/src/utils/potDisplayUtils.ts
@@ -1,5 +1,6 @@
 import { isTournamentFormat, isSitAndGoFormat, GameFormat, TexasHoldemRound } from "@block52/poker-vm-sdk";
 import { formatUSDCToSimpleDollars } from "./numberUtils";
+import { hasElements } from "./guards";
 
 export interface PotDisplayValues {
     totalPot: string;
@@ -29,7 +30,7 @@ export function formatPotDisplay(
     gameFormat: GameFormat | undefined,
     round?: TexasHoldemRound
 ): PotDisplayValues {
-    const mainPotRaw = pots.length > 0 ? BigInt(pots[0]) : 0n;
+    const mainPotRaw = hasElements(pots) ? BigInt(pots[0]) : 0n;
     const totalPotRaw = totalPot ? BigInt(totalPot) : mainPotRaw;
 
     const isTournamentStyle = isTournamentFormat(gameFormat) || isSitAndGoFormat(gameFormat);

--- a/src/utils/raiseUtils.ts
+++ b/src/utils/raiseUtils.ts
@@ -1,5 +1,6 @@
 import { ActionDTO, PlayerActionType, TexasHoldemRound } from "@block52/poker-vm-sdk";
 import { microToUsdc } from "../constants/currency";
+import { isEmpty } from "./guards";
 
 /**
  * Calculate the total amount to display on the raise button.
@@ -21,14 +22,14 @@ export const calculateRaiseToDisplay = (playerSumOfBets: string, raiseAmount: nu
 
 export const getRaiseToAmount = (raiseAmount: number, actions: ActionDTO[], currentRound: TexasHoldemRound, userAddress: string): number => {
     // If no actions, return raiseAmount
-    if (!actions || actions.length === 0) {
+    if (isEmpty(actions)) {
         return raiseAmount;
     }
 
     // Get players previous actions
     const previousActions = actions.filter(action => action.playerId?.toLowerCase() === userAddress.toLowerCase());
 
-    if (!previousActions || previousActions.length === 0) {
+    if (isEmpty(previousActions)) {
         // If no previous actions, return raiseAmount
         return raiseAmount;
     }

--- a/src/utils/tableStatusDisplayUtils.ts
+++ b/src/utils/tableStatusDisplayUtils.ts
@@ -9,6 +9,8 @@
  * by PlayerActionButtons via the "waiting-for-players" kind.
  */
 
+import { hasElements } from "./guards";
+
 export type TableStatusMessage =
     | { kind: "seat-label"; seatNumber: number; text: string }
     | { kind: "your-turn"; text: string }
@@ -104,5 +106,5 @@ export function getWaitingForPlayerLabel(
  * Convenience check for whether any status messages should be rendered.
  */
 export function hasTableStatusMessages(input: TableStatusDisplayInput): boolean {
-    return getTableStatusMessages(input).length > 0;
+    return hasElements(getTableStatusMessages(input));
 }

--- a/src/utils/timerUtils.ts
+++ b/src/utils/timerUtils.ts
@@ -1,4 +1,5 @@
 import { ActionDTO } from "@block52/poker-vm-sdk";
+import { hasElements } from "./guards";
 
 /** Default timeout in seconds for game creation */
 export const DEFAULT_TIMEOUT_SECONDS = 30;
@@ -39,7 +40,7 @@ export const normalizeTimestamp = (timestamp: number): number => {
  * Falls back to Date.now() when the array is empty / undefined.
  */
 export const getLatestActionTimestampMs = (previousActions: ActionDTO[] | undefined): number => {
-    if (!previousActions || previousActions.length === 0) {
+    if (!hasElements(previousActions)) {
         return Date.now();
     }
     const sorted = [...previousActions].sort((a, b) => b.timestamp - a.timestamp);


### PR DESCRIPTION
Second guard batch from the frontend refactoring audit (#449), following #451. Covers the **pure-logic `utils/` and `hooks/` files** (no JSX) — **34 inline checks across 24 files** now route through `utils/guards.ts`.

| Helper | Used for |
|---|---|
| `isEmpty` / `hasElements` | array length checks |
| `isNullish` | `=== undefined` / `=== null` combos |
| `hasValue` | dual-null and `!== null` / `!== undefined` |
| `isBlank` / `hasContent` | `""` string checks |

### Worth a reviewer's eye
- **`timerUtils.getLatestActionTimestampMs`** uses `!hasElements(...)` rather than `isEmpty(...)`: the array is spread (`[...previousActions]`) right after, and `isEmpty` returns a plain `boolean` so it wouldn't narrow `ActionDTO[] | undefined`. `hasElements` is a type guard, so the negated early-return narrows correctly. (tsc caught this — fixed before pushing.)

### Deliberately skipped (not clean guard candidates)
- Sites guarded by `Array.isArray` — `usePlayerLegalActions`, `useNextToActInfo`, `usePlayerChipData`, `useTableState`
- Value-comparison nulls — `playerActionDisplayUtils`, `chipUtils`
- The intentional `!== null` in `tableStatusDisplayUtils` that handles **seat 0** correctly

### Verification
- `tsc --noEmit`: clean (lone `settlementTx.ts` error pre-exists on `main`, unrelated)
- `eslint`: **no new problems** — the 3 react-compiler errors flagged in touched files are confirmed identical on `main` (line numbers just shifted +1 from the added import)
- **Full suite: 816/816 tests pass**

Part of #449. Remaining guard sites (~89, mostly JSX-heavy `components/` and `pages/`) tracked there for a follow-up batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)