### PR TITLE
refactor: extract truncateMiddle, dedupe address/hash formatters (PR 3 of #449)

### DIFF
--- a/src/components/TableList.tsx
+++ b/src/components/TableList.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from "react";
+import { truncateMiddle } from "../utils/stringUtils";
 import { useFindGames, GameWithFormat, treasuryAddress } from "../hooks/game/useFindGames";
 import { useDeleteGame } from "../hooks/game/useDeleteGame";
 import { useForceCloseGame } from "../hooks/game/useForceCloseGame";
@@ -340,7 +341,7 @@ const TableList: React.FC = () => {
                                         <td className="px-4 py-4">
                                             <div className="flex items-center justify-center gap-2">
                                                 <span className="text-gray-300 font-mono text-sm">
-                                                    {`${game.gameId.slice(0, 4)}...${game.gameId.slice(-4)}`}
+                                                    {truncateMiddle(game.gameId, 4, 4)}
                                                 </span>
                                                 <button
                                                     onClick={() => copyToClipboard(game.gameId)}

--- a/src/components/common/utils.ts
+++ b/src/components/common/utils.ts
@@ -1,5 +1,6 @@
+import { truncateMiddle } from "../../utils/stringUtils";
+
 // Add function to format address
 export const formatAddress = (address: string | undefined) => {
-    if (!address) return "";
-    return `${address.slice(0, 6)}...${address.slice(-4)}`;
+    return truncateMiddle(address, 6, 4);
 };

--- a/src/components/depositComponents/Web3DepositSection.tsx
+++ b/src/components/depositComponents/Web3DepositSection.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { truncateMiddle } from "../../utils/stringUtils";
 import styles from "./DepositComponents.module.css";
 
 interface Web3DepositSectionProps {
@@ -90,7 +91,7 @@ export const Web3DepositSection: React.FC<Web3DepositSectionProps> = ({
                     <div className="space-y-4">
                         <div className={`flex justify-between items-center ${styles.connectedText}`}>
                             <span>
-                                Connected: {web3Address?.slice(0, 6)}...{web3Address?.slice(-4)}
+                                Connected: {truncateMiddle(web3Address, 6, 4)}
                             </span>
                             <button
                                 onClick={onDisconnect}

--- a/src/components/modals/DeleteTableModal.tsx
+++ b/src/components/modals/DeleteTableModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from "react";
+import { truncateMiddle } from "../../utils/stringUtils";
 import { colors } from "../../utils/colorConfig";
 import { Modal, LoadingSpinner } from "../common";
 import styles from "./DeleteTableModal.module.css";
@@ -27,7 +28,7 @@ const DeleteTableModal: React.FC<DeleteTableModalProps> = React.memo(({ isOpen, 
         }
     }, [onConfirm, onClose]);
 
-    const truncatedId = `${gameId.slice(0, 6)}...${gameId.slice(-6)}`;
+    const truncatedId = truncateMiddle(gameId, 6, 6);
 
     return (
         <Modal

--- a/src/components/modals/ForceCloseTableModal.tsx
+++ b/src/components/modals/ForceCloseTableModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from "react";
+import { truncateMiddle } from "../../utils/stringUtils";
 import { colors } from "../../utils/colorConfig";
 import { Modal, LoadingSpinner } from "../common";
 import styles from "./DeleteTableModal.module.css";
@@ -38,7 +39,7 @@ const ForceCloseTableModal: React.FC<ForceCloseTableModalProps> = React.memo(
             }
         }, [onConfirm, onClose]);
 
-        const truncatedId = `${gameId.slice(0, 6)}...${gameId.slice(-6)}`;
+        const truncatedId = truncateMiddle(gameId, 6, 6);
         const playerWord = seatedPlayerCount === 1 ? "player" : "players";
 
         return (

--- a/src/components/modals/SitAndGoResultModal.tsx
+++ b/src/components/modals/SitAndGoResultModal.tsx
@@ -17,6 +17,7 @@
  * Refs block52/ui#371, originally tracked in block52/poker-vm#2106.
  */
 import React, { useEffect, useMemo, useState } from "react";
+import { truncateMiddle } from "../../utils/stringUtils";
 import { useSitAndGoPlayerResults } from "../../hooks/game/useSitAndGoPlayerResults";
 import { useFetchSngClaimSignature } from "../../hooks/game/useFetchSngClaimSignature";
 import { useClaimSngWinNFT } from "../../hooks/wallet/useClaimSngWinNFT";
@@ -232,7 +233,7 @@ export const SitAndGoResultModal: React.FC<SitAndGoResultModalProps> = ({ tableI
                                 rel="noopener noreferrer"
                                 className="underline hover:text-green-200"
                             >
-                                {`${claimHash.slice(0, 10)}…${claimHash.slice(-8)}`}
+                                {truncateMiddle(claimHash, 10, 8, "…")}
                             </a>
                         </p>
                     )}

--- a/src/pages/BridgeAdminDashboard.tsx
+++ b/src/pages/BridgeAdminDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { truncateMiddle } from "../utils/stringUtils";
 import useCosmosWallet from "../hooks/wallet/useCosmosWallet";
 import { useNetwork } from "../context/NetworkContext";
 import { toast } from "react-toastify";
@@ -523,7 +524,7 @@ export default function BridgeAdminDashboard() {
                                             <div className="flex justify-between">
                                                 <span className="text-gray-400">Address:</span>
                                                 <span className="text-white font-mono text-xs">
-                                                    {hotWalletInfo.address.slice(0, 10)}...{hotWalletInfo.address.slice(-8)}
+                                                    {truncateMiddle(hotWalletInfo.address, 10, 8)}
                                                 </span>
                                             </div>
                                             <div className="flex justify-between">

--- a/src/pages/GenesisState.tsx
+++ b/src/pages/GenesisState.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { truncateMiddle } from "../utils/stringUtils";
 import useCosmosWallet from "../hooks/wallet/useCosmosWallet";
 import { useNetwork } from "../context/NetworkContext";
 import { toast } from "react-toastify";
@@ -192,7 +193,7 @@ export default function GenesisState() {
     };
 
     const shortenAddress = (address: string): string => {
-        return `${address.slice(0, 12)}...${address.slice(-8)}`;
+        return truncateMiddle(address, 12, 8);
     };
 
     const isMyWallet = (address: string): boolean => {

--- a/src/pages/WithdrawalDashboard.tsx
+++ b/src/pages/WithdrawalDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { truncateMiddle } from "../utils/stringUtils";
 import useCosmosWallet from "../hooks/wallet/useCosmosWallet";
 import { useNetwork } from "../context/NetworkContext";
 import { toast } from "react-toastify";
@@ -416,7 +417,7 @@ export default function WithdrawalDashboard() {
                                         <tr key={withdrawal.nonce} className="hover:bg-gray-700/50 transition-colors">
                                             <td className="px-6 py-4 whitespace-nowrap">
                                                 <span className="text-white font-mono text-sm" title={withdrawal.nonce}>
-                                                    #{withdrawal.nonce.slice(0, 10)}...{withdrawal.nonce.slice(-4)}
+                                                    #{truncateMiddle(withdrawal.nonce, 10, 4)}
                                                 </span>
                                             </td>
                                             <td className="px-6 py-4">

--- a/src/pages/explorer/HandPage.tsx
+++ b/src/pages/explorer/HandPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { truncateMiddle } from "../../utils/stringUtils";
 import { useParams, useSearchParams, useNavigate, Link } from "react-router-dom";
 import { TexasHoldemStateDTO, PlayerDTO } from "@block52/poker-vm-sdk";
 import { AnimatedBackground } from "../../components/common/AnimatedBackground";
@@ -30,7 +31,7 @@ interface HandsResponse {
 
 function truncateAddress(addr: string): string {
     if (!addr || addr.length < 12) return addr;
-    return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+    return truncateMiddle(addr, 6, 4);
 }
 
 function formatStack(stack: string): string {

--- a/src/pages/explorer/HandReplayPage.tsx
+++ b/src/pages/explorer/HandReplayPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
+import { truncateMiddle } from "../../utils/stringUtils";
 import { useParams, Link } from "react-router-dom";
 import { FaCopy, FaCheck } from "react-icons/fa";
 import { AnimatedBackground } from "../../components/common/AnimatedBackground";
@@ -113,7 +114,7 @@ export default function HandReplayPage() {
 
     const truncateId = (id: string) => {
         if (id.length <= 24) return id;
-        return `${id.slice(0, 16)}...${id.slice(-8)}`;
+        return truncateMiddle(id, 16, 8);
     };
 
     return (

--- a/src/utils/accountUtils.ts
+++ b/src/utils/accountUtils.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import { formatMicroAsUsdc } from "../constants/currency";
+import { truncateMiddle } from "./stringUtils";
 
 /**
  * Get public key from private key
@@ -22,7 +23,7 @@ export const getPublicKey = (privateKey: string): string => {
  * @returns Formatted string with first 6 and last 4 characters
  */
 export const formatPlayerId = (playerId: string): string => {
-    return `${playerId.slice(0, 6)}...${playerId.slice(-4)}`;
+    return truncateMiddle(playerId, 6, 4);
 };
 
 /**

--- a/src/utils/b52AccountUtils.ts
+++ b/src/utils/b52AccountUtils.ts
@@ -5,6 +5,7 @@
 // NodeRpcClient removed from SDK - using CosmosClient instead
 // import { NodeRpcClient } from "@block52/poker-vm-sdk";
 import { hasValue } from "./guards";
+import { truncateMiddle } from "./stringUtils";
 
 // Singleton instance for NodeRpcClient (deprecated - kept for potential future use)
 let clientInstance: unknown = null;
@@ -30,9 +31,7 @@ export const getPublicKey = (): string | null => {
  * @returns Formatted address string like "0x1234...abcd" or empty string if no address
  */
 export const getFormattedAddress = (length: number = 6): string => {
-    const pubKey = getPublicKey();
-    if (!pubKey) return "";
-    return `${pubKey.slice(0, length)}...${pubKey.slice(-4)}`;
+    return truncateMiddle(getPublicKey(), length, 4);
 };
 
 /**

--- a/src/utils/cosmos/storage.ts
+++ b/src/utils/cosmos/storage.ts
@@ -2,6 +2,8 @@
  * Browser storage utilities for Cosmos wallet data
  */
 
+import { truncateMiddle } from "../stringUtils";
+
 // Storage keys for cosmos data
 export const STORAGE_COSMOS_MNEMONIC = "user_cosmos_mnemonic";
 export const STORAGE_COSMOS_ADDRESS = "user_cosmos_address";
@@ -51,7 +53,5 @@ export const clearCosmosData = (): void => {
  * @returns Formatted address string like "b521234...abcd" or empty string if no address
  */
 export const getFormattedCosmosAddress = (length: number = 6): string => {
-    const address = getCosmosAddress();
-    if (!address) return "";
-    return `${address.slice(0, length)}...${address.slice(-4)}`;
+    return truncateMiddle(getCosmosAddress(), length, 4);
 };

--- a/src/utils/cosmosAccountUtils.ts
+++ b/src/utils/cosmosAccountUtils.ts
@@ -5,6 +5,7 @@
 
 import { getCosmosClient } from "./cosmos/client";
 import type { NetworkEndpoints } from "./cosmos/urls";
+import { truncateMiddle } from "./stringUtils";
 
 // Local type definition (not exported from SDK main index)
 interface Coin {
@@ -45,9 +46,7 @@ export const getCosmosAddressSync = (): string | null => {
  * @returns Formatted address string like "b521rg...fj9p" or empty string if no address
  */
 export const getFormattedCosmosAddress = (length: number = 6): string => {
-    const address = getCosmosAddressSync();
-    if (!address) return "";
-    return `${address.slice(0, length)}...${address.slice(-4)}`;
+    return truncateMiddle(getCosmosAddressSync(), length, 4);
 };
 
 /**

--- a/src/utils/formatUtils.ts
+++ b/src/utils/formatUtils.ts
@@ -2,6 +2,7 @@
  * Formatting utility functions for the UI
  */
 import { bech32 } from "bech32";
+import { truncateMiddle } from "./stringUtils";
 
 /**
  * Truncates a hash string to show only the beginning and end
@@ -14,7 +15,7 @@ import { bech32 } from "bech32";
 export const truncateHash = (hash: string, length: number = 8): string => {
     if (!hash) return "N/A";
     if (hash.length <= length * 2) return hash;
-    return `${hash.slice(0, length)}...${hash.slice(-length)}`;
+    return truncateMiddle(hash, length, length);
 };
 
 /**

--- a/src/utils/stringUtils.test.ts
+++ b/src/utils/stringUtils.test.ts
@@ -1,0 +1,26 @@
+import { truncateMiddle } from "./stringUtils";
+
+describe("truncateMiddle", () => {
+    it("keeps the first startChars and last endChars joined by the default separator", () => {
+        expect(truncateMiddle("b521rg9q8h7j6k5fj9p", 6, 4)).toBe("b521rg...fj9p");
+    });
+
+    it("supports an asymmetric split", () => {
+        expect(truncateMiddle("0123456789abcdef", 4, 2)).toBe("0123...ef");
+    });
+
+    it("supports a custom separator", () => {
+        expect(truncateMiddle("0123456789abcdef", 10, 8, "…")).toBe("0123456789…89abcdef");
+    });
+
+    it("returns '' for null, undefined, or empty input", () => {
+        expect(truncateMiddle(null, 6, 4)).toBe("");
+        expect(truncateMiddle(undefined, 6, 4)).toBe("");
+        expect(truncateMiddle("", 6, 4)).toBe("");
+    });
+
+    it("does not short-circuit short strings (slices may overlap, matching prior behaviour)", () => {
+        // "abcd".slice(0, 6) === "abcd", "abcd".slice(-4) === "abcd"
+        expect(truncateMiddle("abcd", 6, 4)).toBe("abcd...abcd");
+    });
+});

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * String formatting utilities.
+ */
+
+/**
+ * Truncate a string to its first `startChars` and last `endChars`, joined by a
+ * separator. This is the single home for the
+ * `${value.slice(0, n)}...${value.slice(-m)}` middle-ellipsis pattern that was
+ * previously duplicated across address/hash/id formatters and inline in JSX.
+ *
+ * Returns "" for null/undefined/empty input. Note: like the call sites it
+ * replaces, it does NOT short-circuit when the string is shorter than
+ * startChars + endChars (the slices may overlap). Callers that need that
+ * behaviour (e.g. truncateHash) guard before delegating here.
+ *
+ * @param value - The string to truncate
+ * @param startChars - Number of characters to keep at the start
+ * @param endChars - Number of characters to keep at the end
+ * @param separator - Joiner between the two slices (default "...")
+ * @returns Truncated string like "b521rg...fj9p", or "" when value is empty
+ * @example
+ * truncateMiddle("b521rg9q8h7j6k5fj9p", 6, 4) // "b521rg...fj9p"
+ */
+export const truncateMiddle = (
+    value: string | null | undefined,
+    startChars: number,
+    endChars: number,
+    separator: string = "..."
+): string => {
+    if (!value) return "";
+    return `${value.slice(0, startChars)}${separator}${value.slice(-endChars)}`;
+};


### PR DESCRIPTION
Third PR from the frontend refactoring audit (#449): **duplication cluster #1 — middle-ellipsis truncation.** The `${value.slice(0, n)}...${value.slice(-m)}` pattern was reimplemented ~16 times across address/hash/id formatters and inline in JSX.

### What changed
- **New `src/utils/stringUtils.ts`** → `truncateMiddle(value, startChars, endChars, separator = "...")` with unit tests. Returns `""` for null/undefined/empty; does not short-circuit short strings (matches the prior call-site behaviour).
- **6 existing named helpers now delegate to it** — signatures unchanged, so **zero call-site churn**:
  - `formatUtils.truncateHash` (keeps its own `"N/A"`/short-circuit guards, delegates only the slice)
  - `accountUtils.formatPlayerId`
  - `components/common/utils.formatAddress`
  - `getFormattedCosmosAddress` (×2 — `cosmosAccountUtils` + `cosmos/storage`)
  - `b52AccountUtils.getFormattedAddress`
- **10 inline slice duplicates migrated** across components + pages. Exact output preserved, including:
  - the one unicode `…` separator in `SitAndGoResultModal` → `truncateMiddle(claimHash, 10, 8, "…")`
  - the local length-guards in `HandPage` / `HandReplayPage` / `GenesisState` helpers (only the slice line delegated)

### Verification
- `tsc --noEmit`: clean (lone `settlementTx.ts` error pre-exists on `main`, unrelated)
- `eslint`: **lint problem count identical across changed files — 24 on `main`, 24 on branch.** The remaining `preserve-caught-error` / unused-var warnings (incl. an already-dead `shortenAddress` in GenesisState) all pre-exist and are out of scope.
- **Full suite: 821/821** (47 suites, +1 from the new `stringUtils` test)

### Follow-ups noted (not in this PR)
The three `getFormatted*Address` functions all read the same `user_cosmos_address` key and are now thin wrappers — they could be unified into one in a later pass. Other duplication clusters from the audit (localStorage keys, copy-to-clipboard hook, MM:SS formatting) remain tracked in #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)