### PR TITLE
fix(sng): blind-level countdown resets per level (poker-vm#2292)

### DIFF
--- a/src/hooks/game/useBlindLevel.test.ts
+++ b/src/hooks/game/useBlindLevel.test.ts
@@ -1,0 +1,95 @@
+import { renderHook } from "@testing-library/react";
+import { GameFormat, GameOptionsDTO, TexasHoldemStateDTO, TexasHoldemRound } from "@block52/poker-vm-sdk";
+import { useBlindLevel } from "./useBlindLevel";
+
+const mockUseGameStateContext = jest.fn();
+jest.mock("../../context/GameStateContext", () => ({
+    useGameStateContext: () => mockUseGameStateContext()
+}));
+
+// 3-minute blind levels (the scenario from poker-vm#2292).
+const LEVEL_MINUTES = 3;
+const LEVEL_SECONDS = LEVEL_MINUTES * 60; // 180
+
+const buildOptions = (overrides: Partial<GameOptionsDTO> = {}): GameOptionsDTO => ({
+    minBuyIn: "10000000",
+    maxBuyIn: "10000000",
+    minPlayers: 2,
+    maxPlayers: 9,
+    smallBlind: "25",
+    bigBlind: "50",
+    timeout: 30,
+    blindLevelDuration: LEVEL_MINUTES,
+    blindLevel: 0,
+    nextSmallBlind: "50",
+    nextBigBlind: "100",
+    ...overrides
+});
+
+const buildState = (options: GameOptionsDTO): TexasHoldemStateDTO => ({
+    gameOptions: options,
+    smallBlindPosition: 1,
+    bigBlindPosition: 2,
+    dealer: 1,
+    players: [],
+    communityCards: [],
+    deck: "",
+    pots: ["0"],
+    totalPot: "0",
+    nextToAct: 1,
+    previousActions: [],
+    actionCount: 0,
+    handNumber: 0,
+    round: TexasHoldemRound.ANTE,
+    winners: [],
+    results: [],
+    legalActions: [],
+    availableSeats: [],
+    signature: "sig"
+});
+
+const setContext = (options: GameOptionsDTO) => {
+    mockUseGameStateContext.mockReturnValue({ gameState: buildState(options), gameFormat: GameFormat.SIT_AND_GO });
+};
+
+describe("useBlindLevel — countdown resets per level (poker-vm#2292)", () => {
+    let nowSpy: jest.SpyInstance;
+
+    // The hook reads the current level's start from gameOptions.levelStartTime.
+    // Pin `now` (Date.now) so the hook's tick is deterministic.
+    const renderAt = (levelStartTime: number, secondsIntoLevel: number, options: GameOptionsDTO) => {
+        nowSpy = jest.spyOn(Date, "now").mockReturnValue(levelStartTime + secondsIntoLevel * 1000);
+        setContext({ ...options, levelStartTime });
+        return renderHook(() => useBlindLevel());
+    };
+
+    afterEach(() => {
+        nowSpy?.mockRestore();
+        jest.clearAllMocks();
+    });
+
+    it("level 0: remaining = full level minus elapsed", () => {
+        const start = 1_000_000_000_000;
+        const { result } = renderAt(start, 30, buildOptions({ blindLevel: 0 }));
+        expect(result.current.secondsRemaining).toBe(LEVEL_SECONDS - 30); // 150
+    });
+
+    it("level 1: resets to full level minus elapsed (was the bug: showed ~5.5 min)", () => {
+        const start = 1_000_000_180_000; // level-1 start
+        const { result } = renderAt(start, 30, buildOptions({ blindLevel: 1 }));
+        expect(result.current.secondsRemaining).toBe(LEVEL_SECONDS - 30); // 150, NOT (1+1)*180-30 = 330
+    });
+
+    it("level 2: still resets to full level minus elapsed (was: ~8.5 min)", () => {
+        const start = 1_000_000_360_000; // level-2 start
+        const { result } = renderAt(start, 30, buildOptions({ blindLevel: 2 }));
+        expect(result.current.secondsRemaining).toBe(LEVEL_SECONDS - 30); // 150, NOT (2+1)*180-30 = 510
+    });
+
+    it("counts down within a level and clamps at 0", () => {
+        const start = 1_000_000_360_000;
+        expect(renderAt(start, 170, buildOptions({ blindLevel: 2 })).result.current.secondsRemaining).toBe(10);
+        nowSpy.mockRestore();
+        expect(renderAt(start, 250, buildOptions({ blindLevel: 2 })).result.current.secondsRemaining).toBe(0);
+    });
+});

--- a/src/hooks/game/useBlindLevel.ts
+++ b/src/hooks/game/useBlindLevel.ts
@@ -76,11 +76,15 @@ export const useBlindLevel = (): BlindLevelInfo => {
 
     const secondsRemaining = useMemo(() => {
         if (!hasTimer || !startTime || isNullish(level)) return -1;
-        const elapsedMs = now - startTime;
-        const elapsedSeconds = Math.floor(elapsedMs / 1000);
-        const currentLevelEndSeconds = (level + 1) * levelDurationSeconds;
-        return Math.max(0, currentLevelEndSeconds - elapsedSeconds);
-    }, [hasTimer, startTime, now, level, levelDurationSeconds]);
+        // `startTime` is the CURRENT level's start (callers pass
+        // gameOptions.levelStartTime), so the remaining time is simply the level
+        // duration minus the time elapsed within this level. The old formula used
+        // (level + 1) * levelDurationSeconds — a cumulative-from-game-start end —
+        // which over-counted by level * duration (e.g. a 3-min level showed ~5.5
+        // min at level 1, ~8.5 min at level 2) and never reset. (poker-vm#2292)
+        const elapsedInLevelSeconds = Math.floor((now - startTime) / 1000);
+        return Math.max(0, levelDurationSeconds - elapsedInLevelSeconds);
+    }, [hasTimer, startTime, now, levelDurationSeconds, level]);
 
     // Tick the timer every second when active (same pattern as usePlayerTimer)
     useEffect(() => {


### PR DESCRIPTION
Fixes the SNG blind-level timer not resetting (poker-vm#2292).

## Bug
`useBlindLevel` reads the current level's start from `gameOptions.levelStartTime` and counts down within the level — but the formula used a **cumulative-from-game-start** end:

```ts
const elapsedMs = now - startTime;                                 // elapsed in THIS level
const currentLevelEndSeconds = (level + 1) * levelDurationSeconds; // cumulative ❌
return Math.max(0, currentLevelEndSeconds - elapsedSeconds);
```

Mixing a per-level anchor with a cumulative end over-counts by `level × duration`, so for a 3-min level it's only right at level 0:
- level 1 → ~5.5 min, level 2 → ~8.5 min, growing each level and never resetting — exactly "the timer did not reset to 3 minutes after 1→2".

## Fix
`levelStartTime` is the current level's start, so remaining is just the level duration minus elapsed-in-level:

```ts
const elapsedInLevelSeconds = Math.floor((now - startTime) / 1000);
return Math.max(0, levelDurationSeconds - elapsedInLevelSeconds);
```

Resets to the full level duration whenever `levelStartTime` advances — which, with the engine fix poker-vm#2291 (blind level held per hand, advanced at reInit), happens cleanly at the hand boundary.

## Tests
Adds `useBlindLevel.test.ts`: levels 0/1/2 each reset to full-minus-elapsed (locking out the cumulative bug), counts down within a level, clamps at 0. Game-hooks suite green (41 tests).

Refs poker-vm#2292; depends-with poker-vm#2291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)