### PR TITLE
refactor: route format/variant casts through tested parsers (#449 PR4)

### DIFF
--- a/src/context/GameStateContext.tsx
+++ b/src/context/GameStateContext.tsx
@@ -4,7 +4,7 @@ import { TexasHoldemStateDTO, GameFormat, GameVariant } from "@block52/poker-vm-
 import { createAuthPayload } from "../utils/cosmos/signing";
 import { getGameTransport, getGatewayWsUrl, normalizeGatewayMessage } from "../utils/gameTransport";
 import { setLatestGameState } from "../hooks/playerActions/transportAction";
-import { validateGameState, extractGameDataFromMessage } from "../utils/gameFormatUtils";
+import { validateGameState, extractGameDataFromMessage, toGameFormat, toGameVariant } from "../utils/gameFormatUtils";
 import { hasElements } from "../utils/guards";
 import type { ValidationError } from "../components/playPage/TableErrorPage";
 import { CosmosApi } from "../apis/Api";
@@ -249,8 +249,8 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
                             // Still update gameState so the table renders what it can
                             setGameState(gameStateData as TexasHoldemStateDTO);
                             setLatestGameState(gameStateData as TexasHoldemStateDTO);
-                            setGameFormat(rawFormat as GameFormat | undefined);
-                            setGameVariant(rawVariant as GameVariant | undefined);
+                            setGameFormat(toGameFormat(rawFormat));
+                            setGameVariant(toGameVariant(rawVariant));
                             setPendingAction(null);
                             return;
                         }
@@ -261,8 +261,8 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
                         console.log("🎮 Game state updated. Current player status:", currentPlayer?.status, "| Player:", currentPlayer?.address?.slice(0, 10));
                         setGameState(gameStateData as TexasHoldemStateDTO);
                         setLatestGameState(gameStateData as TexasHoldemStateDTO);
-                        setGameFormat(rawFormat as GameFormat);
-                        setGameVariant(rawVariant as GameVariant);
+                        setGameFormat(toGameFormat(rawFormat));
+                        setGameVariant(toGameVariant(rawVariant));
                         setError(null);
                         setValidationError(null);
                         setPendingAction(null);
@@ -412,8 +412,8 @@ export const GameStateProvider: React.FC<GameStateProviderProps> = ({ children }
                 const rawVariant = parsed.variant;
 
                 setGameState(gameStateData as TexasHoldemStateDTO);
-                setGameFormat(rawFormat as GameFormat | undefined);
-                setGameVariant(rawVariant as GameVariant | undefined);
+                setGameFormat(toGameFormat(rawFormat));
+                setGameVariant(toGameVariant(rawVariant));
                 setPendingAction(null);
             } catch (err) {
                 console.error("[GameStateContext] Failed to load historical state:", err);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -28,7 +28,7 @@ import type { CreateTableOptions } from "../hooks/game/useNewTable"; // Import t
 
 // Cosmos wallet utils
 import { isValidSeedPhrase } from "../utils/cosmos";
-import { isTournamentFormat } from "../utils/gameFormatUtils";
+import { isTournamentFormat, toGameFormat } from "../utils/gameFormatUtils";
 
 // Password protection utils
 import {
@@ -707,7 +707,10 @@ const Dashboard: React.FC = () => {
                                         <label className="block text-white text-sm mb-1">Game Type</label>
                                         <select
                                             value={modalGameFormat}
-                                            onChange={e => setModalGameFormat(e.target.value as GameFormat)}
+                                            onChange={e => {
+                                                const format = toGameFormat(e.target.value);
+                                                if (format) setModalGameFormat(format);
+                                            }}
                                             className="w-full p-2 rounded bg-gray-700 text-white border border-gray-600 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all duration-200"
                                         >
                                             <option value={GameFormat.SIT_AND_GO}>Sit & Go</option>

--- a/src/pages/TableAdminPage.tsx
+++ b/src/pages/TableAdminPage.tsx
@@ -14,7 +14,7 @@ import TableList from "../components/TableList";
 import { calculateBuyIn, BUY_IN_PRESETS } from "../utils/buyInUtils";
 import { sortTablesByAvailableSeats } from "../utils/tableSortingUtils";
 import { BLIND_LEVELS, DEFAULT_BLIND_LEVEL_INDEX } from "../constants/blindLevels";
-import { isTournamentFormat, getGameFormat } from "../utils/gameFormatUtils";
+import { isTournamentFormat, getGameFormat, toGameFormat } from "../utils/gameFormatUtils";
 
 // Game creation fee in base units (1 usdc = 0.000001 USDC)
 // This matches GameCreationCost in pokerchain/x/poker/types/types.go
@@ -375,7 +375,10 @@ export default function TableAdminPage() {
                             <label className="text-gray-300 text-xs mb-1 block">Game Type</label>
                             <select
                                 value={gameFormat}
-                                onChange={e => handleGameFormatChange(e.target.value as GameFormat)}
+                                onChange={e => {
+                                    const format = toGameFormat(e.target.value);
+                                    if (format) handleGameFormatChange(format);
+                                }}
                                 className="w-full px-3 py-2 bg-gray-900 border border-gray-600 rounded-lg text-white text-sm"
                             >
                                 <option value={GameFormat.SIT_AND_GO}>Sit & Go</option>

--- a/src/pages/TestSigningPage.tsx
+++ b/src/pages/TestSigningPage.tsx
@@ -7,7 +7,7 @@ import { useNetwork } from "../context/NetworkContext";
 import { USDC_TO_MICRO, microToUsdc } from "../constants/currency";
 import { AnimatedBackground } from "../components/common/AnimatedBackground";
 import { isEmpty } from "../utils/guards";
-import { isTournamentFormat } from "../utils/gameFormatUtils";
+import { isTournamentFormat, toGameFormat } from "../utils/gameFormatUtils";
 import styles from "./TestSigningPage.module.css";
 
 interface TestResult {
@@ -982,7 +982,10 @@ export default function TestSigningPage() {
                                     <label className="block text-sm text-gray-400 mb-1">Game Format</label>
                                     <select
                                         value={gameFormat}
-                                        onChange={e => setGameFormat(e.target.value as GameFormat)}
+                                        onChange={e => {
+                                            const format = toGameFormat(e.target.value);
+                                            if (format) setGameFormat(format);
+                                        }}
                                         className={`w-full p-2 rounded-lg text-white ${styles.inputField}`}
                                     >
                                         <option value={GameFormat.SIT_AND_GO}>Sit & Go</option>

--- a/src/utils/gameFormatUtils.test.ts
+++ b/src/utils/gameFormatUtils.test.ts
@@ -8,7 +8,9 @@ import {
     convertAmountForBlockchain,
     convertBlindsForBlockchain,
     getBlindsForDisplay,
-    getGameTypeMnemonic
+    getGameTypeMnemonic,
+    toGameFormat,
+    toGameVariant
 } from "./gameFormatUtils";
 
 describe("gameFormatUtils", () => {
@@ -545,6 +547,33 @@ describe("gameFormatUtils", () => {
 
         it("should return empty string for undefined", () => {
             expect(getGameTypeMnemonic(undefined)).toBe("");
+        });
+    });
+
+    describe("toGameFormat", () => {
+        it("should parse valid format strings to the enum", () => {
+            expect(toGameFormat("cash")).toBe(GameFormat.CASH);
+            expect(toGameFormat("sit-and-go")).toBe(GameFormat.SIT_AND_GO);
+            expect(toGameFormat("tournament")).toBe(GameFormat.TOURNAMENT);
+        });
+
+        it("should return undefined for missing or unrecognized values", () => {
+            expect(toGameFormat(undefined)).toBeUndefined();
+            expect(toGameFormat("")).toBeUndefined();
+            expect(toGameFormat("not-a-format")).toBeUndefined();
+        });
+    });
+
+    describe("toGameVariant", () => {
+        it("should parse valid variant strings to the enum", () => {
+            expect(toGameVariant("texas-holdem")).toBe(GameVariant.TEXAS_HOLDEM);
+            expect(toGameVariant("omaha")).toBe(GameVariant.OMAHA);
+        });
+
+        it("should return undefined for missing or unrecognized values", () => {
+            expect(toGameVariant(undefined)).toBeUndefined();
+            expect(toGameVariant("")).toBeUndefined();
+            expect(toGameVariant("not-a-variant")).toBeUndefined();
         });
     });
 });

--- a/src/utils/gameFormatUtils.ts
+++ b/src/utils/gameFormatUtils.ts
@@ -19,8 +19,29 @@ export {
     parseGameVariant
 } from "@block52/poker-vm-sdk";
 
-import { GameFormat, GameVariant, GameOptionsDTO, TexasHoldemStateDTO, COSMOS_CONSTANTS, isTournamentFormat as isTournamentFormatFn } from "@block52/poker-vm-sdk";
+import { GameFormat, GameVariant, GameOptionsDTO, TexasHoldemStateDTO, COSMOS_CONSTANTS, isTournamentFormat as isTournamentFormatFn, parseGameFormat as parseGameFormatFn, parseGameVariant as parseGameVariantFn } from "@block52/poker-vm-sdk";
 import { isBlank, isNullish, hasElements } from "./guards";
+
+/**
+ * Coerce a raw format string into a GameFormat, returning undefined for missing
+ * or unrecognized values. The SDK's parseGameFormat returns the sentinel
+ * "unknown", but UI state is typed `GameFormat | undefined` — routing through
+ * this keeps malformed chain data out of state instead of an inline cast
+ * (Commandment 12) that would store a fake value (Commandment 7).
+ */
+export const toGameFormat = (value: string | undefined): GameFormat | undefined => {
+    const parsed = parseGameFormatFn(value);
+    return parsed === "unknown" ? undefined : parsed;
+};
+
+/**
+ * Coerce a raw variant string into a GameVariant, returning undefined for
+ * missing or unrecognized values. See {@link toGameFormat}.
+ */
+export const toGameVariant = (value: string | undefined): GameVariant | undefined => {
+    const parsed = parseGameVariantFn(value);
+    return parsed === "unknown" ? undefined : parsed;
+};
 
 /**
  * Result of extracting game data from a WebSocket message


### PR DESCRIPTION
First slice of PR4 (type/arch) from the audit (#449): the **Commandment-12 inline `as GameFormat` / `as GameVariant` casts**.

The SDK already exports `parseGameFormat`/`parseGameVariant` (re-exported via `gameFormatUtils.ts`) but they were **called nowhere**. This wires them in.

### New helpers (`gameFormatUtils.ts`)
`toGameFormat` / `toGameVariant` wrap the SDK parsers and map the `"unknown"` sentinel → `undefined`, so they slot into the UI's `GameFormat | undefined` state without leaking the sentinel downstream.

### 9 casts routed
- **`GameStateContext` (6 sites)** — WS `onmessage` + historical-load setters. Malformed/missing chain data now resolves to `undefined` instead of an inline cast that stored a fake value (aligns with Commandment 7: don't hide bad data behind a cast).
- **`Dashboard` / `TableAdminPage` / `TestSigningPage` (3 sites)** — `<select>` `onChange` handlers, guarded so only a recognized format updates state (select values are always valid, so this is purely defensive).

### Tests
Added unit tests for both helpers (valid values → enum; `undefined`/`""`/garbage → `undefined`).

**tsc clean; 829/829 tests pass; no new lint errors.**

---

Part of #449 (PR4). Scoped deliberately to the format/variant casts. The rest of PR4 (raw-`fetch` bypass — 22+ sites — and `any` reduction) remains and should be split into its own epic, as noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)