### PR TITLE
fix(ui): read levelStartTime off gameState so SNG blind countdown shows

### DIFF
--- a/src/components/playPage/Table.tsx
+++ b/src/components/playPage/Table.tsx
@@ -797,9 +797,10 @@ const Table = React.memo(() => {
     // Add the useGameOptions hook
     const { gameOptions } = useGameOptions();
 
-    // Blind level info for SNG/Tournament games.
-    // When the chain doesn't supply levelStartTime, hasTimer stays false and the countdown is hidden.
-    const blindLevel = useBlindLevel(gameOptions?.levelStartTime);
+    // Blind level info for SNG/Tournament games. The hook reads levelStartTime
+    // directly off gameState.gameOptions; when the chain doesn't supply it,
+    // hasTimer stays false and the countdown is hidden.
+    const blindLevel = useBlindLevel();
 
     // Add the useGameResults hook
     const { results } = useGameResults();

--- a/src/hooks/game/useBlindLevel.ts
+++ b/src/hooks/game/useBlindLevel.ts
@@ -33,18 +33,20 @@ export interface BlindLevelInfo {
  * Hook that reads blind level information from the backend game state
  * for SNG/Tournament games.
  *
- * The level, current blinds, and next blinds all come from the PVM via
- * GameOptionsDTO. The timer countdown requires a game start time.
- *
- * @param startTime - Optional epoch ms when the game started (for timer)
+ * The level, current blinds, next blinds, and the level start time all come
+ * from the PVM via GameOptionsDTO. The timer countdown requires levelStartTime.
  */
-export const useBlindLevel = (startTime?: number): BlindLevelInfo => {
+export const useBlindLevel = (): BlindLevelInfo => {
     const { gameState, gameFormat } = useGameStateContext();
     const [now, setNow] = useState<number>(0);
 
     const isActive = isSitAndGoFormat(gameFormat) || isTournamentFormat(gameFormat);
 
     const gameOptions = gameState?.gameOptions;
+
+    // Epoch ms when the current blind level started (for the countdown).
+    // Read directly off gameOptions — useGameOptions() does not surface this field.
+    const startTime = gameOptions?.levelStartTime;
 
     // Current blinds from backend (already escalated by PVM)
     const currentSB = gameOptions?.smallBlind ? Number(gameOptions.smallBlind) : 0;


### PR DESCRIPTION
## Problem

We're testing Sit-and-Goes and the **blind level countdown never shows**.

`useBlindLevel`'s `hasTimer` requires a `levelStartTime`:

```ts
const hasTimer = isActive && levelDurationSeconds > 0 && hasValue(startTime) && startTime > 0;
```

…but `startTime` was always `undefined`. `Table.tsx` passed `gameOptions?.levelStartTime` into the hook, where `gameOptions` comes from `useGameOptions()`. That hook builds a **filtered** object that only copies a fixed set of fields (`useGameOptions.ts`) and **never includes `levelStartTime`**:

```ts
return {
    minBuyIn: options.minBuyIn!,
    // …
    blindLevelDuration: options.blindLevelDuration,
    otherOptions: options.otherOptions || {}
} as Required<GameOptionsDTO>;   // no levelStartTime
```

So `gameOptions.levelStartTime` was always `undefined` → `hasTimer` always `false` → countdown always hidden.

## Fix

`useBlindLevel` already reads `gameState.gameOptions` directly from context (for the level, current blinds, next blinds), so it can source `levelStartTime` itself. Drop the lossy parameter and read `gameOptions.levelStartTime` inside the hook.

```ts
// before
const blindLevel = useBlindLevel(gameOptions?.levelStartTime);

// after — hook reads it off gameState.gameOptions directly
const blindLevel = useBlindLevel();
```

## Verification

- `tsc --noEmit` ✅
- `yarn test` ✅ (825 tests pass)
- Lint: no new issues on the changed lines (`useBlindLevel.ts` clean; the pre-existing `Table.tsx` errors are unrelated, on untouched lines).

## Companion chain change

This is the UI half. The chain half is **block52/pokerchain#223**, which (a) adds `LevelStartTime` to `GameOptionsDTO` and (b) stops the chain overwriting the PVM's escalation fields — so `levelStartTime` (and the live `blindLevel` / `nextSmallBlind` / `nextBigBlind`) actually reach the wire. **Both PRs are needed for the countdown to work end to end.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)