### PR TITLE
fix(ui): render ALL-IN button for short shove when raise isn't legal (#457)

### DIFF
--- a/src/components/Footer/MainActionButtons.tsx
+++ b/src/components/Footer/MainActionButtons.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { LoadingSpinner } from "../common";
 import { TexasHoldemRound, ActionDTO, PlayerStatus } from "@block52/poker-vm-sdk";
 import { FoldButton } from "./FoldButton";
@@ -14,6 +14,9 @@ export const MainActionButtons: React.FC<MainActionButtonsProps> = ({
     callAmount,
     canBet,
     canRaise,
+    canAllIn,
+    allInAmount,
+    allInActionIndex,
     raiseAmount,
     isRaiseAmountInvalid,
     playerStatus,
@@ -27,11 +30,22 @@ export const MainActionButtons: React.FC<MainActionButtonsProps> = ({
     onFold,
     onCheck,
     onCall,
-    onBetOrRaise
+    onBetOrRaise,
+    onAllIn
 }) => {
     // Calculate the total amount to display for raise button
     // This includes blinds posted during ANTE round when we're in PREFLOP
     const raiseToAmount = canRaise ? getRaiseToAmount(raiseAmount, previousActions, currentRound, userAddress) : raiseAmount;
+
+    // Short-shove (poker-vm#2244): when the engine offers ALL_IN but no
+    // bet/raise, there's no slider + Bet/Raise button to confirm through. To
+    // honour the "no accidental full-stack commit" rule (ui#395) we arm on the
+    // first click and only dispatch on the confirm click. We store the action
+    // index we armed against (not a bare boolean) so the arm resets itself as
+    // soon as the action index advances — i.e. on any new turn/state — with no
+    // effect needed.
+    const [armedAllInIndex, setArmedAllInIndex] = useState<number | null>(null);
+    const armedAllIn = armedAllInIndex === allInActionIndex;
     return (
         <div className={`flex justify-between ${isMobileLandscape ? "gap-0.5" : "gap-1 lg:gap-2"}`}>
             {/* Show fold button if canFold OR if currently folding (to show spinner) */}
@@ -109,6 +123,30 @@ export const MainActionButtons: React.FC<MainActionButtonsProps> = ({
                         <>
                             {canRaise ? "RAISE TO" : "BET"}{" "}
                             <span className={styles.amountAccent}>{formatDisplayAmount(raiseToAmount, isTournament)}</span>
+                        </>
+                    )}
+                </button>
+            )}
+
+            {/* Short-shove ALL-IN (poker-vm#2244): rendered only when ALL_IN is the
+                lone aggressive action (no bet/raise slider exists). Two-step: arm,
+                then confirm — see armedAllIn above. */}
+            {canAllIn && (
+                <button
+                    onClick={armedAllIn ? onAllIn : () => setArmedAllInIndex(allInActionIndex)}
+                    disabled={loading !== null}
+                    className={`cursor-pointer hover:scale-105 btn-all-in rounded-lg w-full border shadow-md backdrop-blur-sm transition-all duration-200 font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-1 ${
+                        armedAllIn ? "ring-2 ring-white animate-pulse" : ""
+                    } ${isMobileLandscape ? "px-2 py-0.5 text-[10px]" : "px-2 lg:px-4 py-1.5 lg:py-2 text-xs lg:text-sm"}`}
+                >
+                    {loading === "all-in" ? (
+                        <>
+                            <LoadingSpinner size="sm" />
+                            JAMMING...
+                        </>
+                    ) : (
+                        <>
+                            {armedAllIn ? "CONFIRM ALL-IN" : "ALL-IN"} <span className={styles.amountAccent}>{allInAmount}</span>
                         </>
                     )}
                 </button>

--- a/src/components/Footer/PokerActionPanel.tsx
+++ b/src/components/Footer/PokerActionPanel.tsx
@@ -41,7 +41,8 @@ import {
     handlePostSmallBlind,
     handlePostBigBlind,
     handleBet,
-    handleRaise
+    handleRaise,
+    handleAllIn
 } from "../common/actionHandlers";
 
 // Import utils
@@ -151,6 +152,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         hasCallAction,
         hasBetAction,
         hasRaiseAction,
+        hasAllInAction,
         hasMuckAction,
         hasShowAction,
         hasDealAction,
@@ -285,6 +287,8 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
     const callAction = getActionByType(legalActions, PlayerActionType.CALL);
     const betAction = getActionByType(legalActions, PlayerActionType.BET);
     const raiseAction = getActionByType(legalActions, PlayerActionType.RAISE);
+    // Short-shove (poker-vm#2244): the all-in entry's min === max === full stack.
+    const allInAction = getActionByType(legalActions, PlayerActionType.ALL_IN);
 
     // Store amounts as bigint internally (in micro-units, 10^6 precision)
     const minBetMicro = useMemo(() => parseMicroToBigInt(betAction?.min), [betAction]);
@@ -292,6 +296,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
     const minRaiseMicro = useMemo(() => parseMicroToBigInt(raiseAction?.min), [raiseAction]);
     const maxRaiseMicro = useMemo(() => parseMicroToBigInt(raiseAction?.max), [raiseAction]);
     const callAmountMicro = useMemo(() => parseMicroToBigInt(callAction?.min), [callAction]);
+    const allInAmountMicro = useMemo(() => parseMicroToBigInt(allInAction?.max), [allInAction]);
 
     // Convert to display values — USDC conversion for cash, raw chips for tournaments
     const toDisplay = useCallback((micro: bigint) => (isTournament ? Number(micro) : microBigIntToUsdc(micro)), [isTournament]);
@@ -308,6 +313,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
     const formattedBigBlindAmount = useMemo(() => formatDisplayAmount(toDisplay(bigBlindMicro), isTournament), [toDisplay, bigBlindMicro, isTournament]);
     const bigBlindUsdc = useMemo(() => toDisplay(bigBlindMicro), [toDisplay, bigBlindMicro]);
     const formattedCallAmount = useMemo(() => formatDisplayAmount(callAmount, isTournament), [callAmount, isTournament]);
+    const formattedAllInAmount = useMemo(() => formatDisplayAmount(toDisplay(allInAmountMicro), isTournament), [toDisplay, allInAmountMicro, isTournament]);
     const formattedMaxBetAmount = useMemo(
         () => getFormattedMaxBetAmount(hasBetAction, maxBet, maxRaise, isTournament),
         [hasBetAction, maxBet, maxRaise, isTournament]
@@ -514,6 +520,15 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
         );
     };
 
+    // Short-shove (poker-vm#2244): the engine offers ALL_IN (not RAISE/BET) when
+    // a player facing a bet can't make a full min-raise. There is no slider to
+    // max here — dispatch the engine's ALL_IN directly at the player's full
+    // stack (the all-in entry's max). The two-step confirm lives in the button.
+    const handleShortAllInAction = async () => {
+        if (!hasContent(tableId)) return;
+        await handleActionWithTransaction("all-in", () => handleAllIn(tableId, allInAmountMicro, network));
+    };
+
     return (
         <div
             className={`fixed left-0 right-0 text-white flex justify-center items-center relative ${
@@ -612,6 +627,11 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
                                     callAmount={formattedCallAmount}
                                     canBet={hasBetAction}
                                     canRaise={hasRaiseAction}
+                                    // Short-shove (poker-vm#2244): ALL_IN is the lone aggressive
+                                    // action — no bet/raise, so no slider renders.
+                                    canAllIn={hasAllInAction && !hasBetAction && !hasRaiseAction}
+                                    allInAmount={formattedAllInAmount}
+                                    allInActionIndex={allInAction?.index ?? -1}
                                     raiseAmount={raiseAmount}
                                     isRaiseAmountInvalid={isRaiseAmountInvalid}
                                     playerStatus={userPlayer?.status || PlayerStatus.SEATED}
@@ -626,6 +646,7 @@ export const PokerActionPanel: React.FC<PokerActionPanelProps> = ({ tableId, net
                                     onCheck={() => handleActionWithTransaction("check", () => handleCheck(tableId, network))}
                                     onCall={() => handleActionWithTransaction("call", () => handleCall(callAmountMicro, tableId, network))}
                                     onBetOrRaise={hasRaiseAction ? handleRaiseAction : handleBetAction}
+                                    onAllIn={handleShortAllInAction}
                                 />
 
                                 {/* Raise/Bet Controls */}

--- a/src/components/Footer/types.ts
+++ b/src/components/Footer/types.ts
@@ -122,6 +122,12 @@ export interface MainActionButtonsProps {
     callAmount: string;
     canBet: boolean;
     canRaise: boolean;
+    // Short-shove (poker-vm#2244): ALL_IN is legal but RAISE/BET are not, so a
+    // dedicated two-step ALL-IN button renders alongside FOLD/CALL.
+    canAllIn: boolean;
+    allInAmount: string;
+    // Action index the ALL-IN two-step arms against; resets the arm when it advances.
+    allInActionIndex: number;
     raiseAmount: number;
     isRaiseAmountInvalid: boolean;
     playerStatus: PlayerStatus;
@@ -136,6 +142,7 @@ export interface MainActionButtonsProps {
     onCheck: () => void;
     onCall: () => void;
     onBetOrRaise: () => void;
+    onAllIn: () => void;
 }
 
 // ============================================================================

--- a/src/components/common/actionHandlers.ts
+++ b/src/components/common/actionHandlers.ts
@@ -13,7 +13,8 @@ import {
     startNewHand,
     postSmallBlind,
     postBigBlind,
-    raiseHand
+    raiseHand,
+    allInHand
 } from "../../hooks/playerActions";
 import type { SitInMethod, SitOutMethod } from "../../hooks/playerActions";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
@@ -215,6 +216,12 @@ const handlePostBigBlind = createTableIdAmountHandler("post big blind", postBigB
  */
 const handleRaise = createTableIdAmountHandler("raise", raiseHand);
 
+/**
+ * Handle all-in action (short-shove case, poker-vm#2244)
+ * @param amount - The all-in amount in micro-units as bigint (10^6 precision) — the player's full stack
+ */
+const handleAllIn = createTableIdAmountHandler("all-in", allInHand);
+
 // =============================================================================
 // Exports
 // =============================================================================
@@ -232,7 +239,8 @@ export {
     handleStartNewHand,
     handlePostSmallBlind,
     handlePostBigBlind,
-    handleRaise
+    handleRaise,
+    handleAllIn
 };
 
 // Also export the factories for potential reuse

--- a/src/hooks/playerActions/allInHand.ts
+++ b/src/hooks/playerActions/allInHand.ts
@@ -1,0 +1,22 @@
+import { PlayerActionType } from "@block52/poker-vm-sdk";
+import type { NetworkEndpoints } from "../../context/NetworkContext";
+import type { PlayerActionResult } from "../../types";
+import { executeTransportAction } from "./transportAction";
+
+/**
+ * Go all-in in a poker game using Cosmos SDK SigningCosmosClient.
+ *
+ * Used for the short-shove case (poker-vm#2244): a player facing a bet whose
+ * stack is more than the call but less than a full min-raise can't RAISE, so
+ * the engine advertises ALL_IN instead. The amount is the player's whole stack
+ * (the `all-in` legal action's max).
+ *
+ * @param tableId - The ID of the table (game ID on Cosmos) where the action will be performed
+ * @param amount - The all-in amount in micro-units as bigint (10^6 precision) — the player's full stack
+ * @param network - The current network configuration from NetworkContext
+ * @returns Promise with PlayerActionResult containing transaction details
+ * @throws Error if Cosmos wallet is not initialized or if the action fails
+ */
+export async function allInHand(tableId: string, amount: bigint, network: NetworkEndpoints): Promise<PlayerActionResult> {
+    return executeTransportAction(tableId, PlayerActionType.ALL_IN, amount, network);
+}

--- a/src/hooks/playerActions/index.ts
+++ b/src/hooks/playerActions/index.ts
@@ -1,3 +1,4 @@
+import { allInHand } from "./allInHand";
 import { betHand } from "./betHand";
 import { callHand } from "./callHand";
 import { checkHand } from "./checkHand";
@@ -25,6 +26,7 @@ import { useAutoMuck } from "./useAutoMuck";
 import { useAutoSitOutNextBB } from "./useAutoSitOutNextBB";
 
 export {
+    allInHand,
     betHand,
     callHand,
     checkHand,

--- a/src/utils/pockerActionUtils.test.ts
+++ b/src/utils/pockerActionUtils.test.ts
@@ -171,6 +171,7 @@ describe("pockerActionUtils", () => {
             { action: PlayerActionType.CALL, min: "1000", max: "1000", index: 4 },
             { action: PlayerActionType.BET, min: "1000", max: "5000000", index: 5 },
             { action: PlayerActionType.RAISE, min: "2000", max: "5000000", index: 6 },
+            { action: PlayerActionType.ALL_IN, min: "3800", max: "3800", index: 6 },
             { action: PlayerActionType.MUCK, min: undefined, max: undefined, index: 7 },
             { action: PlayerActionType.SHOW, min: undefined, max: undefined, index: 8 },
             { action: NonPlayerActionType.DEAL, min: undefined, max: undefined, index: 9 },
@@ -186,6 +187,7 @@ describe("pockerActionUtils", () => {
             expect(flags.hasCallAction).toBe(true);
             expect(flags.hasBetAction).toBe(true);
             expect(flags.hasRaiseAction).toBe(true);
+            expect(flags.hasAllInAction).toBe(true);
             expect(flags.hasMuckAction).toBe(true);
             expect(flags.hasShowAction).toBe(true);
             expect(flags.hasDealAction).toBe(true);
@@ -207,7 +209,25 @@ describe("pockerActionUtils", () => {
             expect(flags.hasCallAction).toBe(true);
             expect(flags.hasBetAction).toBe(false);
             expect(flags.hasRaiseAction).toBe(false);
+            expect(flags.hasAllInAction).toBe(false);
             expect(flags.hasCheckAction).toBe(false);
+        });
+
+        // Short-shove (poker-vm#2244): a player facing a bet who can't make a
+        // full min-raise is offered fold/call/all-in — NO raise/bet. The flag
+        // must light up so the panel renders the ALL-IN button.
+        it("should flag hasAllInAction for a short shove (fold/call/all-in, no raise)", () => {
+            const shortShoveActions: LegalActionDTO[] = [
+                { action: PlayerActionType.FOLD, min: undefined, max: undefined, index: 16 },
+                { action: PlayerActionType.CALL, min: "3000", max: "3000", index: 16 },
+                { action: PlayerActionType.ALL_IN, min: "3800", max: "3800", index: 16 }
+            ];
+            const flags = getActionFlags(shortShoveActions);
+            expect(flags.hasFoldAction).toBe(true);
+            expect(flags.hasCallAction).toBe(true);
+            expect(flags.hasAllInAction).toBe(true);
+            expect(flags.hasRaiseAction).toBe(false);
+            expect(flags.hasBetAction).toBe(false);
         });
     });
 });

--- a/src/utils/pockerActionUtils.ts
+++ b/src/utils/pockerActionUtils.ts
@@ -50,6 +50,10 @@ export const getActionFlags = (legalActions: LegalActionDTO[]): ActionFlags => (
     hasCallAction: hasAction(legalActions, PlayerActionType.CALL),
     hasBetAction: hasAction(legalActions, PlayerActionType.BET),
     hasRaiseAction: hasAction(legalActions, PlayerActionType.RAISE),
+    // Short-shove (poker-vm#2244): a player facing a bet who can't make a full
+    // min-raise is offered ALL_IN instead of RAISE. Without this flag the UI is
+    // blind to that action and renders only FOLD/CALL.
+    hasAllInAction: hasAction(legalActions, PlayerActionType.ALL_IN),
     hasMuckAction: hasAction(legalActions, PlayerActionType.MUCK),
     hasShowAction: hasAction(legalActions, PlayerActionType.SHOW),
     hasDealAction: hasAction(legalActions, NonPlayerActionType.DEAL),
@@ -64,6 +68,7 @@ export type ActionFlags = {
     hasCallAction: boolean;
     hasBetAction: boolean;
     hasRaiseAction: boolean;
+    hasAllInAction: boolean;
     hasMuckAction: boolean;
     hasShowAction: boolean;
     hasDealAction: boolean;


### PR DESCRIPTION
Closes #457 — front-end half of block52/poker-vm#2244.

## Problem

When a player faces a bet and their stack is **more than the call but less than a full min-raise**, the engine returns `legalActions = [fold, call, all-in]` — `all-in` is present, `raise`/`bet` are not. The UI offered only **FOLD / CALL**: no shove button, so the player couldn't go all-in even though the engine permits it.

This was **verified live** by replaying the exact scenario against `pvm.block52.xyz` (it returns `[fold, call, all-in]`, no raise). The engine is correct and deployed — the gap was purely front-end.

## Root cause

The UI was structurally blind to the `all-in` action type:

1. `getActionFlags()` built `hasFold/hasCheck/hasCall/hasBet/hasRaise/...` but **no `hasAllInAction`** — nothing ever checked `hasAction(legalActions, ALL_IN)`.
2. `PokerActionPanel.tsx` — the ALL-IN button lived inside `RaiseBetControls`, gated on `(hasBetAction || hasRaiseAction)`. In a short shove both are false, so the control (and its ALL-IN button) never mounted.
3. `handleAllInAction` read `maxBet`/`maxRaise` (undefined here) and dispatched `raise`/`bet` — never `PlayerActionType.ALL_IN`. (The engine rejects a raise/bet from a short stack, so an ALL_IN dispatch is mandatory.)

## Fix

- Add `hasAllInAction` to `getActionFlags`/`ActionFlags`.
- New `allInHand` transport + `handleAllIn` that dispatch `PlayerActionType.ALL_IN` at the player's full stack (the `all-in` entry's `max`).
- Render a dedicated **ALL-IN button** next to FOLD/CALL when ALL_IN is the lone aggressive action.

### Why a two-step button (not instant, not the slider)

ui#395 established that all-in must never instantly commit the full stack — normally the player maxes the slider and confirms via Bet/Raise. That flow is **structurally impossible** in a short shove (no bet/raise ⇒ no slider, no Bet/Raise button). To preserve #395's intent, the button is **two-step**: first click arms (`ALL-IN $X` → `CONFIRM ALL-IN $X`), second click commits. The armed state is keyed to the action index, so it resets automatically on any new turn (no effect, no stale-arm one-click shove).

## Tests

- `pockerActionUtils.test.ts`: assert `hasAllInAction` for the full action set and for the short-shove `[fold, call, all-in]` combination (28/28 green).
- `tsc --noEmit` clean, `eslint` clean on changed files, `yarn build` succeeds.

## Manual test plan

- [ ] Short stack (e.g. 38c) faces a 30c bet that's been called → panel shows FOLD / CALL / **ALL-IN $0.38**.
- [ ] First click → `CONFIRM ALL-IN $0.38` (pulsing); second click → shoves; spinner shows `JAMMING...`.
- [ ] Arm, then let the turn pass / state change → button disarms (no sticky one-click shove next turn).
- [ ] Deep stack facing a bet → unchanged (RAISE slider + its own ALL-IN preset; no new button).
- [ ] Tournament table: amount shown in chips; shove commits full stack.
- [ ] Mobile landscape layout renders the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)