### PR TITLE
fix: route money-movers direct to chain, never via the gateway (#467)

### DIFF
--- a/src/hooks/game/useTableTopUp.ts
+++ b/src/hooks/game/useTableTopUp.ts
@@ -1,8 +1,5 @@
 import { useState } from "react";
-import { NonPlayerActionType } from "@block52/poker-vm-sdk";
 import { getSigningClient } from "../../utils/cosmos/client";
-import { getGameTransport } from "../../utils/gameTransport";
-import { executeGatewayAction, getLatestGameState, nextActionIndex } from "../playerActions/transportAction";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 
 /**
@@ -48,18 +45,10 @@ export const useTableTopUp = (tableId: string, network: NetworkEndpoints) => {
                 throw new Error("Invalid top-up amount. Must be a positive number.");
             }
 
-            // Gateway transport (ui#440): top-up is a signed gateway action.
-            // The engine queues it (flushed at the next hand); the relayed tx
-            // settles it on-chain. KNOWN GAP: perform_action "top-up" queues
-            // the chips but the escrow DEPOSIT lives in MsgTopUp, so the
-            // optimistic chips aren't yet backed by a real deposit (#2243).
-            if (getGameTransport() === "gateway") {
-                const index = nextActionIndex(getLatestGameState());
-                const result = await executeGatewayAction(tableId, NonPlayerActionType.TOP_UP, index, topUpAmount, "", network);
-                return { hash: result.hash, gameId: tableId, amount: topUpAmount.toString() };
-            }
-
-            // Call SigningCosmosClient.topUp()
+            // Money-mover: always direct to chain (MsgTopUp does the escrow
+            // deposit). Never via the gateway relay, which would forward a
+            // MsgPerformAction that queues chips without a real deposit. Closes
+            // #2243. (#467)
             const transactionHash = await signingClient.topUp(tableId, topUpAmount);
 
             return {

--- a/src/hooks/playerActions/joinTable.ts
+++ b/src/hooks/playerActions/joinTable.ts
@@ -1,7 +1,6 @@
-import { COSMOS_CONSTANTS, NonPlayerActionType, TexasHoldemStateDTO } from "@block52/poker-vm-sdk";
+import { COSMOS_CONSTANTS, TexasHoldemStateDTO } from "@block52/poker-vm-sdk";
 import { getSigningClient } from "../../utils/cosmos/client";
-import { getGameTransport } from "../../utils/gameTransport";
-import { executeGatewayAction, getLatestGameState, nextActionIndex } from "./transportAction";
+import { getLatestGameState } from "./transportAction";
 import type { JoinTableOptions } from "./types";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { JoinTableResult } from "../../types";
@@ -62,21 +61,9 @@ export async function joinTable(tableId: string, options: JoinTableOptions, netw
     // the SNG/tournament engine mis-seats). See resolveJoinSeat.
     const seat = resolveJoinSeat(options.seatNumber, getLatestGameState());
 
-    // Gateway transport (ui#440): join is a signed gateway action with the
-    // seat in the (signature-bound) data field. A joiner isn't seated yet,
-    // so the index comes from the table's shared next-action index.
-    if (getGameTransport() === "gateway") {
-        const index = nextActionIndex(getLatestGameState());
-        const result = await executeGatewayAction(tableId, NonPlayerActionType.JOIN, index, buyInAmount, `seat=${seat}`, network);
-        return {
-            hash: result.hash,
-            gameId: tableId,
-            seat,
-            buyInAmount: buyInAmount.toString()
-        };
-    }
-
-    // Call SigningCosmosClient.joinGame()
+    // Money-mover: always direct to chain (MsgJoinGame does the escrow). Never
+    // via the gateway relay, which would forward a MsgPerformAction and skip the
+    // bank movement — leaving the buy-in unsettled. Matches transfers. (#467)
     const transactionHash = await signingClient.joinGame(
         tableId,
         seat,

--- a/src/hooks/playerActions/leaveTable.test.ts
+++ b/src/hooks/playerActions/leaveTable.test.ts
@@ -10,19 +10,12 @@ const mockGetSigningClient = getSigningClient as jest.MockedFunction<typeof getS
 type SigningClient = Awaited<ReturnType<typeof getSigningClient>>["signingClient"];
 
 describe("leaveTable", () => {
-    const savedTransport = process.env.VITE_GAME_TRANSPORT;
-
     beforeEach(() => {
         jest.clearAllMocks();
-        // These assert the chain-direct path; chain is now opt-out (#440).
-        process.env.VITE_GAME_TRANSPORT = "chain";
     });
 
-    afterEach(() => {
-        process.env.VITE_GAME_TRANSPORT = savedTransport;
-        if (savedTransport === undefined) delete process.env.VITE_GAME_TRANSPORT;
-    });
-
+    // leave is a money-mover: ALWAYS direct to chain (MsgLeaveGame), regardless
+    // of game transport — it never routes through the gateway relay. (#467)
     const fakeNetwork = { name: "testnet", rpc: "http://x", rest: "http://y" } as unknown as NetworkEndpoints;
 
     it("broadcasts MsgLeaveGame via signingClient.leaveGame with the tableId only", async () => {
@@ -41,6 +34,27 @@ describe("leaveTable", () => {
             gameId: "game-abc",
             action: NonPlayerActionType.LEAVE
         });
+    });
+
+    it("stays direct-to-chain even under gateway transport (#467)", async () => {
+        const savedTransport = process.env.VITE_GAME_TRANSPORT;
+        process.env.VITE_GAME_TRANSPORT = "gateway";
+        try {
+            const leaveGame = jest.fn().mockResolvedValue("0xfeed");
+            mockGetSigningClient.mockResolvedValue({
+                signingClient: { leaveGame } as unknown as SigningClient,
+                userAddress: "b52test"
+            });
+
+            const result = await leaveTable("game-gw", fakeNetwork);
+
+            // Must call the SDK direct path, NOT route through the gateway relay.
+            expect(leaveGame).toHaveBeenCalledWith("game-gw");
+            expect(result.hash).toBe("0xfeed");
+        } finally {
+            process.env.VITE_GAME_TRANSPORT = savedTransport;
+            if (savedTransport === undefined) delete process.env.VITE_GAME_TRANSPORT;
+        }
     });
 
     it("propagates chain errors so the modal can surface them inline", async () => {

--- a/src/hooks/playerActions/leaveTable.ts
+++ b/src/hooks/playerActions/leaveTable.ts
@@ -1,7 +1,5 @@
 import { getSigningClient } from "../../utils/cosmos/client";
 import { NonPlayerActionType } from "@block52/poker-vm-sdk";
-import { getGameTransport } from "../../utils/gameTransport";
-import { executeGatewayAction, getLatestGameState, nextActionIndex } from "./transportAction";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { LeaveTableResult } from "../../types";
 
@@ -18,15 +16,9 @@ import type { LeaveTableResult } from "../../types";
  * @throws Error if Cosmos wallet is not initialized or if the chain rejects the leave
  */
 export async function leaveTable(tableId: string, network: NetworkEndpoints): Promise<LeaveTableResult> {
-    // Gateway transport (ui#440): leave is a signed gateway action applied
-    // optimistically by the gateway and relayed to the chain for settlement
-    // (the engine's "leave" action triggers the escrow refund — spec §6.10).
-    if (getGameTransport() === "gateway") {
-        const index = nextActionIndex(getLatestGameState());
-        const result = await executeGatewayAction(tableId, NonPlayerActionType.LEAVE, index, 0n, "", network);
-        return { hash: result.hash, gameId: tableId, action: NonPlayerActionType.LEAVE };
-    }
-
+    // Money-mover: always direct to chain (MsgLeaveGame does the refund). Never
+    // via the gateway relay, which would forward a MsgPerformAction and skip the
+    // bank movement. Matches transfers. (#467)
     const { signingClient } = await getSigningClient(network);
     const hash = await signingClient.leaveGame(tableId);
     return { hash, gameId: tableId, action: NonPlayerActionType.LEAVE };


### PR DESCRIPTION
Fixes #467 · closes block52/poker-vm#2243

## Problem

Buy-in, leave, and top-up didn't move the player's on-chain balance under gateway transport. They settle via dedicated chain messages (`MsgJoinGame` / `MsgLeaveGame` / `MsgTopUp`) that do a bank↔module transfer — but `joinTable` / `leaveTable` / `useTableTopUp` branched on `getGameTransport() === "gateway"` and, on that branch, sent the action through `executeGatewayAction`. The gateway relays that as a `MsgPerformAction`, which performs **no** bank movement → balance never changed (e.g. table `0xb72253…a65846`).

## Fix

Money-movers always go **direct to chain**, the same lane transfers already use. Dropped the gateway branch from all three hooks so they unconditionally call `signingClient.joinGame` / `leaveGame` / `topUp`. Gameplay actions still route via the gateway.

Per the agreed rule (block52/poker-vm#2324): **money txs = direct to chain; game txs = gateway relay.** Transport governs gameplay only, never settlement.

## Changes
- `joinTable.ts` — always `signingClient.joinGame(...)` (`MsgJoinGame`, escrow). Kept `getLatestGameState` (used by `resolveJoinSeat`); dropped the gateway/transport imports.
- `leaveTable.ts` — always `signingClient.leaveGame(...)` (`MsgLeaveGame`, refund).
- `useTableTopUp.ts` — always `signingClient.topUp(...)` (`MsgTopUp`, escrow deposit). **Closes poker-vm#2243.**
- `leaveTable.test.ts` — added a regression: leave stays direct-to-chain even when transport=gateway.

## Verify
- `tsc --noEmit` clean; eslint clean on the three files.
- 9 suites / 67 related tests pass.
- Manual: buy-in / leave / top-up move the on-chain balance under gateway transport; gameplay still relays.

## Follow-up (engine side, not this PR)
Money-movers now bypass the gateway, so the gateway's Redis can go stale on join/leave (a subscriber sees an old roster until reconcile). Tracked at block52/poker-vm#2325 (refetch-on-subscribe + chain-event push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)