### PR TITLE
feat(sng): show blind-level overtime as negative time in UI

### DIFF
--- a/src/components/playPage/Table/components/TableHeader.tsx
+++ b/src/components/playPage/Table/components/TableHeader.tsx
@@ -24,10 +24,13 @@ import { BlindLevelInfo } from "../../../../hooks/game/useBlindLevel";
 import styles from "./TableHeader.module.css";
 
 const formatBlindCountdown = (secondsRemaining: number): string => {
-    const safe = Math.max(0, secondsRemaining);
-    const minutes = Math.floor(safe / 60);
-    const seconds = safe % 60;
-    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+    // Negative = overtime (hand still running past the level end); show the
+    // elapsed-over time with a leading minus, e.g. -0:10. (poker-vm#2292)
+    const isOvertime = secondsRemaining < 0;
+    const abs = Math.abs(secondsRemaining);
+    const minutes = Math.floor(abs / 60);
+    const seconds = abs % 60;
+    return `${isOvertime ? "-" : ""}${minutes}:${seconds.toString().padStart(2, "0")}`;
 };
 
 export interface TableHeaderProps {
@@ -244,7 +247,16 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
                         <div className="flex items-center space-x-1 sm:space-x-2">
                             {blindLevel.isActive ? (
                                 <span className={`text-[10px] sm:text-[15px] font-semibold ${styles.secondaryText}`}>
-                                    {blindLevel.level !== undefined && `Level ${blindLevel.level + 1} `}{blindLevel.currentBlindsFormatted} Next {blindLevel.nextBlindsFormatted}{blindLevel.hasTimer && ` (${formatBlindCountdown(blindLevel.secondsRemaining)})`}
+                                    {blindLevel.level !== undefined && `Level ${blindLevel.level + 1} `}{blindLevel.currentBlindsFormatted} Next {blindLevel.nextBlindsFormatted}
+                                    {blindLevel.hasTimer && (
+                                        <>
+                                            {" ("}
+                                            <span className={blindLevel.secondsRemaining < 0 ? "text-red-500" : "text-yellow-300"}>
+                                                {formatBlindCountdown(blindLevel.secondsRemaining)}
+                                            </span>
+                                            {")"}
+                                        </>
+                                    )}
                                 </span>
                             ) : (
                                 <span className={`text-[10px] sm:text-[15px] font-semibold ${styles.secondaryText}`}>

--- a/src/hooks/game/useBlindLevel.test.ts
+++ b/src/hooks/game/useBlindLevel.test.ts
@@ -86,10 +86,15 @@ describe("useBlindLevel — countdown resets per level (poker-vm#2292)", () => {
         expect(result.current.secondsRemaining).toBe(LEVEL_SECONDS - 30); // 150, NOT (2+1)*180-30 = 510
     });
 
-    it("counts down within a level and clamps at 0", () => {
+    it("counts down within a level, then goes negative (overtime) past the level end", () => {
         const start = 1_000_000_360_000;
         expect(renderAt(start, 170, buildOptions({ blindLevel: 2 })).result.current.secondsRemaining).toBe(10);
+        // Hand still in progress past the level end: backend holds levelStartTime
+        // steady, so the UI shows overtime as negative (e.g. -70 → "-1:10" in red),
+        // NOT clamped to 0. (poker-vm#2292)
         nowSpy.mockRestore();
-        expect(renderAt(start, 250, buildOptions({ blindLevel: 2 })).result.current.secondsRemaining).toBe(0);
+        expect(renderAt(start, 190, buildOptions({ blindLevel: 2 })).result.current.secondsRemaining).toBe(-10);
+        nowSpy.mockRestore();
+        expect(renderAt(start, 250, buildOptions({ blindLevel: 2 })).result.current.secondsRemaining).toBe(-70);
     });
 });

--- a/src/hooks/game/useBlindLevel.ts
+++ b/src/hooks/game/useBlindLevel.ts
@@ -19,7 +19,11 @@ export interface BlindLevelInfo {
     currentBlindsFormatted: string;
     /** Formatted next blinds string (e.g., "100/200") */
     nextBlindsFormatted: string;
-    /** Seconds remaining until next blind level (-1 if unknown) */
+    /**
+     * Seconds remaining in the current blind level. Negative while a hand runs
+     * past the level end (overtime); -1 when unknown (no timer — gated by
+     * hasTimer before display).
+     */
     secondsRemaining: number;
     /** Duration of each blind level in seconds */
     levelDurationSeconds: number;
@@ -82,8 +86,13 @@ export const useBlindLevel = (): BlindLevelInfo => {
         // (level + 1) * levelDurationSeconds — a cumulative-from-game-start end —
         // which over-counted by level * duration (e.g. a 3-min level showed ~5.5
         // min at level 1, ~8.5 min at level 2) and never reset. (poker-vm#2292)
+        // Do NOT clamp to 0: while a hand is still in progress past the level
+        // end, the backend holds levelStartTime steady, so this goes negative —
+        // the UI shows that overtime in red (e.g. -0:10). Once the hand
+        // completes the backend advances levelStartTime and the clock resets to
+        // the new level (e.g. 2:50 for a 3-min level that ran 10s over). (poker-vm#2292)
         const elapsedInLevelSeconds = Math.floor((now - startTime) / 1000);
-        return Math.max(0, levelDurationSeconds - elapsedInLevelSeconds);
+        return levelDurationSeconds - elapsedInLevelSeconds;
     }, [hasTimer, startTime, now, levelDurationSeconds, level]);
 
     // Tick the timer every second when active (same pattern as usePlayerTimer)


### PR DESCRIPTION
## What

When a hand runs past the end of a blind level, show the overtime as a negative, red countdown (e.g. `-0:10`) instead of clamping to `0:00`.

## Why

The backend holds `levelStartTime` steady while a hand is still in progress, so the level doesn't advance until the hand completes. Previously the UI clamped `secondsRemaining` to `0`, hiding the fact that the level was running over. Now the clock ticks into negative during overtime; once the hand finishes the backend advances `levelStartTime` and the clock resets to the new level (e.g. **2:50** for a 3-min level that ran 10s over).

This is a **UI-only** change — backend timer logic is unchanged.

## Changes

- `useBlindLevel.ts` — remove the `Math.max(0, …)` clamp so `secondsRemaining` can go negative; updated the field doc.
- `TableHeader.tsx` — `formatBlindCountdown` renders overtime with a leading minus (`-0:10`, `-1:10`); the countdown span is `text-yellow-300` normally (matching the Payouts link) and `text-red-500` in overtime.
- `useBlindLevel.test.ts` — updated the clamp test to assert negative/overtime values (`-10`, `-70`).

## Test

`yarn test src/hooks/game/useBlindLevel.test.ts` → 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)