### PR TITLE
fix(sng): pass finishing order on LEAVE so a WS-first SNG win settles

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "=https://paymentservice.texashodl.net",
   "dependencies": {
-    "@block52/poker-vm-sdk": "1.2.8",
+    "@block52/poker-vm-sdk": "1.2.9",
     "@metamask/sdk": "^0.34.0",
     "@reown/appkit": "1.6.7",
     "@reown/appkit-adapter-ethers": "1.6.7",

--- a/src/hooks/playerActions/transportAction.ts
+++ b/src/hooks/playerActions/transportAction.ts
@@ -19,7 +19,7 @@ import type { NetworkEndpoints } from "../../context/NetworkContext";
 import type { PlayerActionResult } from "../../types";
 import { getSigningClient } from "../../utils/cosmos/client";
 import { signActionMessage } from "../../utils/cosmos/signing";
-import { signSettlementTx } from "../../utils/cosmos/settlementTx";
+import { finishingOrderFromState, signSettlementTx } from "../../utils/cosmos/settlementTx";
 import { getGameTransport, getGatewayApi } from "../../utils/gameTransport";
 import { isNullish } from "../../utils/guards";
 
@@ -124,10 +124,17 @@ export async function executeGatewayAction(
     // Settlement relay (§6.10): sign the action as a cosmos tx and attach it
     // for the gateway to relay to the chain. Best-effort — undefined for
     // unfunded accounts (gameplay still proceeds on the EIP-191 path).
+    //
+    // For a LEAVE on a finished SNG, attach the place-1-first finishing order
+    // from the broadcast state so the chain can finalize and pay the prize —
+    // under WS-first it never saw the tournament-ending action, so its Results
+    // are empty until we tell it the order (pokerchain#229). Empty for every
+    // other case; the chain ignores it.
+    const finishingOrder = action === NonPlayerActionType.LEAVE ? finishingOrderFromState(latestGameState) : [];
     let tx: string | undefined;
     try {
         const { signingClient } = await getSigningClient(network);
-        tx = await signSettlementTx(signingClient, address, network, tableId, action, amount, data);
+        tx = await signSettlementTx(signingClient, address, network, tableId, action, amount, data, finishingOrder);
     } catch (err) {
         console.error("[settlement] tx signing skipped:", err);
     }

--- a/src/utils/cosmos/settlementTx.test.ts
+++ b/src/utils/cosmos/settlementTx.test.ts
@@ -1,7 +1,8 @@
 import { NonPlayerActionType, PlayerActionType } from "@block52/poker-vm-sdk";
 import type { SigningCosmosClient } from "@block52/poker-vm-sdk";
 import type { NetworkEndpoints } from "../../context/NetworkContext";
-import { signSettlementTx } from "./settlementTx";
+import { finishingOrderFromState, signSettlementTx } from "./settlementTx";
+import type { TexasHoldemStateDTO } from "@block52/poker-vm-sdk";
 import { getCosmosUrls } from "./client";
 
 jest.mock("./client", () => ({
@@ -45,13 +46,24 @@ describe("signSettlementTx — money-mover dispatch (#2325)", () => {
         expect(client.signPerformAction).not.toHaveBeenCalled();
     });
 
-    it("signs MsgLeaveGame for LEAVE", async () => {
+    it("signs MsgLeaveGame for LEAVE with an empty finishing order by default", async () => {
         const client = makeClient();
         const tx = await signSettlementTx(client as unknown as SigningCosmosClient, ADDR, fakeNetwork, "game-1", NonPlayerActionType.LEAVE, 0n, "");
 
         expect(tx).toBe("LEAVE_TX");
-        expect(client.signLeaveGame).toHaveBeenCalledWith("game-1", expect.any(Object));
+        expect(client.signLeaveGame).toHaveBeenCalledWith("game-1", expect.any(Object), []);
         expect(client.signPerformAction).not.toHaveBeenCalled();
+    });
+
+    it("passes the finishing order through to signLeaveGame for a finished SNG leave", async () => {
+        const client = makeClient();
+        const order = ["b52winner", "b52second", "b52third"];
+        const tx = await signSettlementTx(
+            client as unknown as SigningCosmosClient, ADDR, fakeNetwork, "game-1", NonPlayerActionType.LEAVE, 0n, "", order
+        );
+
+        expect(tx).toBe("LEAVE_TX");
+        expect(client.signLeaveGame).toHaveBeenCalledWith("game-1", expect.any(Object), order);
     });
 
     it("signs MsgTopUp for TOP_UP", async () => {
@@ -79,5 +91,23 @@ describe("signSettlementTx — money-mover dispatch (#2325)", () => {
         const tx = await signSettlementTx(client as unknown as SigningCosmosClient, ADDR, fakeNetwork, "game-1", NonPlayerActionType.JOIN, 1000n, "");
         expect(tx).toBeUndefined();
         expect(client.signJoinGame).not.toHaveBeenCalled();
+    });
+});
+
+describe("finishingOrderFromState (pokerchain#229)", () => {
+    it("returns [] when the game has no results (not finalized)", () => {
+        expect(finishingOrderFromState(undefined)).toEqual([]);
+        expect(finishingOrderFromState({ results: [] } as unknown as TexasHoldemStateDTO)).toEqual([]);
+    });
+
+    it("returns addresses in place-1-first order regardless of results[] order", () => {
+        const state = {
+            results: [
+                { place: 3, playerId: "b52third", payout: "0" },
+                { place: 1, playerId: "b52winner", payout: "300" },
+                { place: 2, playerId: "b52second", payout: "0" }
+            ]
+        } as unknown as TexasHoldemStateDTO;
+        expect(finishingOrderFromState(state)).toEqual(["b52winner", "b52second", "b52third"]);
     });
 });

--- a/src/utils/cosmos/settlementTx.ts
+++ b/src/utils/cosmos/settlementTx.ts
@@ -22,7 +22,7 @@
  *   - sign error → no tx + sequence reset so the next action re-syncs
  */
 import { NonPlayerActionType } from "@block52/poker-vm-sdk";
-import type { SigningCosmosClient } from "@block52/poker-vm-sdk";
+import type { SigningCosmosClient, TexasHoldemStateDTO } from "@block52/poker-vm-sdk";
 
 import type { NetworkEndpoints } from "../../context/NetworkContext";
 import { getCosmosUrls } from "./client";
@@ -38,6 +38,21 @@ const unfundedWarned = new Set<string>();
 /** Clears tracked sequence so the next action re-fetches it (call on re-sync). */
 export function resetSettlementSequence(address: string): void {
     seqByAddress.delete(address);
+}
+
+/**
+ * Derives the place-1-first finishing order (player addresses) from a finished
+ * SNG's results[]. Empty when the game isn't finalized (no results), so the
+ * chain falls back to its own state for cash/already-finalized leaves. The
+ * chain re-validates this ordering and owns the payout amounts (pokerchain#229);
+ * we only report who finished where, from the gateway-broadcast results.
+ */
+export function finishingOrderFromState(gameState: TexasHoldemStateDTO | undefined): string[] {
+    const results = gameState?.results;
+    if (!results || results.length === 0) {
+        return [];
+    }
+    return [...results].sort((a, b) => a.place - b.place).map(r => r.playerId);
 }
 
 async function loadSeqState(address: string, restEndpoint: string): Promise<SeqState | null> {
@@ -83,7 +98,8 @@ export async function signSettlementTx(
     tableId: string,
     action: string,
     amount: bigint,
-    data: string
+    data: string,
+    finishingOrder: string[] = []
 ): Promise<string | undefined> {
     const { restEndpoint } = getCosmosUrls(network);
     const state = await loadSeqState(address, restEndpoint);
@@ -98,7 +114,7 @@ export async function signSettlementTx(
     try {
         // Money-movers settle via their dedicated message (does the bank
         // movement); everything else is a MsgPerformAction. (#2325)
-        const { base64 } = await signMoneyMover(signingClient, tableId, action, amount, data, signerData)
+        const { base64 } = await signMoneyMover(signingClient, tableId, action, amount, data, signerData, finishingOrder)
             ?? await signingClient.signPerformAction(tableId, action, amount, data, signerData);
         state.sequence += 1; // advance locally for the next action
         return base64;
@@ -122,6 +138,12 @@ function seatFromData(data: string): number {
  * Signs the dedicated money-mover message for join/leave/top-up, or returns
  * undefined for any other action (caller falls back to MsgPerformAction).
  * Returns the same {base64,...} shape as signPerformAction. (#2325)
+ *
+ * For a LEAVE on a finished SNG, `finishingOrder` (place-1-first addresses,
+ * derived from the broadcast state's results[]) is attached so the chain can
+ * finalize and pay the prize even though it never saw the tournament-ending
+ * gameplay action under WS-first (pokerchain#229). Empty for everything else —
+ * the chain ignores it for cash leaves and SNGs it already finalized.
  */
 function signMoneyMover(
     signingClient: SigningCosmosClient,
@@ -129,13 +151,14 @@ function signMoneyMover(
     action: string,
     amount: bigint,
     data: string,
-    signerData: { accountNumber: number; sequence: number; chainId: string }
+    signerData: { accountNumber: number; sequence: number; chainId: string },
+    finishingOrder: string[]
 ): Promise<{ base64: string }> | undefined {
     switch (action) {
         case NonPlayerActionType.JOIN:
             return signingClient.signJoinGame(tableId, seatFromData(data), amount, signerData);
         case NonPlayerActionType.LEAVE:
-            return signingClient.signLeaveGame(tableId, signerData);
+            return signingClient.signLeaveGame(tableId, signerData, finishingOrder);
         case NonPlayerActionType.TOP_UP:
             return signingClient.signTopUp(tableId, amount, signerData);
         default:


### PR DESCRIPTION
Fixes #470

## Problem
An SNG winner clicks LEAVE but their on-chain balance never updates. Under WS-first money-movers (poker-vm#2325) the gateway never relays the tournament-ending action, so the chain's `Results` are empty and `MsgLeaveGame` returns `ErrSNGNotFinalized` — the prize is never paid (diagnosis: pokerchain#229). This PR is the final link that closes the loop end-to-end.

## Change
For a LEAVE, derive the place-1-first finishing order from the broadcast state's `results[]` (`finishingOrderFromState`: sort by `place`, map to `playerId`) and pass it to `signLeaveGame`. Empty for every other case — the chain ignores it for cash leaves and SNGs it already finalized; it re-validates the order and **owns the payout amounts** (we only report who finished where).

- `settlementTx`: `finishingOrderFromState` helper; thread `finishingOrder` through `signSettlementTx` → `signMoneyMover` → `signLeaveGame`
- `transportAction`: attach the order for LEAVE actions
- bump `@block52/poker-vm-sdk` 1.2.8 → 1.2.9

## Tests
4 new: pass-through to `signLeaveGame`, default empty order, and `finishingOrderFromState` ordering (sorts by place regardless of input order; `[]` when not finalized). `tsc --noEmit` clean.

## Depends on
SDK **1.2.9** (poker-vm#2338) — must publish before this merges. Chain side: pokerchain#230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)